### PR TITLE
Fix: Bots attacking players that are not flagged for PvP

### DIFF
--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -95,6 +95,16 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         return false;
     }
 
+    if (target->IsPlayer() && !target->IsPvP() && !target->IsFFAPvP() && (!bot->duel || bot->duel->Opponent != target || bot->duel->StartTime))
+    {
+        if (verbose)
+        {
+            botAI->TellError(Acore::StringFormat("%s is not flagged for pvp", target->GetName()));
+        }
+
+        return false;
+    }
+
     if (bot->IsMounted() && bot->IsWithinLOSInMap(target))
     {
         WorldPacket emptyPacket;


### PR DESCRIPTION
Credit to @Jgoodwin64 and @fuzzdeveloper  because most of it is based on their work along with some changes I've done while comparing how these functions are used in the core.

This should make it so bots will never attack players that are not flagged for PvP and not in a duel with the bot.