### PR TITLE
[feat] Added the function to manually clear shared bot raid status.

### DIFF
--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2624,6 +2624,24 @@ void PlayerbotFactory::InitMounts()
     }
 }
 
+void PlayerbotFactory::UnbindInstance(){
+    Player* p = bot;
+    ObjectGuid guid = p->GetGUID();
+
+    for (uint8 d = 0; d < MAX_DIFFICULTY; ++d)
+    {
+        std::vector<InstanceSave*> toUnbind;
+        BoundInstancesMap const& m_boundInstances = sInstanceSaveMgr->PlayerGetBoundInstances(guid, Difficulty(d));
+        for (BoundInstancesMap::const_iterator itr = m_boundInstances.begin(); itr != m_boundInstances.end(); ++itr)
+        {
+            InstanceSave* instanceSave = itr->second.save;
+            toUnbind.push_back(instanceSave);
+        }
+        for (std::vector<InstanceSave*>::const_iterator itr = toUnbind.begin(); itr != toUnbind.end(); ++itr)
+            sInstanceSaveMgr->PlayerUnbindInstance(guid, (*itr)->GetMapId(), (*itr)->GetDifficulty(), true, p);
+    }
+}
+
 void PlayerbotFactory::InitPotions()
 {
     uint32 effects[] = { SPELL_EFFECT_HEAL, SPELL_EFFECT_ENERGIZE };

--- a/src/PlayerbotFactory.h
+++ b/src/PlayerbotFactory.h
@@ -136,6 +136,7 @@ class PlayerbotFactory
         void InitBags(bool destroyOld = true);
         void ApplyEnchantAndGemsNew(bool destoryOld = true);
         void InitInstanceQuests();
+        void UnbindInstance();
     private:
         void Prepare();
         // void InitSecondEquipmentSet();

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -615,6 +615,14 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
                 return "ok, gear score limit: " + std::to_string(gs / (ITEM_QUALITY_EPIC + 1)) + "(for epic)";
             }
         }
+
+        if (cmd == "refresh=raid")
+        {   // TODO: This function is not perfect yet. If you are already in a raid, 
+            // after the command is executed, the AI ​​needs to go back online or exit the raid and re-enter.
+            PlayerbotFactory factory(bot, bot->getLevel());
+            factory.UnbindInstance();
+            return "ok";
+        }
     }
 
     if (cmd == "levelup" || cmd == "level")


### PR DESCRIPTION
1.When a bot has finished a raid with other players, it will no longer enter the raid with you, if you do not want to switch to another bot ,you can use this command to refresh the bot's raid status.
2.New Command: .playerbot bot refresh=raid
3.You must select the bot when using this command.