### PR TITLE
[Summon] Fix bot remove from world casued by summon

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -451,11 +451,15 @@ void PlayerbotAI::HandleTeleportAck()
 	bot->GetMotionMaster()->Clear(true);
 	bot->StopMoving();
     if (bot->IsBeingTeleportedNear()) {
+        // Temporary fix for instance can not enter
+        if (!bot->IsInWorld()) {
+            bot->GetMap()->AddPlayerToMap(bot);
+        }
         while (bot->IsInWorld() && bot->IsBeingTeleportedNear()) {
             Player* plMover = bot->m_mover->ToPlayer();
             if (!plMover)
                 return;
-            WorldPacket p = WorldPacket(MSG_MOVE_TELEPORT_ACK, 8 + 4 + 4);
+            WorldPacket p = WorldPacket(MSG_MOVE_TELEPORT_ACK, 20);
             p << plMover->GetPackGUID();
             p << (uint32) 0; // supposed to be flags? not used currently
             p << (uint32) 0; // time - not currently used


### PR DESCRIPTION
Summon behavior that used to cause crashes now causes bots to be removed from world. https://github.com/liyunfan1223/mod-playerbots/pull/354

Try to fix this problem. Pass basic tests but not entirely sure if it cause other issues.