### PR TITLE
Fixed AiPlayerbot.PerfMonEnabled crashing server (and printing formatting strings directly to screen) + a few other minor fixes

### DIFF
--- a/src/PerformanceMonitor.cpp
+++ b/src/PerformanceMonitor.cpp
@@ -59,7 +59,7 @@ void PerformanceMonitor::PrintStats(bool perTick, bool fullStack)
                 total += map.second->totalTime;
 
         LOG_INFO("playerbots", "--------------------------------------[TOTAL BOT]------------------------------------------------------");
-        LOG_INFO("playerbots", "percentage   time    |   min  ..    max (     avg  of     count ) - type : name                        ");
+        LOG_INFO("playerbots", "percentage     time  |    min ..    max (      avg  of      count) - type      : name");
 
         for (std::map<PerformanceMetric, std::map<std::string, PerformanceData*>>::iterator i = data.begin(); i != data.end(); ++i)
         {
@@ -115,7 +115,7 @@ void PerformanceMonitor::PrintStats(bool perTick, bool fullStack)
 
                 if (avg >= 0.5f || pd->maxTime > 10)
                 {
-                    LOG_INFO("playerbots", "%7.3f%% %10.3fs | %6u .. %6u (%9.4f of %10u) - {}    : {}"
+                    LOG_INFO("playerbots", "{:7.3f}% {:10.3f}s | {:6d} .. {:6d} ({:10.3f} of {:10d}) - {:6}    : {}"
                         , perc
                         , secs
                         , pd->minTime
@@ -134,10 +134,8 @@ void PerformanceMonitor::PrintStats(bool perTick, bool fullStack)
         float totalCount = data[PERF_MON_TOTAL]["RandomPlayerbotMgr::FullTick"]->count;
         total = data[PERF_MON_TOTAL]["RandomPlayerbotMgr::FullTick"]->totalTime;
 
-        LOG_INFO("playerbots", " ");
-        LOG_INFO("playerbots", " ");
         LOG_INFO("playerbots", "---------------------------------------[PER TICK]------------------------------------------------------");
-        LOG_INFO("playerbots", "percentage   time    |   min  ..    max (     avg  of     count ) - type : name                        ");
+        LOG_INFO("playerbots", "percentage     time  |    min ..    max (      avg  of      count) - type      : name");
 
         for (std::map<PerformanceMetric, std::map<std::string, PerformanceData*>>::iterator i = data.begin(); i != data.end(); ++i)
         {
@@ -190,7 +188,7 @@ void PerformanceMonitor::PrintStats(bool perTick, bool fullStack)
 
                 if (avg >= 0.5f || pd->maxTime > 10)
                 {
-                    LOG_INFO("playerbots", "%7.3f%% %9ums | %6u .. %6u (%9.4f of %10.3f) - {}    : {}"
+                    LOG_INFO("playerbots", "{:7.3f}% {:9d}ms | {:6d} .. {:6d} ({:10.3f} of {:10.3f}) - {:6}    : {}"
                         , perc
                         , secs
                         , pd->minTime

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -2174,8 +2174,10 @@ bool PlayerbotAI::CanCastSpell(uint32 spellid, Unit* target, bool checkHasSpell,
     }
 
     if (bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL) != nullptr) {
-        LOG_DEBUG("playerbots", "CanCastSpell() target name: {}, spellid: {}, bot name: {}, failed because has current channeled spell", 
-            target->GetName(), spellid, bot->GetName());
+        if (!sPlayerbotAIConfig->logInGroupOnly || (bot->GetGroup() && HasRealPlayerMaster())) {
+            LOG_DEBUG("playerbots", "CanCastSpell() target name: {}, spellid: {}, bot name: {}, failed because has current channeled spell",
+                target->GetName(), spellid, bot->GetName());
+        }
         return false;
     }
 

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -357,8 +357,8 @@ void PlayerbotFactory::Randomize(bool incremental)
     // bot->SaveToDB(false, false);
     // InitGuild();
     // bot->SaveToDB(false, false);
-    if (pmo)
-        pmo->finish();
+    //if (pmo)
+    //    pmo->finish();
 
     // if (bot->getLevel() >= 70)
     // {

--- a/src/strategy/StrategyContext.h
+++ b/src/strategy/StrategyContext.h
@@ -87,7 +87,7 @@ class StrategyContext : public NamedObjectContext<Strategy>
             creators["map full"] = &StrategyContext::map_full;
             creators["sit"] = &StrategyContext::sit;
             creators["mark rti"] = &StrategyContext::mark_rti;
-            creators["ads"] = &StrategyContext::possible_adds;
+            creators["adds"] = &StrategyContext::possible_adds;
             creators["close"] = &StrategyContext::close;
             creators["ranged"] = &StrategyContext::ranged;
             creators["behind"] = &StrategyContext::behind;

--- a/src/strategy/actions/BattleGroundJoinAction.cpp
+++ b/src/strategy/actions/BattleGroundJoinAction.cpp
@@ -250,30 +250,13 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
     bool hasBots = (sRandomPlayerbotMgr->BgBots[queueTypeId][bracketId][TEAM_ALLIANCE] + sRandomPlayerbotMgr->BgBots[queueTypeId][bracketId][TEAM_HORDE]) >= bg->GetMinPlayersPerTeam();
     
     if (!sPlayerbotAIConfig->randomBotAutoJoinBG && !hasPlayers)
-    {
         return false;
 
-        if (sPlayerbotAIConfig->enablePrototypePerformanceDiff)
-        {
-            if (!noLag)
-            {
-                return false;
-            }
-        }
-    }
-    
-    if (!hasPlayers && !(isArena)) 
-    {
+    if (!(hasPlayers || hasBots))
         return false;
 
-        if (sPlayerbotAIConfig->enablePrototypePerformanceDiff) 
-        {
-            if (!noLag) 
-            {
-                return false;
-            }
-        }
-    }
+    if (sPlayerbotAIConfig->enablePrototypePerformanceDiff && !hasPlayers && !noLag)
+        return false;
 
     uint32 BracketSize = bg->GetMaxPlayersPerTeam() * 2;
     uint32 TeamSize = bg->GetMaxPlayersPerTeam();
@@ -607,7 +590,6 @@ bool FreeBGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battleg
 
     bool isArena = false;
     bool isRated = false;
-    bool noLag = sWorldUpdateTime.GetAverageUpdateTime() < (sRandomPlayerbotMgr->GetPlayers().empty() ? sPlayerbotAIConfig->diffEmpty : sPlayerbotAIConfig->diffWithPlayer) * 1.1;
 
     ArenaType type = ArenaType(BattlegroundMgr::BGArenaType(queueTypeId));
     if (type != ARENA_TYPE_NONE)


### PR DESCRIPTION
Trying to figure out recent performance problems related to midsummer fire festival (which I had no idea the cause of) led to me trying out AiPlayerbot.PerfMonEnabled setting, which I found was broken in a few ways so I've fixed it. Also included a few other minor fixes I've been using on my server for some time.

For the ads/adds strategy change (it had different names for adding and removing ie: co +ads / co -ad**d**s) I made sure the "ads" name isn't used anywhere else in code (eg:  AiFactory::AddDefaultCombatStrategies() ) and also looked through unbot addon and I dont see it used there either).

Note: the issues fixed by last [commit [](url)](https://github.com/liyunfan1223/mod-playerbots/commit/6dddab7c1a8e6c1c6e747eb63b31e38c580568ef) were raised in https://github.com/liyunfan1223/mod-playerbots/issues/258 and fixed by @brian8544 but only in his branch (which seems to contain other changes not related to performance tuning), this will atleast fix those issues until he's ready to merge (if he's still working on it).