### PR TITLE
Modify command `s` to prevent the accidental sale of all items

### DIFF
--- a/src/strategy/actions/SellAction.cpp
+++ b/src/strategy/actions/SellAction.cpp
@@ -74,13 +74,18 @@ bool SellAction::Execute(Event event)
         return true;
     }
 
-    std::vector<Item*> items = parseItems(text, ITERATE_ITEMS_IN_BAGS);
-    for (Item* item : items)
+    if (text == "all")
     {
-        Sell(item);
+        std::vector<Item *> items = parseItems(text, ITERATE_ITEMS_IN_BAGS);
+        for (Item *item : items)
+        {
+            Sell(item);
+        }
+        return true;
     }
 
-    return true;
+    botAI->TellError("Usage: s gray/*/vendor/all");
+    return false;
 }
 
 void SellAction::Sell(FindItemVisitor* visitor)


### PR DESCRIPTION
目前直接输入指令`s`会卖光机器人队友的所有物品，有玩家误操作卖光小号身上的东西，这太不安全了，所以增加`all`参数。