### PR TITLE
Conditions for Summon

### DIFF
--- a/src/strategy/actions/UseMeetingStoneAction.cpp
+++ b/src/strategy/actions/UseMeetingStoneAction.cpp
@@ -176,8 +176,28 @@ bool SummonAction::Teleport(Player* summoner, Player* player)
 
             if (summoner->IsWithinLOS(x, y, z))
             {
-                bool allowed = sPlayerbotAIConfig->botReviveWhenSummon == 2 || (sPlayerbotAIConfig->botReviveWhenSummon == 1 && !master->IsInCombat() && master->IsAlive());
-                if (allowed && bot->isDead())
+                if (sPlayerbotAIConfig->botReviveWhenSummon < 2)
+                {
+                    if (master->IsInCombat())
+                    {
+                        botAI->TellError("You cannot summon me while you're in combat");
+                        return false;
+                    }
+
+                    if (!master->IsAlive())
+                    {
+                        botAI->TellError("You cannot summon me while you're dead");
+                        return false;
+                    }
+
+                    if (bot->isDead() && !bot->HasPlayerFlag(PLAYER_FLAGS_GHOST))
+                    {
+                        botAI->TellError("You cannot summon me while I'm dead, you need to release my spirit first");
+                        return false;
+                    }
+                }
+
+                if (sPlayerbotAIConfig->botReviveWhenSummon > 0 && bot->isDead())
                 {
                     bot->ResurrectPlayer(1.0f, false);
                     bot->DurabilityRepairAll(false, 1.0f, false);


### PR DESCRIPTION
Closes https://github.com/liyunfan1223/mod-playerbots/issues/312

Credit to @conFIGured65 for several suggestions, extensive testing, and more.

If AiPlayerbot.BotReviveWhenSummon is set to 0 or 1 the following requirements must be met:
- The master isn't dead
- The master isn't in combat
- The bot isn't dead or the bot is a ghost

We added error messages for all conditions to let the player know exactly why the bot(s) can't be summoned.