### PR TITLE
Enable Compilation on More Platforms

### DIFF
--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
+#include <algorithm>
 
 void split(std::vector<std::string>& dest, std::string const str, char const* delim)
 {


### PR DESCRIPTION
Solves the "fatal error: no member named 'find_if' in namespace 'std'" compiler error experienced by certain environments.