### PR TITLE
[Suggestion + first part] Implement LFG (create party/raid command)

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -535,6 +535,7 @@ bool PlayerbotAI::IsAllowedCommand(std::string const text)
         unsecuredCommands.insert("sendmail");
         unsecuredCommands.insert("invite");
         unsecuredCommands.insert("leave");
+        unsecuredCommands.insert("lfg");
     }
 
     for (std::set<std::string>::iterator i = unsecuredCommands.begin(); i != unsecuredCommands.end(); ++i)
@@ -1579,8 +1580,7 @@ int32 PlayerbotAI::GetMeleeIndex(Player* player)
     return 0;
 }
 
-
-bool PlayerbotAI::IsTank(Player* player)
+bool PlayerbotAI::IsTank(Player* player, bool inGroup)
 {
     PlayerbotAI* botAi = GET_PLAYERBOT_AI(player);
     if (botAi)
@@ -1613,7 +1613,7 @@ bool PlayerbotAI::IsTank(Player* player)
     return false;
 }
 
-bool PlayerbotAI::IsHeal(Player* player)
+bool PlayerbotAI::IsHeal(Player* player, bool inGroup)
 {
     PlayerbotAI* botAi = GET_PLAYERBOT_AI(player);
     if (botAi)

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -329,8 +329,8 @@ class PlayerbotAI : public PlayerbotAIBase
         void ResetStrategies(bool load = false);
         void ReInitCurrentEngine();
         void Reset(bool full = false);
-        static bool IsTank(Player* player);
-        static bool IsHeal(Player* player);
+        static bool IsTank(Player* player, bool inGroup = true);
+        static bool IsHeal(Player* player, bool inGroup = true);
         static bool IsDps(Player* player);
         static bool IsRanged(Player* player);
         static bool IsMelee(Player* player);
@@ -423,6 +423,13 @@ class PlayerbotAI : public PlayerbotAIBase
         //Checks if the bot is summoned as alt of a player
         bool IsAlt();
         Player* GetGroupMaster();
+
+        /*
+        //Check if player is safe to use.
+        bool IsSafe(Player* player) { return player && player->GetMapId() == bot->GetMapId() && player->GetInstanceId() == bot->GetInstanceId() && !player->IsBeingTeleported(); }
+        bool IsSafe(WorldObject* obj) { return obj && obj->GetMapId() == bot->GetMapId() && obj->GetInstanceId() == bot->GetInstanceId() && (!obj->IsPlayer() || !((Player*)obj)->IsBeingTeleported()); }
+        */
+
         //Returns a semi-random (cycling) number that is fixed for each bot.
         uint32 GetFixedBotNumer(BotTypeNumber typeNumber, uint32 maxNum = 100, float cyclePerMin = 1);
         GrouperType GetGrouperType();

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -136,6 +136,7 @@ class ChatActionContext : public NamedObjectContext<Action>
             creators["cast custom spell"] = &ChatActionContext::cast_custom_spell;
             creators["cast custom nc spell"] = &ChatActionContext::cast_custom_nc_spell;
             creators["invite"] = &ChatActionContext::invite;
+            creators["lfg"] = &ChatActionContext::lfg;
             creators["spell"] = &ChatActionContext::spell;
             creators["rti"] = &ChatActionContext::rti;
             creators["spirit healer"] = &ChatActionContext::spirit_healer;
@@ -196,6 +197,7 @@ class ChatActionContext : public NamedObjectContext<Action>
         static Action* spirit_healer(PlayerbotAI* botAI) { return new SpiritHealerAction(botAI); }
         static Action* rti(PlayerbotAI* botAI) { return new RtiAction(botAI); }
         static Action* invite(PlayerbotAI* botAI) { return new InviteToGroupAction(botAI); }
+        static Action* lfg(PlayerbotAI* botAI) { return new LfgAction(botAI); }
         static Action* spell(PlayerbotAI* botAI) { return new TellSpellAction(botAI); }
         static Action* cast_custom_spell(PlayerbotAI* botAI) { return new CastCustomSpellAction(botAI); }
         static Action* cast_custom_nc_spell(PlayerbotAI* botAI) { return new CastCustomNcSpellAction(botAI); }

--- a/src/strategy/actions/InviteToGroupAction.cpp
+++ b/src/strategy/actions/InviteToGroupAction.cpp
@@ -7,6 +7,7 @@
 #include "GuildMgr.h"
 #include "Playerbots.h"
 #include "ServerFacade.h"
+#include "PlayerbotAI.h"
 
 bool InviteToGroupAction::Execute(Event event)
 {
@@ -14,10 +15,10 @@ bool InviteToGroupAction::Execute(Event event)
     if (!master)
         return false;
 
-    return Invite(master);
+    return Invite(master, bot);
 }
 
-bool InviteToGroupAction::Invite(Player* player)
+bool InviteToGroupAction::Invite(Player* inviter, Player* player)
 {
     if (!player)
         return false;
@@ -66,7 +67,179 @@ bool InviteNearbyToGroupAction::Execute(Event event)
         if (sServerFacade->GetDistance2d(bot, player) > sPlayerbotAIConfig->sightDistance)
             continue;
 
-        return Invite(player);
+        return Invite(player, bot);
+    }
+
+    return false;
+}
+
+bool LfgAction::Execute(Event event)
+{
+    Player* master = event.getOwner() ? event.getOwner() : GetMaster();
+    if (bot->InBattleground())
+        return false;
+
+    if (bot->InBattlegroundQueue())
+        return false;
+
+    /* Not implemented yet.
+    if (!ai->IsSafe(requester))
+        return false;
+    */
+
+    if (master->GetLevel() == DEFAULT_MAX_LEVEL && bot->GetLevel() != DEFAULT_MAX_LEVEL)
+        return false;
+
+    if (master->GetLevel() > bot->GetLevel() + 4 || bot->GetLevel() > master->GetLevel() + 4)
+        return false;
+
+    std::string param = event.getParam();
+
+    if (!param.empty() && param != "40" && param != "25" && param != "20" && param != "10" && param != "5")
+    {
+        botAI->TellError("Unknown group size. Valid sizes for lfg are 40, 25, 20, 10 and 5.", {});
+        return false;
+    }
+
+    Group* group = master->GetGroup();
+
+    std::unordered_map<Classes, std::unordered_map<BotRoles, uint32>> allowedClassNr;
+    std::unordered_map<BotRoles, uint32> allowedRoles;
+
+    allowedRoles[BOT_ROLE_TANK] = 1;
+    allowedRoles[BOT_ROLE_HEALER] = 1;
+    allowedRoles[BOT_ROLE_DPS] = 3;
+
+    BotRoles role = botAI->IsTank(master, false) ? BOT_ROLE_TANK : (botAI->IsHeal(master, false) ? BOT_ROLE_HEALER : BOT_ROLE_DPS);
+    Classes cls = (Classes)master->getClass();
+
+    if (group)
+    {
+        //If no input use max raid for raid groups.
+        if (param.empty() && group->isRaidGroup())
+            /// Default to WotLK Raiding. Max size 25.
+            param = "25";
+
+        //Select optimal group layout.
+        if (param == "40")
+        {
+            allowedRoles[BOT_ROLE_TANK] = 4;
+            allowedRoles[BOT_ROLE_HEALER] = 16;
+            allowedRoles[BOT_ROLE_DPS] = 20;
+
+            //allowedClassNr[CLASS_WARRIOR][BOT_ROLE_TANK] = ;
+            allowedClassNr[CLASS_PALADIN][BOT_ROLE_TANK] = 0;
+            allowedClassNr[CLASS_DRUID][BOT_ROLE_TANK] = 1;
+            //allowedClassNr[CLASS_DEATH_KNIGHT][BOT_ROLE_TANK] = ;
+
+            allowedClassNr[CLASS_DRUID][BOT_ROLE_HEALER] = 3;
+            allowedClassNr[CLASS_PALADIN][BOT_ROLE_HEALER] = 4;
+            allowedClassNr[CLASS_SHAMAN][BOT_ROLE_HEALER] = 4;
+            allowedClassNr[CLASS_PRIEST][BOT_ROLE_HEALER] = 11;
+
+            allowedClassNr[CLASS_WARRIOR][BOT_ROLE_DPS] = 8;
+            allowedClassNr[CLASS_PALADIN][BOT_ROLE_DPS] = 4;
+            allowedClassNr[CLASS_HUNTER][BOT_ROLE_DPS] = 4;
+            allowedClassNr[CLASS_ROGUE][BOT_ROLE_DPS] = 6;
+            allowedClassNr[CLASS_PRIEST][BOT_ROLE_DPS] = 1;
+            allowedClassNr[CLASS_SHAMAN][BOT_ROLE_DPS] = 4;
+            allowedClassNr[CLASS_MAGE][BOT_ROLE_DPS] = 15;
+            allowedClassNr[CLASS_WARLOCK][BOT_ROLE_DPS] = 4;
+            allowedClassNr[CLASS_DRUID][BOT_ROLE_DPS] = 1;
+            //allowedClassNr[CLASS_DEATH_KNIGHT][BOT_ROLE_DPS] = ;
+        }
+        else if (param == "25")
+        {
+            allowedRoles[BOT_ROLE_TANK] = 3;
+            allowedRoles[BOT_ROLE_HEALER] = 7;
+            allowedRoles[BOT_ROLE_DPS] = 15;
+        }
+        else if (param == "20")
+        {
+            allowedRoles[BOT_ROLE_TANK] = 2;
+            allowedRoles[BOT_ROLE_HEALER] = 5;
+            allowedRoles[BOT_ROLE_DPS] = 13;
+        }
+        else if (param == "10")
+        {
+            allowedRoles[BOT_ROLE_TANK] = 2;
+            allowedRoles[BOT_ROLE_HEALER] = 3;
+            allowedRoles[BOT_ROLE_DPS] = 5;
+        }
+
+        if (group->IsFull())
+        {
+            if (param.empty() || param == "5" || group->isRaidGroup())
+                return false; //Group or raid is full so stop trying.
+            else
+                group->ConvertToRaid(); //We want a raid but are in a group so convert and continue.
+        }
+
+        Group::MemberSlotList const& groupSlot = group->GetMemberSlots();
+        for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
+        {
+            // Only add group member targets that are alive and near the player
+            Player* player = ObjectAccessor::FindPlayer(itr->guid);
+
+            /* This whole function is not implemented in PlayerbotAI.h
+            if (!botAI->IsSafe(player))
+                return false;
+            */
+
+            role = botAI->IsTank(player, false) ? BOT_ROLE_TANK : (botAI->IsHeal(player, false) ? BOT_ROLE_HEALER : BOT_ROLE_DPS);
+            cls = (Classes)player->getClass();
+
+            if (allowedRoles[role] > 0)
+                allowedRoles[role]--;
+
+            if (allowedClassNr[cls].find(role) != allowedClassNr[cls].end() && allowedClassNr[cls][role] > 0)
+                allowedClassNr[cls][role]--;
+        }
+    }
+    else
+    {
+        if (allowedRoles[role] > 0)
+            allowedRoles[role]--;
+
+        if (allowedClassNr[cls].find(role) != allowedClassNr[cls].end() && allowedClassNr[cls][role] > 0)
+            allowedClassNr[cls][role]--;
+    }
+
+    role = botAI->IsTank(bot, false) ? BOT_ROLE_TANK : (botAI->IsHeal(bot, false) ? BOT_ROLE_HEALER : BOT_ROLE_DPS);
+    cls = (Classes)bot->getClass();
+
+    if (allowedRoles[role] == 0)
+        return false;
+
+    if (allowedClassNr[cls].find(role) != allowedClassNr[cls].end() && allowedClassNr[cls][role] == 0)
+        return false;
+
+    if (bot->GetGroup())
+    {
+        if (botAI->HasRealPlayerMaster())
+            return false;
+
+        if (!botAI->DoSpecificAction("leave", event, true))
+            return false;
+    }
+
+    bool invite = Invite(master, bot);
+
+    if (invite)
+    {
+        if (!botAI->DoSpecificAction("accept invitation", event, true))
+            return false;
+
+        std::map<std::string, std::string> placeholders;
+        placeholders["%role"] = (role == BOT_ROLE_TANK ? "tank" : (role == BOT_ROLE_HEALER ? "healer" : "dps"));
+        placeholders["%spotsleft"] = std::to_string(allowedRoles[role] - 1);
+
+        if (allowedRoles[role] > 1)
+            botAI->TellMaster("Joining as %role, %spotsleft %role spots left.");
+        else
+            botAI->TellMaster("Joining as %role.");
+
+        return true;
     }
 
     return false;
@@ -155,7 +328,7 @@ bool InviteGuildToGroupAction::Execute(Event event)
         if (!botAI && sServerFacade->GetDistance2d(bot, player) > sPlayerbotAIConfig->sightDistance)
             continue;
 
-        return Invite(player);
+        return Invite(bot, player);
     }
 
     return false;

--- a/src/strategy/actions/InviteToGroupAction.h
+++ b/src/strategy/actions/InviteToGroupAction.h
@@ -17,7 +17,15 @@ class InviteToGroupAction : public Action
 
         bool Execute(Event event) override;
 
-        virtual bool Invite(Player* player);
+        virtual bool Invite(Player* inviter, Player* player);
+};
+
+class LfgAction : public InviteToGroupAction
+{
+    public:
+        LfgAction(PlayerbotAI* ai, std::string const name = "lfg") : InviteToGroupAction(botAI, name) { }
+
+        virtual bool Execute(Event event) override;
 };
 
 class InviteNearbyToGroupAction : public InviteToGroupAction

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -101,6 +101,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("gb");
     supported.push_back("bank");
     supported.push_back("invite");
+    supported.push_back("lfg");
     supported.push_back("spell");
     supported.push_back("rti");
     supported.push_back("position");

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -148,6 +148,7 @@ class ChatTriggerContext : public NamedObjectContext<Trigger>
         static Trigger* revive(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "revive"); }
         static Trigger* rti(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rti"); }
         static Trigger* invite(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "invite"); }
+        static Trigger* lfg(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "lfg"); }
         static Trigger* cast(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "cast"); }
         static Trigger* castnc(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "castnc"); }
         static Trigger* talk(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "talk"); }


### PR DESCRIPTION
Implement "lfg" command which automatically creates a party/raid. The party part is not as important, since WotLK has the rdf tool, but it could make forming raid groups really easy.

Usage:
lfg
lfg 5
lfg 10
lfg 25
lfg 40

I tried implementing this myself, but it **doesn't** seem to work:
https://github.com/liyunfan1223/mod-playerbots/commit/4b688874d867fb92363e3bff06b810f3bb5e1450


How it should work:
https://github.com/search?q=repo%3Acelguar%2Fmangosbot-bots+lfg&type=commits