### PR TITLE
Fix/rewrite Shaman weapon buff checking (incl. dual wield support)

### DIFF
--- a/src/strategy/shaman/CasterShamanStrategy.cpp
+++ b/src/strategy/shaman/CasterShamanStrategy.cpp
@@ -49,10 +49,10 @@ void CasterShamanStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     GenericShamanStrategy::InitTriggers(triggers);
 
     // triggers.push_back(new TriggerNode("enemy out of spell", NextAction::array(0, new NextAction("reach spell", ACTION_NORMAL + 9), nullptr)));
-    triggers.push_back(new TriggerNode("shaman weapon", NextAction::array(0, new NextAction("flametongue weapon", 23.0f), nullptr)));
+    // triggers.push_back(new TriggerNode("shaman weapon", NextAction::array(0, new NextAction("flametongue weapon", 23.0f), nullptr)));
+    triggers.push_back(new TriggerNode("main hand weapon no imbue", NextAction::array(0, new NextAction("flametongue weapon", 22.0f), nullptr)));
     // triggers.push_back(new TriggerNode("searing totem", NextAction::array(0, new NextAction("searing totem", 19.0f), nullptr)));
     triggers.push_back(new TriggerNode("flame shock", NextAction::array(0, new NextAction("flame shock", 20.0f), nullptr)));
-    triggers.push_back(new TriggerNode("elemental mastery", NextAction::array(0, new NextAction("elemental mastery", 27.0f), nullptr)));
     // triggers.push_back(new TriggerNode("frost shock snare", NextAction::array(0, new NextAction("frost shock", 21.0f), nullptr)));
     triggers.push_back(new TriggerNode(
         "no fire totem",

--- a/src/strategy/shaman/CasterShamanStrategy.cpp
+++ b/src/strategy/shaman/CasterShamanStrategy.cpp
@@ -53,6 +53,7 @@ void CasterShamanStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("main hand weapon no imbue", NextAction::array(0, new NextAction("flametongue weapon", 22.0f), nullptr)));
     // triggers.push_back(new TriggerNode("searing totem", NextAction::array(0, new NextAction("searing totem", 19.0f), nullptr)));
     triggers.push_back(new TriggerNode("flame shock", NextAction::array(0, new NextAction("flame shock", 20.0f), nullptr)));
+    triggers.push_back(new TriggerNode("elemental mastery", NextAction::array(0, new NextAction("elemental mastery", 27.0f), nullptr)));
     // triggers.push_back(new TriggerNode("frost shock snare", NextAction::array(0, new NextAction("frost shock", 21.0f), nullptr)));
     triggers.push_back(new TriggerNode(
         "no fire totem",

--- a/src/strategy/shaman/GenericShamanStrategy.cpp
+++ b/src/strategy/shaman/GenericShamanStrategy.cpp
@@ -35,7 +35,7 @@ class GenericShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionN
         {
             return new ActionNode ("flametongue weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("frostbrand weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("flametongue weapon"), nullptr),
                 /*C*/ nullptr);
         }
 
@@ -43,7 +43,7 @@ class GenericShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionN
         {
             return new ActionNode ("frostbrand weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("rockbiter weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("frostbrand weapon"), nullptr),
                 /*C*/ nullptr);
         }
 
@@ -51,7 +51,7 @@ class GenericShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionN
         {
             return new ActionNode ("windfury weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("rockbiter weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("windfury weapon"), nullptr),
                 /*C*/ nullptr);
         }
 

--- a/src/strategy/shaman/HealShamanStrategy.cpp
+++ b/src/strategy/shaman/HealShamanStrategy.cpp
@@ -42,7 +42,8 @@ void HealShamanStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     GenericShamanStrategy::InitTriggers(triggers);
 
     // triggers.push_back(new TriggerNode("enemy out of spell", NextAction::array(0, new NextAction("reach spell", ACTION_NORMAL + 9), nullptr)));
-    triggers.push_back(new TriggerNode("shaman weapon", NextAction::array(0, new NextAction("earthliving weapon", 22.0f), nullptr)));
+    // triggers.push_back(new TriggerNode("shaman weapon", NextAction::array(0, new NextAction("earthliving weapon", 22.0f), nullptr)));
+    triggers.push_back(new TriggerNode("main hand weapon no imbue", NextAction::array(0, new NextAction("earthliving weapon", 22.0f), nullptr)));
     triggers.push_back(new TriggerNode(
 		"group heal occasion",
 		NextAction::array(0, new NextAction("riptide on party", 23.0f), new NextAction("chain heal", 22.0f), NULL)));

--- a/src/strategy/shaman/MeleeShamanStrategy.cpp
+++ b/src/strategy/shaman/MeleeShamanStrategy.cpp
@@ -63,7 +63,9 @@ void MeleeShamanStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     GenericShamanStrategy::InitTriggers(triggers);
 
-    triggers.push_back(new TriggerNode("shaman weapon", NextAction::array(0, new NextAction("flametongue weapon", 22.0f), nullptr)));
+    //triggers.push_back(new TriggerNode("shaman weapon", NextAction::array(0, new NextAction("flametongue weapon", 22.0f), nullptr)));
+    triggers.push_back(new TriggerNode("main hand weapon no imbue", NextAction::array(0, new NextAction("windfury weapon", 22.0f), nullptr)));
+    triggers.push_back(new TriggerNode("off hand weapon no imbue", NextAction::array(0, new NextAction("flametongue weapon", 21.0f), nullptr)));
     // triggers.push_back(new TriggerNode("searing totem", NextAction::array(0, new NextAction("reach melee", 22.0f), new NextAction("searing totem", 22.0f), nullptr)));
     triggers.push_back(new TriggerNode("flame shock", NextAction::array(0, new NextAction("flame shock", 20.0f), nullptr)));
     triggers.push_back(new TriggerNode(

--- a/src/strategy/shaman/ShamanAiObjectContext.cpp
+++ b/src/strategy/shaman/ShamanAiObjectContext.cpp
@@ -79,7 +79,9 @@ class ShamanATriggerFactoryInternal : public NamedObjectContext<Trigger>
             creators["searing totem"] = &ShamanATriggerFactoryInternal::searing_totem;
             creators["wind shear"] = &ShamanATriggerFactoryInternal::wind_shear;
             creators["purge"] = &ShamanATriggerFactoryInternal::purge;
-            creators["shaman weapon"] = &ShamanATriggerFactoryInternal::shaman_weapon;
+            //creators["shaman weapon"] = &ShamanATriggerFactoryInternal::shaman_weapon;
+            creators["main hand weapon no imbue"] = &ShamanATriggerFactoryInternal::main_hand_weapon_no_imbue;
+            creators["off hand weapon no imbue"] = &ShamanATriggerFactoryInternal::off_hand_weapon_no_imbue;
             creators["water shield"] = &ShamanATriggerFactoryInternal::water_shield;
             creators["lightning shield"] = &ShamanATriggerFactoryInternal::lightning_shield;
             creators["water breathing"] = &ShamanATriggerFactoryInternal::water_breathing;
@@ -136,7 +138,9 @@ class ShamanATriggerFactoryInternal : public NamedObjectContext<Trigger>
         static Trigger* searing_totem(PlayerbotAI* botAI) { return new SearingTotemTrigger(botAI); }
         static Trigger* wind_shear(PlayerbotAI* botAI) { return new WindShearInterruptSpellTrigger(botAI); }
         static Trigger* purge(PlayerbotAI* botAI) { return new PurgeTrigger(botAI); }
-        static Trigger* shaman_weapon(PlayerbotAI* botAI) { return new ShamanWeaponTrigger(botAI); }
+        //static Trigger* shaman_weapon(PlayerbotAI* botAI) { return new ShamanWeaponTrigger(botAI); }
+        static Trigger* main_hand_weapon_no_imbue(PlayerbotAI* botAI) { return new MainHandWeaponNoImbueTrigger(botAI); }
+        static Trigger* off_hand_weapon_no_imbue(PlayerbotAI* botAI) { return new OffHandWeaponNoImbueTrigger(botAI); }
         static Trigger* water_shield(PlayerbotAI* botAI) { return new WaterShieldTrigger(botAI); }
         static Trigger* lightning_shield(PlayerbotAI* botAI) { return new LightningShieldTrigger(botAI); }
         static Trigger* shock(PlayerbotAI* botAI) { return new ShockTrigger(botAI); }

--- a/src/strategy/shaman/ShamanTriggers.cpp
+++ b/src/strategy/shaman/ShamanTriggers.cpp
@@ -5,6 +5,7 @@
 #include "ShamanTriggers.h"
 #include "Playerbots.h"
 
+/*
 std::vector<std::string> ShamanWeaponTrigger::spells;
 
 bool ShamanWeaponTrigger::IsActive()
@@ -29,6 +30,21 @@ bool ShamanWeaponTrigger::IsActive()
     }
 
     return false;
+}
+*/
+
+bool MainHandWeaponNoImbueTrigger::IsActive() {
+    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND );
+    if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+        return false;
+    return true;
+}
+
+bool OffHandWeaponNoImbueTrigger::IsActive() {
+    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND );
+    if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+        return false;
+    return true;
 }
 
 bool ShockTrigger::IsActive()

--- a/src/strategy/shaman/ShamanTriggers.h
+++ b/src/strategy/shaman/ShamanTriggers.h
@@ -11,6 +11,7 @@
 
 class PlayerbotAI;
 
+/*
 class ShamanWeaponTrigger : public BuffTrigger
 {
     public:
@@ -20,6 +21,21 @@ class ShamanWeaponTrigger : public BuffTrigger
 
     private:
         static std::vector<std::string> spells;
+};
+*/
+
+class MainHandWeaponNoImbueTrigger : public BuffTrigger
+{
+    public:
+        MainHandWeaponNoImbueTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "main hand", 1) {}
+        virtual bool IsActive();
+};
+
+class OffHandWeaponNoImbueTrigger : public BuffTrigger
+{
+    public:
+        OffHandWeaponNoImbueTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "off hand", 1) {}
+        virtual bool IsActive();
 };
 
 class TotemTrigger : public Trigger


### PR DESCRIPTION
Replace the self-weapon shaman imbues with buff checking similar to rogue poisons. Includes support for buffing offhand for enhancement DW shamans.
I have rewritten the weapon buffing triggers using the rogue poisons as a template, by checking temp enchants on the items rather than looking for a player buff.
I also fixed up what seemed to be mis-labelling of the cast actions for most of the weapon buffs.

I noticed with the existing code, my enhancement shaman bot in my party would often play without a weapon buff at all, even when he was using a 2h weapon. I only noticed him actually use a weapon buff once or twice in the last few days.

Shaman weapon buffs are a bit weird, you can't control which weapon they apply to (unlike poison or sharpening stone) so the order of casting is important.

Tested and working on my own server, I have added a trigger for each shaman strat which aligns with the typical meta recommendation:

Enhancement spec: Windfury MH, Flametongue OH
Resto spec: Earthliving MH
Elemental spec: Flametongue MH