### PR TITLE
SummonAction::Teleport Repairwhensummon changed to a .conf option

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -132,7 +132,7 @@ AiPlayerbot.GroupInvitationPermission = 1
 AiPlayerbot.BotReviveWhenSummon = 1
 
 # Enable/Disable bot repair gear when summon (0 = no, 1 = yes)
-# default: 1 (enable for non-combat)
+# default: 1
 AiPlayerbot.BotRepairWhenSummon = 1
 
 # Non-GM player can only use init=auto to initialize bots based on their own level and gear score

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -127,9 +127,13 @@ AiPlayerbot.EquipmentPersistenceLevel = 80
 # default: 1 (accept based on level)
 AiPlayerbot.GroupInvitationPermission = 1
 
-# Enable/Disable bot revive and repair gear when summon (0 = never, 1 = enable when non-combat and alive, 2 = enable always)
+# Enable/Disable bot revive when summon (0 = never, 1 = enable when non-combat and alive, 2 = enable always)
 # default: 1 (enable for non-combat)
 AiPlayerbot.BotReviveWhenSummon = 1
+
+# Enable/Disable bot repair gear when summon (0 = no, 1 = yes)
+# default: 1 (enable for non-combat)
+AiPlayerbot.BotRepairWhenSummon = 1
 
 # Non-GM player can only use init=auto to initialize bots based on their own level and gear score
 # default: 0 (non-gm player can use any intialization commands)

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -273,7 +273,7 @@ bool PlayerbotAIConfig::Initialize()
     equipmentPersistenceLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.EquipmentPersistenceLevel", 80);
     groupInvitationPermission = sConfigMgr->GetOption<int32>("AiPlayerbot.GroupInvitationPermission", 1);
     botReviveWhenSummon = sConfigMgr->GetOption<int>("AiPlayerbot.BotReviveWhenSummon", 1);
-    botRepairWhenSummon = sConfigMgr->GetOption<bool>("AiPlayerbot.BotRepairWhenSummon", false);
+    botRepairWhenSummon = sConfigMgr->GetOption<bool>("AiPlayerbot.BotRepairWhenSummon", true);
     autoInitOnly = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoInitOnly", false);
     autoInitEquipLevelLimitRatio = sConfigMgr->GetOption<float>("AiPlayerbot.AutoInitEquipLevelLimitRatio", 1.0);
     addClassCommand = sConfigMgr->GetOption<int32>("AiPlayerbot.AddClassCommand", 1);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -273,6 +273,7 @@ bool PlayerbotAIConfig::Initialize()
     equipmentPersistenceLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.EquipmentPersistenceLevel", 80);
     groupInvitationPermission = sConfigMgr->GetOption<int32>("AiPlayerbot.GroupInvitationPermission", 1);
     botReviveWhenSummon = sConfigMgr->GetOption<int>("AiPlayerbot.BotReviveWhenSummon", 1);
+    botRepairWhenSummon = sConfigMgr->GetOption<bool>("AiPlayerbot.BotRepairWhenSummon", false);
     autoInitOnly = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoInitOnly", false);
     autoInitEquipLevelLimitRatio = sConfigMgr->GetOption<float>("AiPlayerbot.AutoInitEquipLevelLimitRatio", 1.0);
     addClassCommand = sConfigMgr->GetOption<int32>("AiPlayerbot.AddClassCommand", 1);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -215,6 +215,7 @@ class PlayerbotAIConfig
         int32 equipmentPersistenceLevel;
         int32 groupInvitationPermission;
         int32 botReviveWhenSummon;
+        bool botRepairWhenSummon;
         bool autoInitOnly;
         float autoInitEquipLevelLimitRatio;
         int32 addClassCommand;

--- a/src/strategy/actions/UseMeetingStoneAction.cpp
+++ b/src/strategy/actions/UseMeetingStoneAction.cpp
@@ -176,6 +176,9 @@ bool SummonAction::Teleport(Player* summoner, Player* player)
 
             if (summoner->IsWithinLOS(x, y, z))
             {
+                if (sPlayerbotAIConfig->botRepairWhenSummon) // .conf option to repair bot gear when summoned 0 = off, 1 = on
+                    bot->DurabilityRepairAll(false, 1.0f, false);
+
                 if (sPlayerbotAIConfig->botReviveWhenSummon < 2)
                 {
                     if (master->IsInCombat())
@@ -200,7 +203,6 @@ bool SummonAction::Teleport(Player* summoner, Player* player)
                 if (sPlayerbotAIConfig->botReviveWhenSummon > 0 && bot->isDead())
                 {
                     bot->ResurrectPlayer(1.0f, false);
-                    bot->DurabilityRepairAll(false, 1.0f, false);
                     botAI->TellMasterNoFacing("I live, again!");
                 }
 


### PR DESCRIPTION
Removed repairwhensummon from everytime bot summon and added it as a .conf option giving server owners the choice to allow players to repair or not repair when summoning their bots.