### PR TITLE
New AiPlayerbot.LimitGearExpansion option

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -511,9 +511,15 @@ AiPlayerbot.RandomGearScoreLimit = 0
 # Default: 60
 AiPlayerbot.MinEnchantingBotLevel = 60
 
-# Enable expansion limitation
-# Default: 1
-AiPlayerbot.LimitEnchantExpansion = 1
+# Enable expansion limitation for enchants - ie: level <= 60 bot only uses enchants
+# available in vanilla, level <= 70 bot only uses enchants available in TBC)
+# Default: 0
+AiPlayerbot.LimitEnchantExpansion = 0
+
+# Enable expansion limitation for gear - ie: level <= 60 bot only uses gear
+# available in vanilla, level <= 70 bot only uses gear available in TBC)
+# Default: 0
+AiPlayerbot.LimitGearExpansion = 0
 
 # Change random bot has lower gear
 AiPlayerbot.RandomGearLoweringChance = 0

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -300,7 +300,8 @@ bool PlayerbotAIConfig::Initialize()
     randombotsWalkingRPG = sConfigMgr->GetOption<bool>("AiPlayerbot.RandombotsWalkingRPG", false);
     randombotsWalkingRPGInDoors = sConfigMgr->GetOption<bool>("AiPlayerbot.RandombotsWalkingRPG.InDoors", false);
     minEnchantingBotLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.MinEnchantingBotLevel", 60);
-    limitEnchantExpansion = sConfigMgr->GetOption<int32>("AiPlayerbot.LimitEnchantExpansion", 1);
+    limitEnchantExpansion = sConfigMgr->GetOption<int32>("AiPlayerbot.LimitEnchantExpansion", 0);
+    limitGearExpansion = sConfigMgr->GetOption<int32>("AiPlayerbot.LimitGearExpansion", 0);
     randombotStartingLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandombotStartingLevel", 5);
     enableRotation = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableRotation", false);
     rotationPoolSize = sConfigMgr->GetOption<int32>("AiPlayerbot.RotationPoolSize", 500);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -136,6 +136,7 @@ class PlayerbotAIConfig
         bool randombotsWalkingRPGInDoors;
         uint32 minEnchantingBotLevel;
         uint32 limitEnchantExpansion;
+        uint32 limitGearExpansion;
         uint32 randombotStartingLevel;
         bool enableRotation;
         uint32 rotationPoolSize;

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -1456,6 +1456,14 @@ void PlayerbotFactory::InitEquipment(bool incremental)
                         if (itemId == 46978) { // shaman earth ring totem
                             continue;
                         }
+
+                        // disable next expansion gear
+                        if (sPlayerbotAIConfig->limitGearExpansion && bot->GetLevel() <= 60 && itemId >= 23728)
+                            continue;
+
+                        if (sPlayerbotAIConfig->limitGearExpansion && bot->GetLevel() <= 70 && itemId >= 35570 && itemId != 36737 && itemId != 37739 && itemId != 37740)//transition point from TBC -> WOTLK isn't as clear, and there are other wearable TBC items above 35570 but nothing of significance
+                            continue;
+
                         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
                         if (!proto)
                             continue;
@@ -3454,15 +3462,12 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destoryOld)
                 continue;
             }
             
-            // disable next expansion
-            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 69 && enchantSpell >= 25072) {
+            // disable next expansion enchantments
+            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 60 && enchantSpell >= 25072)
                 continue;
-            }
 
-            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 79 && enchantSpell > 48557) {
+            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 70 && enchantSpell > 48557)
                 continue;
-            }
-
 
             for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
             {


### PR DESCRIPTION
Added AiPlayerbot.LimitGearExpansion option which works similar to AiPlayerbot.LimitEnchantExpansion:
- Bot-level <= 60 limited to vanilla gear
- Bot-level <= 70 limited to TBC gear
- Also modified bot-level thresholds for LimitEnchantExpansion option - which were previously <= 69 for vanilla enchants and <= 79 for TBC (those dont seem right because 61-69 are TBC levels, not vanilla, same for 71-79 being WOTLK)

Gear thresholds are based on itemID, which isn't a perfect method but works pretty well, here are the equippable items that are miscategorised by the itemID thresholds I've chosen:
- Vanilla items above vanilla itemID threshold: https://www.wowhead.com/classic/items?filter=151:151:195;2:5:1;23728:100000:0 (rip that one dagger)
- TBC items below vanilla itemID threshold: https://www.wowhead.com/tbc/items/max-req-level:60?filter=151:195:82;4:1:2;23728:0:20001 (most dont seem like TBC items at all, except for that weird purple chestpiece with 3 meta sockets which I've never seen bots use anyway)
- TBC items above TBC itemID threshold: https://www.wowhead.com/tbc/items?filter=151:195;2:1;35570:0 (TBC->WOTLK was a lot harder to pin down to a specific itemID, but note that I've made exceptions specifically for the 3 PVP weapons in this list so that bots can use those below level 71)
- WOTLK items below TBC itemID threshold: https://www.wowhead.com/wotlk/items/max-req-level:70?filter=151:195:82;5:1:2;35570:0:30001
