### PR TITLE
fix for #271 - Issues with gems added to randomised bot gear

### DIFF
--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -3466,8 +3466,19 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destoryOld)
             if (!socketColor) {
                 continue;
             }
+            int32 gemId;
+            if (1 == socketColor)//meta
+                gemId = bestGemEnchantId[0];
+            else if (2 == socketColor)//red
+                gemId = bestGemEnchantId[1];
+            else if (4 == socketColor)//yellow
+                gemId = bestGemEnchantId[2];
+            else if (8 == socketColor)//blue
+                gemId = bestGemEnchantId[3];
+            else
+                continue;
             bot->ApplyEnchantment(item, EnchantmentSlot(enchant_slot), false);
-            item->SetEnchantment(EnchantmentSlot(enchant_slot), bestGemEnchantId[socketColor], 0, 0, bot->GetGUID());
+            item->SetEnchantment(EnchantmentSlot(enchant_slot), gemId, 0, 0, bot->GetGUID());
             bot->ApplyEnchantment(item, EnchantmentSlot(enchant_slot), true);
         }
     }


### PR DESCRIPTION
#271 fix

socketColor variable has value of 1, 2, 4, 8, but was being used directly for accessing index of bestGemEnchantId[] array (causing wrong gems in meta and red sockets, no gems in blue sockets, and missing yellow socket).

Tested fix and it works as intended, has significant impact on quality of bot gear too (I notice level 70 prot warriors have gone from about 17K to 21K HP buffed - probably wont make them work in the harder TBC raids but its a start).