### PR TITLE
Shaman weapon buff fixes

### DIFF
--- a/src/strategy/shaman/GenericShamanStrategy.cpp
+++ b/src/strategy/shaman/GenericShamanStrategy.cpp
@@ -35,7 +35,7 @@ class GenericShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionN
         {
             return new ActionNode ("flametongue weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("flametongue weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("rockbiter weapon"), nullptr),
                 /*C*/ nullptr);
         }
 
@@ -43,7 +43,7 @@ class GenericShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionN
         {
             return new ActionNode ("frostbrand weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("frostbrand weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("flametongue weapon"), nullptr),
                 /*C*/ nullptr);
         }
 
@@ -51,7 +51,7 @@ class GenericShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionN
         {
             return new ActionNode ("windfury weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("windfury weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("flametongue weapon"), nullptr),
                 /*C*/ nullptr);
         }
 

--- a/src/strategy/shaman/HealShamanStrategy.cpp
+++ b/src/strategy/shaman/HealShamanStrategy.cpp
@@ -19,7 +19,7 @@ class HealShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionNode
         {
             return new ActionNode ("earthliving weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("earthliving weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("flametongue weapon"), nullptr),
                 /*C*/ nullptr);
         }
 

--- a/src/strategy/shaman/HealShamanStrategy.cpp
+++ b/src/strategy/shaman/HealShamanStrategy.cpp
@@ -19,7 +19,7 @@ class HealShamanStrategyActionNodeFactory : public NamedObjectFactory<ActionNode
         {
             return new ActionNode ("earthliving weapon",
                 /*P*/ nullptr,
-                /*A*/ NextAction::array(0, new NextAction("flametongue weapon"), nullptr),
+                /*A*/ NextAction::array(0, new NextAction("earthliving weapon"), nullptr),
                 /*C*/ nullptr);
         }
 

--- a/src/strategy/shaman/ShamanTriggers.cpp
+++ b/src/strategy/shaman/ShamanTriggers.cpp
@@ -34,15 +34,15 @@ bool ShamanWeaponTrigger::IsActive()
 */
 
 bool MainHandWeaponNoImbueTrigger::IsActive() {
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND );
+    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
     if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
         return false;
     return true;
 }
 
 bool OffHandWeaponNoImbueTrigger::IsActive() {
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND );
-    if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+    if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) || itemForSpell->GetTemplate()->InventoryType != INVTYPE_WEAPONOFFHAND)
         return false;
     return true;
 }

--- a/src/strategy/shaman/ShamanTriggers.cpp
+++ b/src/strategy/shaman/ShamanTriggers.cpp
@@ -42,7 +42,7 @@ bool MainHandWeaponNoImbueTrigger::IsActive() {
 
 bool OffHandWeaponNoImbueTrigger::IsActive() {
     Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) || itemForSpell->GetTemplate()->InventoryType != INVTYPE_WEAPONOFFHAND)
+    if (!itemForSpell || itemForSpell->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) || itemForSpell->GetTemplate()->InventoryType != INVTYPE_WEAPON)
         return false;
     return true;
 }


### PR DESCRIPTION
- Fix endless loop for resto shamans trying to cast flametongue weap
- Add guard for offhand buffing to only buff weapons (no shields/offhand held items)