### PR TITLE
Add performance tuning

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -412,7 +412,7 @@ AiPlayerbot.MinRandomBotReviveTime = 60
 AiPlayerbot.MaxRandomBotReviveTime = 300
 AiPlayerbot.MinRandomBotTeleportInterval = 3600
 AiPlayerbot.MaxRandomBotTeleportInterval = 18000
-AiPlayerbot.RandomBotInWorldWithRotaionDisabled = 31104000
+AiPlayerbot.RandomBotInWorldWithRotationDisabled = 31104000
 
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -449,6 +449,11 @@ AiPlayerbot.BotCheats = "taxi"
 # Enables/Disables password to bot account
 AiPlayerbot.RandomBotRandomPassword = 0
 
+# Diff with/without player in server. The server will tune bot activity to reach the desired server tick speed (in ms).
+# AiPlayerbot.EnablePrototypePerformanceDiff = 0
+# AiPlayerbot.DiffWithPlayer = 100
+# AiPlayerbot.DiffEmpty = 200
+
 ##################################################################################
 #                                                                                #
 # Database Stuff 																 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -282,6 +282,11 @@ bool PlayerbotAIConfig::Initialize()
 
     playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 10);
+
+    enablePrototypePerformanceDiff = sConfigMgr->GetOption<bool>("AiPlayerbot.EnablePrototypePerformanceDiff", false);
+    diffWithPlayer = sConfigMgr->GetOption("AiPlayerbot.DiffWithPlayer", 100);
+    diffEmpty = sConfigMgr->GetIntDefault("AiPlayerbot.DiffEmpty", 200);
+
     randombotsWalkingRPG = sConfigMgr->GetOption<bool>("AiPlayerbot.RandombotsWalkingRPG", false);
     randombotsWalkingRPGInDoors = sConfigMgr->GetOption<bool>("AiPlayerbot.RandombotsWalkingRPG.InDoors", false);
     minEnchantingBotLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.MinEnchantingBotLevel", 60);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -130,7 +130,7 @@ bool PlayerbotAIConfig::Initialize()
     maxRandomBotReviveTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotReviveTime", 5 * MINUTE);
     minRandomBotTeleportInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotTeleportInterval", 1 * HOUR);
     maxRandomBotTeleportInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotTeleportInterval", 5 * HOUR);
-    randomBotInWorldWithRotaionDisabled = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotInWorldWithRotaionDisabled", 1 * YEAR);
+    randomBotInWorldWithRotationDisabled = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotInWorldWithRotationDisabled", 1 * YEAR);
     randomBotTeleportDistance = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleportDistance", 100);
     randomBotsPerInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotsPerInterval", MINUTE);
     minRandomBotsPriceChangeInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotsPriceChangeInterval", 2 * HOUR);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -178,6 +178,10 @@ class PlayerbotAIConfig
         uint32 playerbotsXPrate;
         uint32 botActiveAlone;
 
+        uint32 enablePrototypePerformanceDiff;
+        uint32 diffWithPlayer;
+        uint32 diffEmpty;
+
         bool freeMethodLoot;
         int32 lootRollLevel;
         std::string autoPickReward;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -88,7 +88,7 @@ class PlayerbotAIConfig
         uint32 minRandomBotChangeStrategyTime, maxRandomBotChangeStrategyTime;
         uint32 minRandomBotReviveTime, maxRandomBotReviveTime;
         uint32 minRandomBotTeleportInterval, maxRandomBotTeleportInterval;
-        uint32 randomBotInWorldWithRotaionDisabled;
+        uint32 randomBotInWorldWithRotationDisabled;
         uint32 minRandomBotPvpTime, maxRandomBotPvpTime;
         uint32 randomBotsPerInterval;
         uint32 minRandomBotsPriceChangeInterval, maxRandomBotsPriceChangeInterval;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -501,7 +501,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
             for (uint32 &guid : guids) {
                 uint32 add_time = sPlayerbotAIConfig->enableRotation ? 
                 urand(sPlayerbotAIConfig->minRandomBotInWorldTime, sPlayerbotAIConfig->maxRandomBotInWorldTime) :
-                sPlayerbotAIConfig->randomBotInWorldWithRotaionDisabled;
+                sPlayerbotAIConfig->randomBotInWorldWithRotationDisabled;
                     
                 SetEventValue(guid, "add", 1, add_time);
                 SetEventValue(guid, "logout", 0, 0);

--- a/src/strategy/actions/BattleGroundJoinAction.cpp
+++ b/src/strategy/actions/BattleGroundJoinAction.cpp
@@ -11,6 +11,7 @@
 #include "PlayerbotAI.h"
 #include "Playerbots.h"
 #include "PositionValue.h"
+#include "UpdateTime.h"
 
 bool BGJoinAction::Execute(Event event)
 {
@@ -239,6 +240,7 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
 
     bool isArena = false;
     bool isRated = false;
+    bool noLag = sWorldUpdateTime.GetAverageUpdateTime() < (sRandomPlayerbotMgr->GetPlayers().empty() ? sPlayerbotAIConfig->diffEmpty : sPlayerbotAIConfig->diffWithPlayer) * 1.1;
 
     ArenaType type = ArenaType(BattlegroundMgr::BGArenaType(queueTypeId));
     if (type != ARENA_TYPE_NONE)
@@ -246,11 +248,32 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
 
     bool hasPlayers = (sRandomPlayerbotMgr->BgPlayers[queueTypeId][bracketId][TEAM_ALLIANCE] + sRandomPlayerbotMgr->BgPlayers[queueTypeId][bracketId][TEAM_HORDE]) > 0;
     bool hasBots = (sRandomPlayerbotMgr->BgBots[queueTypeId][bracketId][TEAM_ALLIANCE] + sRandomPlayerbotMgr->BgBots[queueTypeId][bracketId][TEAM_HORDE]) >= bg->GetMinPlayersPerTeam();
+    
     if (!sPlayerbotAIConfig->randomBotAutoJoinBG && !hasPlayers)
+    {
         return false;
 
-    if (!(hasPlayers || hasBots))
+        if (sPlayerbotAIConfig->enablePrototypePerformanceDiff)
+        {
+            if (!noLag)
+            {
+                return false;
+            }
+        }
+    }
+    
+    if (!hasPlayers && !(isArena)) 
+    {
         return false;
+
+        if (sPlayerbotAIConfig->enablePrototypePerformanceDiff) 
+        {
+            if (!noLag) 
+            {
+                return false;
+            }
+        }
+    }
 
     uint32 BracketSize = bg->GetMaxPlayersPerTeam() * 2;
     uint32 TeamSize = bg->GetMaxPlayersPerTeam();
@@ -584,6 +607,7 @@ bool FreeBGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battleg
 
     bool isArena = false;
     bool isRated = false;
+    bool noLag = sWorldUpdateTime.GetAverageUpdateTime() < (sRandomPlayerbotMgr->GetPlayers().empty() ? sPlayerbotAIConfig->diffEmpty : sPlayerbotAIConfig->diffWithPlayer) * 1.1;
 
     ArenaType type = ArenaType(BattlegroundMgr::BGArenaType(queueTypeId));
     if (type != ARENA_TYPE_NONE)


### PR DESCRIPTION
((Some changes were not applied in the previous PR, I created a new PR, just to make sure everything is alright and clean this time.))

We spoke about it here (https://github.com/liyunfan1223/mod-playerbots/discussions/191), a long time ago. Today I tried implementing this myself.

The original implementation of which I used the references can be found here: https://github.com/celguar/mangosbot-bots/commit/ce4bd79d2dbc7e8453303f9f94c27761615c64a9

I have implemented the changes + on/off config switch as you asked in this new pull request. So far, everything seems to be running fine on my end, with all modified systems (such as battlegrounds) still working as it should.

However, I would greatly appreciate it if @liyunfan1223 & others could test it out to ensure that everything works fine across different environments and use cases. The same goes for coding standards. Perhaps it can be used as a base / reference for a future proper implementation.

Thanks!

-Brian8544