### PR TITLE
Summon cleanup

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -139,9 +139,9 @@ AiPlayerbot.AllowSummonWhenMasterIsDead = 1
 # default: 1 (always)
 AiPlayerbot.AllowSummonWhenBotIsDead = 1
 
-# Enable/Disable bot revive when summon (0 = never, 1 = enable when non-combat, 2 = enable always)
-# default: 1 (enable for non-combat)
-AiPlayerbot.BotReviveWhenSummon = 1
+# Enable/Disable reviving the bots when summoning them
+# default: 1 (enable)
+AiPlayerbot.ReviveBotWhenSummoned = 1
 
 # Enable/Disable bot repair gear when summon (0 = no, 1 = yes)
 # default: 1

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -276,7 +276,7 @@ bool PlayerbotAIConfig::Initialize()
     allowSummonInCombat = sConfigMgr->GetOption<bool>("AiPlayerbot.AllowSummonInCombat", true);
     allowSummonWhenMasterIsDead = sConfigMgr->GetOption<bool>("AiPlayerbot.AllowSummonWhenMasterIsDead", true);
     allowSummonWhenBotIsDead = sConfigMgr->GetOption<bool>("AiPlayerbot.AllowSummonWhenBotIsDead", true);
-    botReviveWhenSummon = sConfigMgr->GetOption<int>("AiPlayerbot.BotReviveWhenSummon", 1);
+    reviveBotWhenSummoned = sConfigMgr->GetOption<bool>("AiPlayerbot.ReviveBotWhenSummoned", true);
     botRepairWhenSummon = sConfigMgr->GetOption<bool>("AiPlayerbot.BotRepairWhenSummon", true);
     autoInitOnly = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoInitOnly", false);
     autoInitEquipLevelLimitRatio = sConfigMgr->GetOption<float>("AiPlayerbot.AutoInitEquipLevelLimitRatio", 1.0);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -217,7 +217,7 @@ class PlayerbotAIConfig
         bool allowSummonInCombat;
         bool allowSummonWhenMasterIsDead;
         bool allowSummonWhenBotIsDead;
-        int32 botReviveWhenSummon;
+        bool reviveBotWhenSummoned;
         bool botRepairWhenSummon;
         bool autoInitOnly;
         float autoInitEquipLevelLimitRatio;

--- a/src/strategy/actions/UseMeetingStoneAction.cpp
+++ b/src/strategy/actions/UseMeetingStoneAction.cpp
@@ -197,7 +197,7 @@ bool SummonAction::Teleport(Player* summoner, Player* player)
                     return false;
                 }
 
-                if (sPlayerbotAIConfig->botReviveWhenSummon == 2 || (sPlayerbotAIConfig->botReviveWhenSummon == 1 && !master->IsInCombat() && master->IsAlive()))
+                if (bot->isDead() && sPlayerbotAIConfig->reviveBotWhenSummoned)
                 {
                     bot->ResurrectPlayer(1.0f, false);
                     botAI->TellMasterNoFacing("I live, again!");


### PR DESCRIPTION
Three pull requests to do something so simple, it just goes to show that you shouldn't rush things - especially not when you're tired. Hopefully this is the last one for these options.

Changed the existing `BotReviveWhenSummon` to a bool. The other options take care of everything else so there's no need to add additional checks to this one. It's enabled by default.
I accidentally forgot to add the `isDead()` check before reviving the bots. I don't know if could cause crashes but I needed to add this back as soon as possible.