### PR TITLE
Fix: Updated to work with newer commits of AzerothCore

### DIFF
--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -55,7 +55,7 @@ uint8 AiFactory::GetPlayerSpecTab(Player* bot)
 {
     std::map<uint8, uint32> tabs = GetPlayerSpecTabs(bot);
 
-    if (bot->getLevel() >= 10 && ((tabs[0] + tabs[1] + tabs[2]) > 0))
+    if (bot->GetLevel() >= 10 && ((tabs[0] + tabs[1] + tabs[2]) > 0))
     {
         int8 tab = -1;
         uint32 max = 0;
@@ -301,7 +301,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
         case CLASS_WARRIOR:
             if (tab == 2)
                 engine->addStrategies("tank", "tank assist", "aoe", "mark rti", nullptr);
-            else if (player->getLevel() < 36 || tab == 0)
+            else if (player->GetLevel() < 36 || tab == 0)
                 engine->addStrategies("arms", "aoe", "dps assist",/*"behind",*/ nullptr);
             else
                 engine->addStrategies("fury", "aoe", "dps assist",/*"behind",*/ nullptr);

--- a/src/ChatFilter.cpp
+++ b/src/ChatFilter.cpp
@@ -68,14 +68,14 @@ class LevelChatFilter : public ChatFilter
                 uint32 fromLevel = atoi(message.substr(message.find("@") + 1, message.find("-")).c_str());
                 uint32 toLevel = atoi(message.substr(message.find("-") + 1, message.find(" ")).c_str());
 
-                if (bot->getLevel() >= fromLevel && bot->getLevel() <= toLevel)
+                if (bot->GetLevel() >= fromLevel && bot->GetLevel() <= toLevel)
                     return ChatFilter::Filter(message);
 
                 return message;
             }
 
 		    uint32 level = atoi(message.substr(message.find("@") + 1, message.find(" ")).c_str());
-            if (bot->getLevel() == level)
+            if (bot->GetLevel() == level)
                 return ChatFilter::Filter(message);
 
             return message;

--- a/src/GuildTaskMgr.cpp
+++ b/src/GuildTaskMgr.cpp
@@ -173,11 +173,11 @@ private:
 
 bool GuildTaskMgr::CreateItemTask(Player* player, uint32 guildId)
 {
-    if (!player || player->getLevel() < 5)
+    if (!player || player->GetLevel() < 5)
         return false;
 
     RandomItemBySkillGuildTaskPredicate predicate(player);
-    uint32 itemId = sRandomItemMgr->GetRandomItem(player->getLevel() - 5, RANDOM_ITEM_GUILD_TASK, &predicate);
+    uint32 itemId = sRandomItemMgr->GetRandomItem(player->GetLevel() - 5, RANDOM_ITEM_GUILD_TASK, &predicate);
     if (!itemId)
     {
         LOG_ERROR("playerbots",  "{} / {}: no items avaible for item task", sGuildMgr->GetGuildById(guildId)->GetName().c_str(), player->GetName().c_str());
@@ -203,7 +203,7 @@ bool GuildTaskMgr::CreateKillTask(Player* player, uint32 guildId)
 
     std::vector<uint32> ids;
 
-    uint32 level = player->getLevel();
+    uint32 level = player->GetLevel();
     QueryResult results = WorldDatabase.Query("SELECT ct.Entry, c.map, c.position_x, c.position_y, ct.Name FROM creature_template ct "
         "JOIN creature c ON ct.Entry = c.id1 WHERE ct.MaxLevel < {} AND ct.MinLevel > {} AND ct.Rank = {} ", level + 4, level - 3, rank);
     if (results)
@@ -910,7 +910,7 @@ bool GuildTaskMgr::Reward(CharacterDatabaseTransaction& trans, uint32 owner, uin
         body << guild->GetName() << "\n";
         body << leader->GetName() << "\n";
         rewardType = proto->Quality > ITEM_QUALITY_NORMAL ? RANDOM_ITEM_GUILD_TASK_REWARD_EQUIP_BLUE : RANDOM_ITEM_GUILD_TASK_REWARD_EQUIP_GREEN;
-        itemId = sRandomItemMgr->GetRandomItem(player->getLevel() - 5, rewardType);
+        itemId = sRandomItemMgr->GetRandomItem(player->GetLevel() - 5, rewardType);
     }
     else if (killTask)
     {
@@ -924,7 +924,7 @@ bool GuildTaskMgr::Reward(CharacterDatabaseTransaction& trans, uint32 owner, uin
         body << guild->GetName() << "\n";
         body << leader->GetName() << "\n";
         rewardType = proto->rank == CREATURE_ELITE_RARE ? RANDOM_ITEM_GUILD_TASK_REWARD_TRADE : RANDOM_ITEM_GUILD_TASK_REWARD_TRADE_RARE;
-        itemId = sRandomItemMgr->GetRandomItem(player->getLevel(), rewardType);
+        itemId = sRandomItemMgr->GetRandomItem(player->GetLevel(), rewardType);
         if (itemId)
         {
             ItemTemplate const* itemProto = sObjectMgr->GetItemTemplate(itemId);

--- a/src/LootObjectStack.cpp
+++ b/src/LootObjectStack.cpp
@@ -71,7 +71,7 @@ void LootObject::Refresh(Player* bot, ObjectGuid lootGUID)
         if (creature->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE))
         {
             skillId = creature->GetCreatureTemplate()->GetRequiredLootSkill();
-            uint32 targetLevel = creature->getLevel();
+            uint32 targetLevel = creature->GetLevel();
             reqSkillValue = targetLevel < 10 ? 1 : targetLevel < 20 ? (targetLevel - 10) * 10 : targetLevel * 5;
             if (botAI->HasSkill((SkillType) skillId) && bot->GetSkillValue(skillId) >= reqSkillValue)
                 guid = lootGUID;

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -1104,7 +1104,7 @@ void PlayerbotAI::DoNextAction(bool min)
                     if (!group->SameSubGroup(bot, member))
                         continue;
 
-                    if (member->getLevel() < bot->getLevel())
+                    if (member->GetLevel() < bot->GetLevel())
                         continue;
 
                     // follow real player only if he has more honor/arena points

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -282,7 +282,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     if (pmo)
         pmo->finish();
 
-    // if (bot->getLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
+    // if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
     // {
     //     pmo = sPerformanceMonitor->start(PERF_MON_RNDBOT, "PlayerbotFactory_Enchant");
     //     LOG_INFO("playerbots", "Initializing enchant templates...");
@@ -328,7 +328,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     if (pmo)
         pmo->finish();
 
-    if (bot->getLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
+    if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
         ApplyEnchantAndGemsNew();
     }
     // {
@@ -363,7 +363,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     //if (pmo)
     //    pmo->finish();
 
-    // if (bot->getLevel() >= 70)
+    // if (bot->GetLevel() >= 70)
     // {
     //     pmo = sPerformanceMonitor->start(PERF_MON_RNDBOT, "PlayerbotFactory_Arenas");
     //     LOG_INFO("playerbots", "Initializing arena teams...");
@@ -377,7 +377,7 @@ void PlayerbotFactory::Randomize(bool incremental)
         bot->RemovePet(nullptr, PET_SAVE_NOT_IN_SLOT, true);
         // bot->SaveToDB(false, false);
     }
-    if (bot->getLevel() >= 10)
+    if (bot->GetLevel() >= 10)
     {
         pmo = sPerformanceMonitor->start(PERF_MON_RNDBOT, "PlayerbotFactory_Pet");
         LOG_DEBUG("playerbots", "Initializing pet...");
@@ -417,7 +417,7 @@ void PlayerbotFactory::Refresh()
     InitAvailableSpells();
     InitSkills();
     InitMounts();
-    if (bot->getLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
+    if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
         ApplyEnchantAndGemsNew();
     }
     bot->DurabilityRepairAll(false, 1.0f, false);
@@ -666,7 +666,7 @@ void PlayerbotFactory::InitPet()
             if (!itr->second.IsTameable(bot->CanTameExoticPets()))
                 continue;
 
-            if (itr->second.minlevel > bot->getLevel())
+            if (itr->second.minlevel > bot->GetLevel())
                 continue;
             
 			ids.push_back(itr->first);
@@ -674,7 +674,7 @@ void PlayerbotFactory::InitPet()
 
         if (ids.empty())
         {
-            LOG_ERROR("playerbots", "No pets available for bot {} ({} level)", bot->GetName().c_str(), bot->getLevel());
+            LOG_ERROR("playerbots", "No pets available for bot {} ({} level)", bot->GetName().c_str(), bot->GetLevel());
             return;
         }
 
@@ -728,8 +728,8 @@ void PlayerbotFactory::InitPet()
 
     if (pet)
     {
-        pet->InitStatsForLevel(bot->getLevel());
-        pet->SetLevel(bot->getLevel());
+        pet->InitStatsForLevel(bot->GetLevel());
+        pet->SetLevel(bot->GetLevel());
         pet->SetPower(POWER_HAPPINESS, pet->GetMaxPower(Powers(POWER_HAPPINESS)));
         pet->SetHealth(pet->GetMaxHealth());
     }
@@ -1241,7 +1241,7 @@ bool PlayerbotFactory::CanEquipItem(ItemTemplate const* proto, uint32 desiredQua
     if (!requiredLevel)
         return false;
 
-    uint32 level = bot->getLevel();
+    uint32 level = bot->GetLevel();
     uint32 delta = 2;
     if (level < 15)
         delta = std::min(level, 15u); // urand(7, 15);
@@ -1363,7 +1363,7 @@ void Shuffle(std::vector<uint32>& items)
 //                         newItem->SetOwnerGUID(bot->GetGUID());
 //                         EnchantItem(newItem);
 //                         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Equip: {}, slot: {}, Old item: {}",
-//                             bot->GetGUID().ToString().c_str(), IsAlliance(bot->getRace()) ? "A" : "H", bot->getLevel(), bot->GetName(), newItemId, slot, itemInSlot);
+//                             bot->GetGUID().ToString().c_str(), IsAlliance(bot->getRace()) ? "A" : "H", bot->GetLevel(), bot->GetName(), newItemId, slot, itemInSlot);
 //                         found = true;
 //                         break;
 //                     }
@@ -1390,7 +1390,7 @@ void Shuffle(std::vector<uint32>& items)
 //                         EnchantItem(newItem);
 //                         found = true;
 //                         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Equip: {}, slot: {}",
-//                             bot->GetGUID().ToString().c_str(), IsAlliance(bot->getRace()) ? "A" : "H", bot->getLevel(), bot->GetName(), newItemId, slot);
+//                             bot->GetGUID().ToString().c_str(), IsAlliance(bot->getRace()) ? "A" : "H", bot->GetLevel(), bot->GetName(), newItemId, slot);
 //                         break;
 //                     }
 //                 }
@@ -1400,7 +1400,7 @@ void Shuffle(std::vector<uint32>& items)
 //         if (!found)
 //         {
 //             LOG_INFO("playerbots", "Bot {} {}:{} <{}>: no item for slot {}",
-//                 bot->GetGUID().ToString().c_str(), IsAlliance(bot->getRace()) ? "A" : "H", bot->getLevel(), bot->GetName(), slot);
+//                 bot->GetGUID().ToString().c_str(), IsAlliance(bot->getRace()) ? "A" : "H", bot->GetLevel(), bot->GetName(), slot);
 //             continue;
 //         }
 //     }
@@ -1411,7 +1411,7 @@ void PlayerbotFactory::InitEquipment(bool incremental)
     std::unordered_map<uint8, std::vector<uint32> > items;
     int tab = AiFactory::GetPlayerSpecTab(bot);
     
-    uint32 blevel = bot->getLevel();
+    uint32 blevel = bot->GetLevel();
     int32 delta = 2;
     if (blevel < 15)
         delta = std::min(blevel, 15u);
@@ -1593,8 +1593,8 @@ bool PlayerbotFactory::IsDesiredReplacement(Item* item)
     //     requiredLevel = sRandomItemMgr->GetMinLevelFromCache(proto->ItemId);
     // }
     
-    uint32 delta = 1 + (80 - bot->getLevel()) / 10;
-    return proto->Quality < ITEM_QUALITY_RARE || int32(bot->getLevel() - requiredLevel) > delta;
+    uint32 delta = 1 + (80 - bot->GetLevel()) / 10;
+    return proto->Quality < ITEM_QUALITY_RARE || int32(bot->GetLevel() - requiredLevel) > delta;
 }
 
 inline Item* StoreNewItemInInventorySlot(Player* player, uint32 newItemId, uint32 count)
@@ -1747,7 +1747,7 @@ void PlayerbotFactory::InitBags(bool destroyOld)
 
 void PlayerbotFactory::EnchantItem(Item* item)
 {
-    if (bot->getLevel() < sPlayerbotAIConfig->minEnchantingBotLevel)
+    if (bot->GetLevel() < sPlayerbotAIConfig->minEnchantingBotLevel)
         return;
 
     if (urand(0, 100) < 100 * sPlayerbotAIConfig->randomGearLoweringChance)
@@ -1932,19 +1932,19 @@ void PlayerbotFactory::InitSkills()
 
     uint16 step = bot->GetSkillValue(SKILL_RIDING) ? bot->GetSkillStep(SKILL_RIDING) : 1;
 
-    if (bot->getLevel() >= 70)
+    if (bot->GetLevel() >= 70)
         bot->SetSkill(SKILL_RIDING, step, 300, 300);
-    else if (bot->getLevel() >= 60)
+    else if (bot->GetLevel() >= 60)
         bot->SetSkill(SKILL_RIDING, step, 225, 225);
-    else if (bot->getLevel() >= 40)
+    else if (bot->GetLevel() >= 40)
         bot->SetSkill(SKILL_RIDING, step, 150, 150);
-    else if (bot->getLevel() >= 20)
+    else if (bot->GetLevel() >= 20)
         bot->SetSkill(SKILL_RIDING, step, 75, 75);
     else
         bot->SetSkill(SKILL_RIDING, 0, 0, 0);
 
-    uint32 skillLevel = bot->getLevel() < 40 ? 0 : 1;
-    uint32 dualWieldLevel = bot->getLevel() < 20 ? 0 : 1;
+    uint32 skillLevel = bot->GetLevel() < 40 ? 0 : 1;
+    uint32 dualWieldLevel = bot->GetLevel() < 20 ? 0 : 1;
     SetRandomSkill(SKILL_DEFENSE);
     switch (bot->getClass())
     {
@@ -2161,7 +2161,7 @@ void PlayerbotFactory::InitAvailableSpells()
 
 void PlayerbotFactory::InitClassSpells()
 {
-    int32_t level = bot->getLevel();
+    int32_t level = bot->GetLevel();
     switch (bot->getClass())
     {
         case CLASS_WARRIOR:
@@ -2450,14 +2450,14 @@ void PlayerbotFactory::InitQuests(std::list<uint32>& questMap)
         uint32 questId = *i;
         Quest const *quest = sObjectMgr->GetQuestTemplate(questId);
 
-        if (!bot->SatisfyQuestClass(quest, false) || quest->GetMinLevel() > bot->getLevel() || !bot->SatisfyQuestRace(quest, false))
+        if (!bot->SatisfyQuestClass(quest, false) || quest->GetMinLevel() > bot->GetLevel() || !bot->SatisfyQuestRace(quest, false))
             continue;
 
         bot->SetQuestStatus(questId, QUEST_STATUS_COMPLETE);
         bot->RewardQuest(quest, 0, bot, false);
 
         LOG_INFO("playerbots", "Bot {} ({} level) rewarded quest {}: {} (MinLevel={}, QuestLevel={})",
-            bot->GetName().c_str(), bot->getLevel(), questId, quest->GetTitle().c_str(), quest->GetMinLevel(), quest->GetQuestLevel());
+            bot->GetName().c_str(), bot->GetLevel(), questId, quest->GetTitle().c_str(), quest->GetMinLevel(), quest->GetQuestLevel());
 
         if (!(count++ % 10))
             ClearInventory();
@@ -2545,7 +2545,7 @@ void PlayerbotFactory::InitMounts()
     uint32 thirdmount = 60;
     uint32 fourthmount = 70;
 
-    if (bot->getLevel() < firstmount)
+    if (bot->GetLevel() < firstmount)
         return;
 
     std::map<uint8, std::map<uint32, std::vector<uint32>>> mounts;
@@ -2616,13 +2616,13 @@ void PlayerbotFactory::InitMounts()
 
     for (uint32 type = 0; type < 4; type++)
     {
-        if (bot->getLevel() < secondmount && type == 1)
+        if (bot->GetLevel() < secondmount && type == 1)
             continue;
 
-        if (bot->getLevel() < thirdmount && type == 2)
+        if (bot->GetLevel() < thirdmount && type == 2)
             continue;
 
-        if (bot->getLevel() < fourthmount && type == 3)
+        if (bot->GetLevel() < fourthmount && type == 3)
             continue;
 
         uint32 index = urand(0, mounts[bot->getRace()][type].size() - 1);
@@ -2630,7 +2630,7 @@ void PlayerbotFactory::InitMounts()
         if (spell)
         {
             bot->learnSpell(spell);
-            LOG_DEBUG("playerbots", "Bot {} ({}) learned {} mount {}", bot->GetGUID().ToString().c_str(), bot->getLevel(), type == 0 ? "slow" : (type == 1 ? "fast" : "flying"), spell);
+            LOG_DEBUG("playerbots", "Bot {} ({}) learned {} mount {}", bot->GetGUID().ToString().c_str(), bot->GetLevel(), type == 0 ? "slow" : (type == 1 ? "fast" : "flying"), spell);
         }
     }
 }
@@ -2667,7 +2667,7 @@ void PlayerbotFactory::InitPotions()
         uint32 itemId = sRandomItemMgr->GetRandomPotion(level, effect);
         if (!itemId)
         {
-            // LOG_INFO("playerbots", "No potions (type {}) available for bot {} ({} level)", effect, bot->GetName().c_str(), bot->getLevel());
+            // LOG_INFO("playerbots", "No potions (type {}) available for bot {} ({} level)", effect, bot->GetName().c_str(), bot->GetLevel());
             continue;
         }
 
@@ -2701,7 +2701,7 @@ void PlayerbotFactory::InitFood()
             proto->Bonding != NO_BIND)
             continue;
 
-        if (proto->RequiredLevel > bot->getLevel() || proto->RequiredLevel < bot->getLevel() - 9)
+        if (proto->RequiredLevel > bot->GetLevel() || proto->RequiredLevel < bot->GetLevel() - 9)
             continue;
 
         if (proto->RequiredSkill && !bot->HasSkill(proto->RequiredSkill))
@@ -2744,7 +2744,7 @@ void PlayerbotFactory::InitFood()
 
 void PlayerbotFactory::InitReagents()
 {
-    int level = bot->getLevel();
+    int level = bot->GetLevel();
     std::vector<std::pair<uint32, uint32>> items;
     switch (bot->getClass()) 
     {
@@ -2754,14 +2754,14 @@ void PlayerbotFactory::InitReagents()
             std::vector<int> deadly_poison_ids = {43233, 43232, 22054, 22053, 20844, 8985, 8984, 2893, 2892};
             for (int& itemId: deadly_poison_ids) {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                if (proto->RequiredLevel > bot->getLevel())
+                if (proto->RequiredLevel > bot->GetLevel())
                     continue;
                 items.push_back({itemId, 20}); // deadly poison
                 break;    
             }
             for (int& itemId: instant_poison_ids) {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                if (proto->RequiredLevel > bot->getLevel())
+                if (proto->RequiredLevel > bot->GetLevel())
                     continue;
                 items.push_back({itemId, 20}); // instant poison
                 break;    
@@ -2774,7 +2774,7 @@ void PlayerbotFactory::InitReagents()
             items.push_back({5176, 1}); // Flame Totem
             items.push_back({5177, 1}); // Water Totem
             items.push_back({5178, 1}); // Air Totem
-            if (bot->getLevel() >= 30)
+            if (bot->GetLevel() >= 30)
                 items.push_back({17030, 40}); // Ankh
             break;
         case CLASS_WARLOCK:
@@ -2848,7 +2848,7 @@ void PlayerbotFactory::InitGlyphs(bool increment)
         }
     }
 
-    uint32 level = bot->getLevel();
+    uint32 level = bot->GetLevel();
     uint32 maxSlot = 0;
     if (level >= 15)
         maxSlot = 2;
@@ -3041,7 +3041,7 @@ void PlayerbotFactory::InitInventoryTrade()
     uint32 itemId = sRandomItemMgr->GetRandomTrade(level);
     if (!itemId)
     {
-        LOG_ERROR("playerbots", "No trade items available for bot {} ({} level)", bot->GetName().c_str(), bot->getLevel());
+        LOG_ERROR("playerbots", "No trade items available for bot {} ({} level)", bot->GetName().c_str(), bot->GetLevel());
         return;
     }
 
@@ -3151,7 +3151,7 @@ void PlayerbotFactory::InitGuild()
         guild->AddMember(bot->GetGUID(), urand(GR_OFFICER, GR_INITIATE));
 
     // add guild tabard
-    if (bot->GetGuildId() && bot->getLevel() > 9 && urand(0, 4) && !bot->HasItemCount(5976, 1))
+    if (bot->GetGuildId() && bot->GetLevel() > 9 && urand(0, 4) && !bot->HasItemCount(5976, 1))
         StoreItem(5976, 1);
 
     bot->SaveToDB(false, false);
@@ -3229,7 +3229,7 @@ void PlayerbotFactory::InitImmersive()
         {
             Stats from = (Stats)urand(STAT_STRENGTH, MAX_STATS - 1);
             Stats to = (Stats)urand(STAT_STRENGTH, MAX_STATS - 1);
-            int32 delta = urand(0, 5 + bot->getLevel() / 3);
+            int32 delta = urand(0, 5 + bot->GetLevel() / 3);
             if (from != to && percentMap[to] + delta <= 100 && percentMap[from] - delta >= 0)
             {
                 percentMap[to] += delta;
@@ -3275,7 +3275,7 @@ void PlayerbotFactory::InitArenaTeam()
         return;
     }
 
-    if (arenateam->GetMembersSize() < ((uint32)arenateam->GetType() * 2) && bot->getLevel() >= 70)
+    if (arenateam->GetMembersSize() < ((uint32)arenateam->GetType() * 2) && bot->GetLevel() >= 70)
     {
         ObjectGuid capt = arenateam->GetCaptain();
         Player* botcaptain = ObjectAccessor::FindPlayer(capt);

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -504,15 +504,15 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
 
     bot->SaveToDB(false, false);
     if (master && isRandomAccount && master->GetLevel() < bot->GetLevel()) {
-        // PlayerbotFactory factory(bot, master->getLevel());
+        // PlayerbotFactory factory(bot, master->GetLevel());
         // factory.Randomize(false);
         uint32 mixedGearScore = PlayerbotAI::GetMixedGearScore(master, true, false, 12) * sPlayerbotAIConfig->autoInitEquipLevelLimitRatio;
-        PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
+        PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
         factory.Randomize(false);
     }
 
     // bots join World chat if not solo oriented
-    if (bot->getLevel() >= 10 && sRandomPlayerbotMgr->IsRandomBot(bot) && GET_PLAYERBOT_AI(bot) && GET_PLAYERBOT_AI(bot)->GetGrouperType() != GrouperType::SOLO)
+    if (bot->GetLevel() >= 10 && sRandomPlayerbotMgr->IsRandomBot(bot) && GET_PLAYERBOT_AI(bot) && GET_PLAYERBOT_AI(bot)->GetGrouperType() != GrouperType::SOLO)
     {
         // TODO make action/config
         // Make the bot join the world channel for chat
@@ -628,44 +628,44 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
             int gs;
             if (cmd == "init=white" || cmd == "init=common")
             {
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_NORMAL);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_NORMAL);
                 factory.Randomize(false);
                 return "ok";
             }
             else if (cmd == "init=green" || cmd == "init=uncommon")
             {
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_UNCOMMON);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_UNCOMMON);
                 factory.Randomize(false);
                 return "ok";
             }
             else if (cmd == "init=blue" || cmd == "init=rare")
             {
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_RARE);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_RARE);
                 factory.Randomize(false);
                 return "ok";
             }
             else if (cmd == "init=epic" || cmd == "init=purple")
             {
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_EPIC);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_EPIC);
                 factory.Randomize(false);
                 return "ok";
             }
             else if (cmd == "init=legendary" || cmd == "init=yellow")
             {
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_LEGENDARY);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY);
                 factory.Randomize(false);
                 return "ok";
             }
             else if (cmd == "init=auto")
             {
                 uint32 mixedGearScore = PlayerbotAI::GetMixedGearScore(master, true, false, 12) * sPlayerbotAIConfig->autoInitEquipLevelLimitRatio;
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
                 factory.Randomize(false);
                 return "ok, gear score limit: " + std::to_string(mixedGearScore / (ITEM_QUALITY_EPIC + 1)) + "(for epic)";
             }
             else if (cmd.starts_with("init=") && sscanf(cmd.c_str(), "init=%d", &gs) != -1)
             {
-                PlayerbotFactory factory(bot, master->getLevel(), ITEM_QUALITY_LEGENDARY, gs);
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, gs);
                 factory.Randomize(false);
                 return "ok, gear score limit: " + std::to_string(gs / (ITEM_QUALITY_EPIC + 1)) + "(for epic)";
             }
@@ -674,7 +674,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
         if (cmd == "refresh=raid")
         {   // TODO: This function is not perfect yet. If you are already in a raid, 
             // after the command is executed, the AI ​​needs to go back online or exit the raid and re-enter.
-            PlayerbotFactory factory(bot, bot->getLevel());
+            PlayerbotFactory factory(bot, bot->GetLevel());
             factory.UnbindInstance();
             return "ok";
         }
@@ -682,13 +682,13 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
 
     if (cmd == "levelup" || cmd == "level")
     {
-        PlayerbotFactory factory(bot, bot->getLevel());
+        PlayerbotFactory factory(bot, bot->GetLevel());
         factory.Randomize(true);
         return "ok";
     }
     else if (cmd == "refresh")
     {
-        PlayerbotFactory factory(bot, bot->getLevel());
+        PlayerbotFactory factory(bot, bot->GetLevel());
         factory.Refresh();
         return "ok";
     }
@@ -698,7 +698,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
         return "ok";
     }
     else if (cmd == "quests"){
-        PlayerbotFactory factory(bot, bot->getLevel());
+        PlayerbotFactory factory(bot, bot->GetLevel());
         factory.InitInstanceQuests();
         return "Initialization quests";
     }
@@ -764,7 +764,7 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
     if (!strcmp(cmd, "initself")) {
         if (master->GetSession()->GetSecurity() >= SEC_GAMEMASTER) {
             // OnBotLogin(master);
-            PlayerbotFactory factory(master, master->getLevel(), ITEM_QUALITY_EPIC);
+            PlayerbotFactory factory(master, master->GetLevel(), ITEM_QUALITY_EPIC);
             factory.Randomize(false);
             messages.push_back("initself ok");
             return messages;
@@ -778,7 +778,7 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
         if (!strcmp(cmd, "initself=rare")) {
             if (master->GetSession()->GetSecurity() >= SEC_GAMEMASTER) {
                 // OnBotLogin(master);
-                PlayerbotFactory factory(master, master->getLevel(), ITEM_QUALITY_RARE);
+                PlayerbotFactory factory(master, master->GetLevel(), ITEM_QUALITY_RARE);
                 factory.Randomize(false);
                 messages.push_back("initself ok");
                 return messages;
@@ -790,7 +790,7 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
         if (!strcmp(cmd, "initself=epic")) {
             if (master->GetSession()->GetSecurity() >= SEC_GAMEMASTER) {
                 // OnBotLogin(master);
-                PlayerbotFactory factory(master, master->getLevel(), ITEM_QUALITY_EPIC);
+                PlayerbotFactory factory(master, master->GetLevel(), ITEM_QUALITY_EPIC);
                 factory.Randomize(false);
                 messages.push_back("initself ok");
                 return messages;
@@ -803,7 +803,7 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
         if (sscanf(cmd, "initself=%d", &gs) != -1) {
             if (master->GetSession()->GetSecurity() >= SEC_GAMEMASTER) {
                 // OnBotLogin(master);
-                PlayerbotFactory factory(master, master->getLevel(), ITEM_QUALITY_LEGENDARY, gs);
+                PlayerbotFactory factory(master, master->GetLevel(), ITEM_QUALITY_LEGENDARY, gs);
                 factory.Randomize(false);
                 messages.push_back("initself ok, gs = " + std::to_string(gs));
                 return messages;

--- a/src/PlayerbotSecurity.cpp
+++ b/src/PlayerbotSecurity.cpp
@@ -69,7 +69,7 @@ PlayerbotSecurityLevel PlayerbotSecurity::LevelFor(Player* from, DenyReason* rea
             return PLAYERBOT_SECURITY_TALK;
         }
 
-        if (sPlayerbotAIConfig->groupInvitationPermission <= 1 && (int32)bot->getLevel() - (int8)from->getLevel() > 5)
+        if (sPlayerbotAIConfig->groupInvitationPermission <= 1 && (int32)bot->GetLevel() - (int8)from->GetLevel() > 5)
         {
             if (!bot->GetGuildId() || bot->GetGuildId() != from->GetGuildId())
             {
@@ -84,8 +84,8 @@ PlayerbotSecurityLevel PlayerbotSecurity::LevelFor(Player* from, DenyReason* rea
         int32 fromGS = (int32)botAI->GetEquipGearScore(from, false, false);
         if (sPlayerbotAIConfig->gearscorecheck)
         {
-            if (botGS && bot->getLevel() > 15 && botGS > fromGS &&
-                static_cast<float>(100 * (botGS - fromGS) / botGS) >= static_cast<float>(12 * sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) / from->getLevel()))
+            if (botGS && bot->GetLevel() > 15 && botGS > fromGS &&
+                static_cast<float>(100 * (botGS - fromGS) / botGS) >= static_cast<float>(12 * sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) / from->GetLevel()))
             {
                 if (reason) *reason = PLAYERBOT_DENY_GEARSCORE;
                 return PLAYERBOT_SECURITY_TALK;
@@ -199,14 +199,14 @@ bool PlayerbotSecurity::CheckLevelFor(PlayerbotSecurityLevel level, bool silent,
                 out << "I'll do it later";
                 break;
             case PLAYERBOT_DENY_LOW_LEVEL:
-                out << "You are too low level: |cffff0000" << (uint32)from->getLevel() << "|cffffffff/|cff00ff00" << (uint32)bot->getLevel();
+                out << "You are too low level: |cffff0000" << (uint32)from->GetLevel() << "|cffffffff/|cff00ff00" << (uint32)bot->GetLevel();
                 break;
             case PLAYERBOT_DENY_GEARSCORE:
                 {
                     int botGS = (int)botAI->GetEquipGearScore(bot, false, false);
                     int fromGS = (int)botAI->GetEquipGearScore(from, false, false);
                     int diff = (100 * (botGS - fromGS) / botGS);
-                    int req = 12 * sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) / from->getLevel();
+                    int req = 12 * sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) / from->GetLevel();
                     out << "Your gearscore is too low: |cffff0000" << fromGS << "|cffffffff/|cff00ff00" << botGS << " |cffff0000" << diff << "%|cffffffff/|cff00ff00" << req << "%";
                 }
                 break;

--- a/src/RandomItemMgr.cpp
+++ b/src/RandomItemMgr.cpp
@@ -1696,11 +1696,11 @@ uint32 RandomItemMgr::GetUpgrade(Player* player, std::string spec, uint8 slot, u
             continue;
 
         // skip higher lvl
-        if (info.minLevel > player->getLevel())
+        if (info.minLevel > player->GetLevel())
             continue;
 
         // skip too low level
-        if (info.minLevel < (player->getLevel() - 10))
+        if (info.minLevel < (player->GetLevel() - 10))
             continue;
 
         // skip wrong team
@@ -1720,7 +1720,7 @@ uint32 RandomItemMgr::GetUpgrade(Player* player, std::string spec, uint8 slot, u
             continue;
 
         // skip items that only fit in slot, but not stats
-        if (!itemId && info.weights[specId] == 1 && player->getLevel() > 40)
+        if (!itemId && info.weights[specId] == 1 && player->GetLevel() > 40)
             continue;
 
         // skip quest items
@@ -1751,7 +1751,7 @@ uint32 RandomItemMgr::GetUpgrade(Player* player, std::string spec, uint8 slot, u
             }
         }
 
-        if (bestSpecId && bestSpecId != specId && player->getLevel() > 40)
+        if (bestSpecId && bestSpecId != specId && player->GetLevel() > 40)
             return 0;
 
         if (!closestUpgrade)
@@ -1820,11 +1820,11 @@ std::vector<uint32> RandomItemMgr::GetUpgradeList(Player* player, std::string sp
             continue;
 
         // skip higher lvl
-        if (info.minLevel > player->getLevel())
+        if (info.minLevel > player->GetLevel())
             continue;
 
         // skip too low level
-        if ((int32)info.minLevel < (int32)(player->getLevel() - 20))
+        if ((int32)info.minLevel < (int32)(player->GetLevel() - 20))
             continue;
 
         // skip wrong team
@@ -1844,7 +1844,7 @@ std::vector<uint32> RandomItemMgr::GetUpgradeList(Player* player, std::string sp
             continue;
 
         // skip items that only fit in slot, but not stats
-        if (!itemId && info.weights[specId] == 1 && player->getLevel() > 40)
+        if (!itemId && info.weights[specId] == 1 && player->GetLevel() > 40)
             continue;
 
         // skip quest items
@@ -1863,7 +1863,7 @@ std::vector<uint32> RandomItemMgr::GetUpgradeList(Player* player, std::string sp
             info.slot == EQUIPMENT_SLOT_FINGER2))
             continue;
 
-        //if (player->getLevel() >= 40)
+        //if (player->GetLevel() >= 40)
         //{
         //    // check if item stat score is the best among class specs
         //    uint32 bestSpecId = 0;
@@ -1990,11 +1990,11 @@ uint32 RandomItemMgr::GetLiveStatWeight(Player* player, uint32 itemId)
     statWeight = itr->second.weights[specId];
 
     // skip higher lvl
-    if (itr->second.minLevel > player->getLevel())
+    if (itr->second.minLevel > player->GetLevel())
         return 0;
 
     // skip too low level
-    //if ((int32)info->minLevel < (int32)(player->getLevel() - 20))
+    //if ((int32)info->minLevel < (int32)(player->GetLevel() - 20))
     //    return 0;
 
     // skip wrong team
@@ -2025,7 +2025,7 @@ uint32 RandomItemMgr::GetLiveStatWeight(Player* player, uint32 itemId)
         return 0;
 
     // skip items that only fit in slot, but not stats
-    if (!itemId && itr->second.weights[specId] == 1 && player->getLevel() > 20)
+    if (!itemId && itr->second.weights[specId] == 1 && player->GetLevel() > 20)
         return 0;
 
     // check if item stat score is the best among class specs
@@ -2040,7 +2040,7 @@ uint32 RandomItemMgr::GetLiveStatWeight(Player* player, uint32 itemId)
         }
     }
 
-    if (bestSpecId && bestSpecId != specId && player->getLevel() >= 60)
+    if (bestSpecId && bestSpecId != specId && player->GetLevel() >= 60)
         return 0;*/
 
     return statWeight;

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -466,7 +466,7 @@ void RandomPlayerbotFactory::CreateRandomBots()
                 if (Player* playerBot = factory.CreateRandomBot(session, cls, names)) {
                     playerBot->SaveToDB(true, false);
                     sCharacterCache->AddCharacterCacheEntry(playerBot->GetGUID(), accountId, playerBot->GetName(), 
-                        playerBot->getGender(), playerBot->getRace(), playerBot->getClass(), playerBot->getLevel());
+                        playerBot->getGender(), playerBot->getRace(), playerBot->getClass(), playerBot->GetLevel());
                     playerBot->CleanupsBeforeDelete();
                     delete playerBot;
                 }
@@ -666,7 +666,7 @@ void RandomPlayerbotFactory::CreateRandomArenaTeams()
         {
             Player* player = ObjectAccessor::FindConnectedPlayer(captain);
 
-            if (!arenateam && player && player->getLevel() >= 70)
+            if (!arenateam && player && player->GetLevel() >= 70)
                 availableCaptains.push_back(captain);
         }
     }
@@ -692,7 +692,7 @@ void RandomPlayerbotFactory::CreateRandomArenaTeams()
             continue;
         }
 
-        if (player->getLevel() < 70)
+        if (player->GetLevel() < 70)
         {
             LOG_ERROR("playerbots", "Bot {} must be level 70 to create an arena team", captain.ToString().c_str());
             continue;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -250,7 +250,7 @@ void RandomPlayerbotMgr::LogPlayerLocation()
                 out << std::to_string(bot->getRace()) << ",";
                 out << std::to_string(bot->getClass()) << ",";
                 out << bot->GetMapId() << ",";
-                out << bot->getLevel() << ",";
+                out << bot->GetLevel() << ",";
                 out << bot->GetHealth() << ",";
                 out << bot->GetPowerPct(bot->getPowerType()) << ",";
                 out << bot->GetMoney() << ",";
@@ -293,7 +293,7 @@ void RandomPlayerbotMgr::LogPlayerLocation()
                 out << std::to_string(bot->getRace()) << ",";
                 out << std::to_string(bot->getClass()) << ",";
                 out << bot->GetMapId() << ",";
-                out << bot->getLevel() << ",";
+                out << bot->GetLevel() << ",";
                 out << bot->GetHealth() << ",";
                 out << bot->GetPowerPct(bot->getPowerType()) << ",";
                 out << bot->GetMoney() << ",";
@@ -653,7 +653,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
             BattlegroundTypeId bgTypeId = sBattlegroundMgr->BGTemplateId(queueTypeId);
             Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
             uint32 mapId = bg->GetMapId();
-            PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, player->getLevel());
+            PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, player->GetLevel());
             if (!pvpDiff)
                 continue;
 
@@ -743,7 +743,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
             BattlegroundTypeId bgTypeId = sBattlegroundMgr->BGTemplateId(queueTypeId);
             Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
             uint32 mapId = bg->GetMapId();
-            PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->getLevel());
+            PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
             if (!pvpDiff)
                 continue;
 
@@ -893,8 +893,8 @@ void RandomPlayerbotMgr::CheckPlayers()
         //if (player->GetSession()->GetSecurity() > SEC_PLAYER)
         //    continue;
 
-        if (player->getLevel() > playersLevel)
-            playersLevel = player->getLevel() + 3;
+        if (player->GetLevel() > playersLevel)
+            playersLevel = player->GetLevel() + 3;
     }
 
     LOG_INFO("playerbots", "Max player level is {}, max bot level set to {}", playersLevel - 3, playersLevel);
@@ -935,7 +935,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
 		if (!player || !player->GetGroup())
 		{
             if (player)
-                LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H", player->getLevel(), player->GetName().c_str());
+                LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H", player->GetLevel(), player->GetName().c_str());
             else
                 LOG_INFO("playerbots", "Bot #{}: log out", bot);
 
@@ -1016,7 +1016,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
     uint32 logout = GetEventValue(bot, "logout");
     if (player && !logout && !isValid)
     {
-        LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H", player->getLevel(), player->GetName().c_str());
+        LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H", player->GetLevel(), player->GetName().c_str());
         LogoutPlayerBot(botGUID);
         currentBots.remove(bot);
         SetEventValue(bot, "logout", 1, urand(sPlayerbotAIConfig->minRandomBotInWorldTime, sPlayerbotAIConfig->maxRandomBotInWorldTime));
@@ -1089,7 +1089,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* player)
     if (!randomize)
     {
         Randomize(player);
-        LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: randomized", bot, player->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", player->getLevel(), player->GetName());
+        LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: randomized", bot, player->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", player->GetLevel(), player->GetName());
         uint32 randomTime = urand(sPlayerbotAIConfig->minRandomBotRandomizeTime, sPlayerbotAIConfig->maxRandomBotRandomizeTime);
         ScheduleRandomize(bot, randomTime);
         return true;
@@ -1145,7 +1145,7 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
     if (bot->InBattlegroundQueue())
         return;
 
-    // if (bot->getLevel() < 5)
+    // if (bot->GetLevel() < 5)
     //     return;
 
     // if (sPlayerbotAIConfig->randomBotRpgChance < 0)
@@ -1423,7 +1423,7 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
     if (bot->InBattleground())
         return;
 
-    uint32 level = bot->getLevel();
+    uint32 level = bot->GetLevel();
     uint8 race = bot->getRace();
     LOG_DEBUG("playerbots", "Random teleporting bot {} for level {} ({} locations available)", bot->GetName().c_str(), bot->GetLevel(), locsPerLevelCache[level].size());
     if (level > 10 && urand(0, 100) < sPlayerbotAIConfig->probTeleToBankers * 100) {
@@ -1438,7 +1438,7 @@ void RandomPlayerbotMgr::RandomTeleportGrindForLevel(Player* bot)
     if (bot->InBattleground())
         return;
 
-    uint32 level = bot->getLevel();
+    uint32 level = bot->GetLevel();
     uint8 race = bot->getRace();
     LOG_DEBUG("playerbots", "Random teleporting bot {} for level {} ({} locations available)", bot->GetName().c_str(), bot->GetLevel(), locsPerLevelCache[level].size());
 
@@ -1489,11 +1489,11 @@ void RandomPlayerbotMgr::Randomize(Player* bot)
     if (bot->InBattleground())
         return;
 
-    if (bot->getLevel() < 3 || (bot->getLevel() < 56 && bot->getClass() == CLASS_DEATH_KNIGHT)) {
+    if (bot->GetLevel() < 3 || (bot->GetLevel() < 56 && bot->getClass() == CLASS_DEATH_KNIGHT)) {
         RandomizeFirst(bot);
     }
-    else if (bot->getLevel() < sPlayerbotAIConfig->randomBotMaxLevel || !sPlayerbotAIConfig->downgradeMaxLevelBot) {
-        uint8 level = bot->getLevel();
+    else if (bot->GetLevel() < sPlayerbotAIConfig->randomBotMaxLevel || !sPlayerbotAIConfig->downgradeMaxLevelBot) {
+        uint8 level = bot->GetLevel();
         PlayerbotFactory factory(bot, level);
         factory.Randomize(true);
         // IncreaseLevel(bot);
@@ -1512,7 +1512,7 @@ void RandomPlayerbotMgr::IncreaseLevel(Player* bot)
 
 	PerformanceMonitorOperation* pmo = sPerformanceMonitor->start(PERF_MON_RNDBOT, "IncreaseLevel");
 	uint32 lastLevel = GetValue(bot, "level");
-	uint8 level = bot->getLevel() + 1;
+	uint8 level = bot->GetLevel() + 1;
     if (level > maxLevel) {
         level = maxLevel;
     }
@@ -1690,7 +1690,7 @@ void RandomPlayerbotMgr::Refresh(Player* bot)
 	bot->SetFullHealth();
 	bot->SetPvP(true);
 
-    PlayerbotFactory factory(bot, bot->getLevel(), ITEM_QUALITY_RARE);
+    PlayerbotFactory factory(bot, bot->GetLevel(), ITEM_QUALITY_RARE);
     factory.Refresh();
 
     if (bot->GetMaxPower(POWER_MANA) > 0)
@@ -1700,7 +1700,7 @@ void RandomPlayerbotMgr::Refresh(Player* bot)
         bot->SetPower(POWER_ENERGY, bot->GetMaxPower(POWER_ENERGY));
 
     uint32 money = bot->GetMoney();
-    bot->SetMoney(money + 500 * sqrt(urand(1, bot->getLevel() * 5)));
+    bot->SetMoney(money + 500 * sqrt(urand(1, bot->GetLevel() * 5)));
 
     if (bot->GetGroup())
         bot->RemoveFromGroup();
@@ -2216,9 +2216,9 @@ void RandomPlayerbotMgr::PrintStats()
     {
         Player* bot = i->second;
         if (IsAlliance(bot->getRace()))
-            ++alliance[bot->getLevel() / 10];
+            ++alliance[bot->GetLevel() / 10];
         else
-            ++horde[bot->getLevel() / 10];
+            ++horde[bot->GetLevel() / 10];
 
         ++perRace[bot->getRace()];
         ++perClass[bot->getClass()];

--- a/src/TravelMgr.cpp
+++ b/src/TravelMgr.cpp
@@ -1063,7 +1063,7 @@ bool QuestRelationTravelDestination::isActive(Player* bot)
 {
     if (relation == 0)
     {
-        if (questTemplate->GetQuestLevel() >= bot->getLevel() + 5)
+        if (questTemplate->GetQuestLevel() >= bot->GetLevel() + 5)
             return false;
 
         //if (questTemplate->XPValue(bot) == 0)
@@ -1135,19 +1135,19 @@ std::string const QuestRelationTravelDestination::getTitle()
 
 bool QuestObjectiveTravelDestination::isActive(Player* bot)
 {
-    if (questTemplate->GetQuestLevel() > bot->getLevel() + 1)
+    if (questTemplate->GetQuestLevel() > bot->GetLevel() + 1)
         return false;
 
     PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
     AiObjectContext* context = botAI->GetAiObjectContext();
-    if (questTemplate->GetQuestLevel() + 5 > bot->getLevel() && !AI_VALUE(bool, "can fight equal"))
+    if (questTemplate->GetQuestLevel() + 5 > bot->GetLevel() && !AI_VALUE(bool, "can fight equal"))
         return false;
 
     //Check mob level
     if (getEntry() > 0)
     {
         CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(getEntry());
-        if (cInfo && (int)cInfo->maxlevel - (int)bot->getLevel() > 4)
+        if (cInfo && (int)cInfo->maxlevel - (int)bot->GetLevel() > 4)
             return false;
 
          // Do not try to hand-in dungeon/elite quests in instances without a group.
@@ -1258,7 +1258,7 @@ bool ExploreTravelDestination::isActive(Player* bot)
 {
     AreaTableEntry const* area = sAreaTableStore.LookupEntry(areaId);
 
-    if (area->area_level && (uint32)area->area_level > bot->getLevel() && bot->getLevel() < DEFAULT_MAX_LEVEL)
+    if (area->area_level && (uint32)area->area_level > bot->GetLevel() && bot->GetLevel() < DEFAULT_MAX_LEVEL)
         return false;
 
     if (area->exploreFlag == 0xffff)
@@ -1290,7 +1290,7 @@ bool GrindTravelDestination::isActive(Player* bot)
 
     CreatureTemplate const* cInfo = GetCreatureTemplate();
 
-    int32 botLevel = bot->getLevel();
+    int32 botLevel = bot->GetLevel();
 
     uint8 botPowerLevel = AI_VALUE(uint8, "durability");
     float levelMod = botPowerLevel / 500.0f; //(0-0.2f)
@@ -1345,7 +1345,7 @@ bool BossTravelDestination::isActive(Player* bot)
     CreatureTemplate const* cInfo = getCreatureTemplate();
 
     /*
-    int32 botLevel = bot->getLevel();
+    int32 botLevel = bot->GetLevel();
 
     uint8 botPowerLevel = AI_VALUE(uint8, "durability");
     float levelMod = botPowerLevel / 500.0f; //(0-0.2f)
@@ -1362,7 +1362,7 @@ bool BossTravelDestination::isActive(Player* bot)
         return false;
     */
 
-    if ((int32)cInfo->maxlevel > bot->getLevel() + 3)
+    if ((int32)cInfo->maxlevel > bot->GetLevel() + 3)
         return false;
 
     FactionTemplateEntry const* factionEntry = sFactionTemplateStore.LookupEntry(cInfo->faction);
@@ -3842,7 +3842,7 @@ uint32 TravelMgr::getDialogStatus(Player* pPlayer, int32 questgiver, Quest const
                     {
                         dialogStatusNew = DIALOG_STATUS_REWARD_REP;
                     }
-                    else if (lowLevelDiff < 0 || pPlayer->getLevel() <= pPlayer->GetQuestLevel(pQuest) + uint32(lowLevelDiff))
+                    else if (lowLevelDiff < 0 || pPlayer->GetLevel() <= pPlayer->GetQuestLevel(pQuest) + uint32(lowLevelDiff))
                     {
                         dialogStatusNew = DIALOG_STATUS_AVAILABLE;
                     }

--- a/src/TravelNode.cpp
+++ b/src/TravelNode.cpp
@@ -126,7 +126,7 @@ float TravelNodePath::getCost(Player* bot, uint32 cGold)
         if (bot->HasSpell(1066))
             swimSpeed *= 1.5;
 
-        uint32 level = bot->getLevel();
+        uint32 level = bot->GetLevel();
         bool isAlliance = Unit::GetFactionReactionTo(bot->GetFactionTemplateEntry(), sFactionTemplateStore.LookupEntry(1)) > REP_NEUTRAL;
 
         int factionAnnoyance = 0;

--- a/src/cs_playerbots.cpp
+++ b/src/cs_playerbots.cpp
@@ -20,24 +20,26 @@
 #include "RandomPlayerbotMgr.h"
 #include "ScriptMgr.h"
 
+using namespace Acore::ChatCommands;
+
 class playerbots_commandscript : public CommandScript
 {
 public:
     playerbots_commandscript() : CommandScript("playerbots_commandscript") { }
 
-    std::vector<ChatCommand> GetCommands() const override
+    ChatCommandTable GetCommands() const override
     {
-        static std::vector<ChatCommand> playerbotsCommandTable =
+        static ChatCommandTable playerbotsCommandTable =
         {
-            { "bot",            SEC_PLAYER,         false,  &HandlePlayerbotCommand,           nullptr },
-            { "gtask",          SEC_GAMEMASTER,     true,   &HandleGuildTaskCommand,           nullptr },
-            { "pmon",           SEC_GAMEMASTER,     true,   &HandlePerfMonCommand,             nullptr },
-            { "rndbot",         SEC_GAMEMASTER,     true,   &HandleRandomPlayerbotCommand,     nullptr }
+            { "bot",            HandlePlayerbotCommand,       SEC_PLAYER,         Console::No },
+            { "gtask",          HandleGuildTaskCommand,       SEC_GAMEMASTER,     Console::Yes },
+            { "pmon",           HandlePerfMonCommand,         SEC_GAMEMASTER,     Console::Yes },
+            { "rndbot",         HandleRandomPlayerbotCommand, SEC_GAMEMASTER,     Console::Yes }
         };
 
-        static std::vector<ChatCommand> commandTable =
+        static ChatCommandTable commandTable =
         {
-            { "playerbots",     SEC_PLAYER,         true,   nullptr, "",  playerbotsCommandTable },
+            { "playerbots",     playerbotsCommandTable },
         };
 
         return commandTable;

--- a/src/strategy/actions/AutoLearnSpellAction.cpp
+++ b/src/strategy/actions/AutoLearnSpellAction.cpp
@@ -121,7 +121,7 @@ void AutoLearnSpellAction::LearnQuestSpells(std::ostringstream* out)
         if (!quest->GetRequiredClasses() || quest->IsRepeatable() || quest->GetMinLevel() < 10)
             continue;
 
-        if (!bot->SatisfyQuestClass(quest, false) || quest->GetMinLevel() > bot->getLevel() || !bot->SatisfyQuestRace(quest, false))
+        if (!bot->SatisfyQuestClass(quest, false) || quest->GetMinLevel() > bot->GetLevel() || !bot->SatisfyQuestRace(quest, false))
             continue;
 
         if (quest->GetRewSpellCast() > 0)

--- a/src/strategy/actions/BattleGroundJoinAction.cpp
+++ b/src/strategy/actions/BattleGroundJoinAction.cpp
@@ -32,7 +32,7 @@ bool BGJoinAction::Execute(Event event)
             return false;
 
         uint32 mapId = bg->GetMapId();
-        PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->getLevel());
+        PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
         if (!pvpDiff)
             return false;
 
@@ -169,7 +169,7 @@ bool BGJoinAction::gatherArenaTeam(ArenaType type)
         if (!member)
             continue;
 
-        if (member->getLevel() < 70)
+        if (member->GetLevel() < 70)
             continue;
 
         if (!group->AddMember(member))
@@ -218,7 +218,7 @@ bool BGJoinAction::canJoinBg(BattlegroundQueueTypeId queueTypeId, BattlegroundBr
     // check bracket
     Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
     uint32 mapId = bg->GetMapId();
-    PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->getLevel());
+    PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
     if (!pvpDiff)
         return false;
 
@@ -371,7 +371,7 @@ bool BGJoinAction::isUseful()
         return false;
 
     // check level
-    if (bot->getLevel() < 10)
+    if (bot->GetLevel() < 10)
         return false;
 
     // do not try if with player master or in combat/group
@@ -438,7 +438,7 @@ bool BGJoinAction::JoinQueue(uint32 type)
         return false;
 
     uint32 mapId = bg->GetMapId();
-    PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->getLevel());
+    PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
     if (!pvpDiff)
         return false;
 
@@ -548,7 +548,7 @@ bool BGJoinAction::JoinQueue(uint32 type)
     }
 
     LOG_INFO("playerbots", "Bot {} {}:{} <{}> queued {} {}",
-        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), _bgType.c_str(),
+        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), _bgType.c_str(),
         isRated ? "Rated Arena" : isArena ? "Arena" : "");
 
 
@@ -722,7 +722,7 @@ bool BGLeaveAction::Execute(Event event)
     if (bot->InBattleground())
     {
         LOG_INFO("playerbots", "Bot {} {}:{} <{}> leaves {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG");
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG");
 
         WorldPacket leave(CMSG_LEAVE_BATTLEFIELD);
         leave << uint8(0) << uint8(0) << uint32(0) << uint16(0);
@@ -744,7 +744,7 @@ bool BGLeaveAction::Execute(Event event)
         return false;
 
     LOG_INFO("playerbots", "Bot {} {}:{} <{}> leaves {} queue",
-        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), isArena ? "Arena" : "BG");
+        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), isArena ? "Arena" : "BG");
 
     WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
     packet << type << unk2 << (uint32)_bgTypeId << unk << uint8(0);
@@ -828,7 +828,7 @@ bool BGStatusAction::Execute(Event event)
     BattlegroundBracketId bracketId;
     Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(_bgTypeId);
     mapId = bg->GetMapId();
-    PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->getLevel());
+    PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
     if (pvpDiff)
         bracketId = pvpDiff->GetBracketId();
 
@@ -892,7 +892,7 @@ bool BGStatusAction::Execute(Event event)
     if (Time1 == TIME_TO_AUTOREMOVE) //Battleground is over, bot needs to leave
     {
         LOG_INFO("playerbots", "Bot {} <{}> ({} {}): Received BG status TIME_REMOVE for {} {}",
-            bot->GetGUID().ToString().c_str(), bot->GetName(), bot->getLevel(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", isArena ? "Arena" : "BG", _bgType);
+            bot->GetGUID().ToString().c_str(), bot->GetName(), bot->GetLevel(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", isArena ? "Arena" : "BG", _bgType);
 
         if (Battleground* bg = bot->GetBattleground())
         {
@@ -924,7 +924,7 @@ bool BGStatusAction::Execute(Event event)
         botAI->ChangeStrategy("-arena", BOT_STATE_NON_COMBAT);
 
         LOG_INFO("playerbots", "Bot {} {}:{} <{}> leaves {} - {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
 
         WorldPacket packet(CMSG_LEAVE_BATTLEFIELD);
         packet << uint8(0);
@@ -947,7 +947,7 @@ bool BGStatusAction::Execute(Event event)
     if (statusid == STATUS_WAIT_QUEUE) // bot is in queue
     {
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Received BG status WAIT_QUEUE (wait time: {}) for {} {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), Time2, isArena ? "Arena" : "BG", _bgType);
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), Time2, isArena ? "Arena" : "BG", _bgType);
         // temp fix for crash
         //return true;
 
@@ -967,7 +967,7 @@ bool BGStatusAction::Execute(Event event)
                     }
 
                     LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Force join {} {}",
-                        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+                        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
                     WorldPacket emptyPacket;
                     bot->GetSession()->HandleCancelMountAuraOpcode(emptyPacket);
                     action = 0x1;
@@ -1017,7 +1017,7 @@ bool BGStatusAction::Execute(Event event)
                 return false;
 
             LOG_INFO("playerbots", "Bot {} {}:{} <{}> waited too long and leaves queue ({} {}).",
-                bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+                bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
 
             WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
             action = 0;
@@ -1037,14 +1037,14 @@ bool BGStatusAction::Execute(Event event)
     if (statusid == STATUS_IN_PROGRESS) // placeholder for Leave BG if it takes too long
     {
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Received BG status IN_PROGRESS for {} {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
         return false;
     }
 
     if (statusid == STATUS_WAIT_JOIN) //bot may join
     {
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Received BG status WAIT_JOIN for {} {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
 
         if (isArena)
         {
@@ -1055,7 +1055,7 @@ bool BGStatusAction::Execute(Event event)
             if (!bgQueue.GetPlayerGroupInfoData(bot->GetGUID(), &ginfo))
             {
                 LOG_ERROR("playerbots", "Bot {} {}:{} <{}>: Missing QueueInfo for {} {}",
-                    bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+                    bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
                 return false;
             }
 
@@ -1066,7 +1066,7 @@ bool BGStatusAction::Execute(Event event)
                 if (!bg)
                 {
                     LOG_ERROR("playerbots", "Bot {} {}:{} <{}>: Missing QueueInfo for {} {}",
-                        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+                        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
                     return false;
                 }
 
@@ -1075,7 +1075,7 @@ bool BGStatusAction::Execute(Event event)
         }
 
         LOG_INFO("playerbots", "Bot {} {}:{} <{}> joined {} - {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), isArena ? "Arena" : "BG", _bgType);
 
         WorldPacket emptyPacket;
         bot->GetSession()->HandleCancelMountAuraOpcode(emptyPacket);
@@ -1118,7 +1118,7 @@ bool BGStatusCheckAction::Execute(Event event)
     bot->GetSession()->HandleBattlefieldStatusOpcode(packet);
 
     LOG_INFO("playerbots", "Bot {} <{}> ({} {}) : Checking BG invite status",
-        bot->GetGUID().ToString().c_str(), bot->GetName(), bot->getLevel(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H");
+        bot->GetGUID().ToString().c_str(), bot->GetName(), bot->GetLevel(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H");
 
     return true;
 }

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -3545,7 +3545,7 @@ bool BGTactics::selectObjective(bool reset)
                         {
                             // Capture front objectives before attacking back objectives
                             // LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Get Front Objectives",
-                            // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName());
+                            // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
                             if (role < 6)
                             {
                                 BgObjective = bg->GetBGObject(attackObjectivesFront[0]);
@@ -3559,7 +3559,7 @@ bool BGTactics::selectObjective(bool reset)
                         {
                             // Now capture all objectives with priority on back
                             // LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Get All Objectives",
-                            // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName());
+                            // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
                             if (role < 4)
                             {
                                 BgObjective = bg->GetBGObject(attackObjectivesFront[0]);
@@ -3632,7 +3632,7 @@ bool BGTactics::selectObjective(bool reset)
                 {
                     //Retreat with flag
                     //LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Retreat with flag",
-                    //bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName());
+                    //bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
                     if (rootTeam == TEAM_HORDE)
                     {
                         areaTrigger = 0;
@@ -3648,7 +3648,7 @@ bool BGTactics::selectObjective(bool reset)
                 {
                     //Deliver flag
                     //LOG_INFO("playerbots", "Bot {} {}:{} <{}>: Deliver flag",
-                    //bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName());
+                    //bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
                     if (eyeOfTheStormBG->GetCapturePointInfo(EY_AttackObjectives[0])._ownerTeamId == rootTeamIndex)
                     {
                         areaTrigger = AT_FEL_REAVER_POINT;

--- a/src/strategy/actions/ChangeTalentsAction.cpp
+++ b/src/strategy/actions/ChangeTalentsAction.cpp
@@ -155,7 +155,7 @@ std::string ChangeTalentsAction::SpecApply(std::string param)
 //     // for (auto& path : sPlayerbotAIConfig->classSpecs[bot->getClass()].talentPath)
 //     // {
 //     //     TalentSpec newSpec = *GetBestPremadeSpec(path.id);
-//     //     newSpec.CropTalents(bot->getLevel());
+//     //     newSpec.CropTalents(bot->GetLevel());
 //     //     if (oldSpec->isEarlierVersionOf(newSpec))
 //     //     {
 //     //         ret.push_back(&path);
@@ -225,7 +225,7 @@ std::string ChangeTalentsAction::SpecApply(std::string param)
 // bool ChangeTalentsAction::AutoSelectTalents(std::ostringstream* out)
 // {
 //     // Does the bot have talentpoints?
-//     if (bot->getLevel() < 10)
+//     if (bot->GetLevel() < 10)
 //     {
 //         *out << "No free talent points.";
 //         return false;
@@ -239,7 +239,7 @@ std::string ChangeTalentsAction::SpecApply(std::string param)
 //     if (specNo > 0)
 //     {
 //         TalentSpec newSpec = *GetBestPremadeSpec(specId);
-//         newSpec.CropTalents(bot->getLevel());
+//         newSpec.CropTalents(bot->GetLevel());
 //         newSpec.ApplyTalents(bot, out);
 //         if (newSpec.GetTalentPoints() > 0)
 //         {
@@ -249,7 +249,7 @@ std::string ChangeTalentsAction::SpecApply(std::string param)
 //     else if (!specLink.empty())
 //     {
 //         TalentSpec newSpec(bot, specLink);
-//         newSpec.CropTalents(bot->getLevel());
+//         newSpec.CropTalents(bot->GetLevel());
 //         newSpec.ApplyTalents(bot, out);
 //         if (newSpec.GetTalentPoints() > 0)
 //         {
@@ -288,7 +288,7 @@ std::string ChangeTalentsAction::SpecApply(std::string param)
 //             specId = PickPremadePath(paths, sRandomPlayerbotMgr->IsRandomBot(bot))->id;
 //             TalentSpec newSpec = *GetBestPremadeSpec(specId);
 //             specLink = newSpec.GetTalentLink();
-//             newSpec.CropTalents(bot->getLevel());
+//             newSpec.CropTalents(bot->GetLevel());
 //             newSpec.ApplyTalents(bot, out);
 
 //             if (paths.size() > 1)

--- a/src/strategy/actions/CheckMountStateAction.cpp
+++ b/src/strategy/actions/CheckMountStateAction.cpp
@@ -132,7 +132,7 @@ bool CheckMountStateAction::isUseful()
     if (!GET_PLAYERBOT_AI(bot)->HasStrategy("mount", BOT_STATE_NON_COMBAT) && !bot->IsMounted())
         return false;
 
-    bool firstmount = bot->getLevel() >= 20;
+    bool firstmount = bot->GetLevel() >= 20;
     if (!firstmount)
         return false;
 
@@ -197,7 +197,7 @@ bool CheckMountStateAction::Mount()
         }
     }
 
-    if (bot->GetPureSkillValue(SKILL_RIDING) <= 75 && bot->getLevel() < secondmount)
+    if (bot->GetPureSkillValue(SKILL_RIDING) <= 75 && bot->GetLevel() < secondmount)
         masterSpeed = 59;
 
     if (bot->InBattleground() && masterSpeed > 99)

--- a/src/strategy/actions/ChooseTravelTargetAction.cpp
+++ b/src/strategy/actions/ChooseTravelTargetAction.cpp
@@ -789,7 +789,7 @@ bool ChooseTravelTargetAction::needForQuest(Unit* target)
         {
             QuestStatusData questStatus = quest.second;
 
-            if (questTemplate->GetQuestLevel() > bot->getLevel())
+            if (questTemplate->GetQuestLevel() > bot->GetLevel())
                 continue;
 
             for (int j = 0; j < QUEST_OBJECTIVES_COUNT; j++)

--- a/src/strategy/actions/DropQuestAction.cpp
+++ b/src/strategy/actions/DropQuestAction.cpp
@@ -111,9 +111,9 @@ void CleanQuestLogAction::DropQuestType(uint8& numQuest, uint8 wantNum, bool isG
             numQuest++;
 
         int32 lowLevelDiff = sWorld->getIntConfig(CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF);
-        if (lowLevelDiff < 0 || bot->getLevel() <= bot->GetQuestLevel(quest) + uint32(lowLevelDiff)) // Quest is not gray
+        if (lowLevelDiff < 0 || bot->GetLevel() <= bot->GetQuestLevel(quest) + uint32(lowLevelDiff)) // Quest is not gray
         {
-            if (bot->getLevel() + 5 > bot->GetQuestLevel(quest)) // Quest is not red
+            if (bot->GetLevel() + 5 > bot->GetQuestLevel(quest)) // Quest is not red
                 if (!isGreen)
                     continue;
         }

--- a/src/strategy/actions/EmoteAction.cpp
+++ b/src/strategy/actions/EmoteAction.cpp
@@ -672,7 +672,7 @@ bool EmoteAction::Execute(Event event)
             (namlen > 1 && strstri(bot->GetName().c_str(), nam.c_str()))))
         {
             LOG_INFO("playerbots", "Bot {} {}:{} <{}> received SMSG_TEXT_EMOTE {} from player {} <{}>",
-                bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(),
+                bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(),
                 bot->GetName(), text_emote, pSource->GetGUID().ToString().c_str(), pSource->GetName());
 
             emote = text_emote;
@@ -694,7 +694,7 @@ bool EmoteAction::Execute(Event event)
                 (urand(0, 1) && bot->HasInArc(static_cast<float>(M_PI), pSource, 10.0f))))
             {
                 LOG_INFO("playerbots", "Bot {} {}:{} <{}> received SMSG_EMOTE {} from player {} <{}>",
-                    bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(),
+                    bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(),
                     emoteId, pSource->GetGUID().ToString().c_str(), pSource->GetName());
 
                 std::vector<uint32> types;

--- a/src/strategy/actions/HireAction.cpp
+++ b/src/strategy/actions/HireAction.cpp
@@ -31,15 +31,15 @@ bool HireAction::Execute(Event event)
         return false;
     }
 
-    if (bot->getLevel() > master->getLevel())
+    if (bot->GetLevel() > master->GetLevel())
     {
         botAI->TellMaster("You cannot hire higher level characters than you");
         return false;
     }
 
     uint32 discount = sRandomPlayerbotMgr->GetTradeDiscount(bot, master);
-    uint32 m = 1 + (bot->getLevel() / 10);
-    uint32 moneyReq = m * 5000 * bot->getLevel();
+    uint32 m = 1 + (bot->GetLevel() / 10);
+    uint32 moneyReq = m * 5000 * bot->GetLevel();
     if (discount < moneyReq)
     {
         std::ostringstream out;

--- a/src/strategy/actions/InviteToGroupAction.cpp
+++ b/src/strategy/actions/InviteToGroupAction.cpp
@@ -60,7 +60,7 @@ bool InviteNearbyToGroupAction::Execute(Event event)
                 return false;
         }
 
-        if (abs(int32(player->getLevel() - bot->getLevel())) > 2)
+        if (abs(int32(player->GetLevel() - bot->GetLevel())) > 2)
             continue;
 
         if (sServerFacade->GetDistance2d(bot, player) > sPlayerbotAIConfig->sightDistance)
@@ -135,7 +135,7 @@ bool InviteGuildToGroupAction::Execute(Event event)
             if (botAI->HasActivePlayerMaster()) //Do not invite alts of active players.
                 continue;
 
-            if (player->getLevel() > bot->getLevel() + 5) // Only invite higher levels that need money so they can grind money and help out.
+            if (player->GetLevel() > bot->GetLevel() + 5) // Only invite higher levels that need money so they can grind money and help out.
             {
                 AiObjectContext* botContext = botAI->GetAiObjectContext();
 
@@ -149,7 +149,7 @@ bool InviteGuildToGroupAction::Execute(Event event)
                 return false;
         }
 
-        if (abs(int32(player->getLevel() - bot->getLevel())) > 4)
+        if (abs(int32(player->GetLevel() - bot->GetLevel())) > 4)
             continue;
 
         if (!botAI && sServerFacade->GetDistance2d(bot, player) > sPlayerbotAIConfig->sightDistance)

--- a/src/strategy/actions/LeaveGroupAction.cpp
+++ b/src/strategy/actions/LeaveGroupAction.cpp
@@ -144,14 +144,14 @@ bool LeaveFarAwayAction::isUseful()
 
     if (bot->GetGuildId() == master->GetGuildId())
     {
-        if (bot->getLevel() > master->getLevel() + 5)
+        if (bot->GetLevel() > master->GetLevel() + 5)
         {
             if (AI_VALUE(bool, "should get money"))
                 return false;
         }
     }
 
-    if (abs(int32(master->getLevel() - bot->getLevel())) > 4)
+    if (abs(int32(master->GetLevel() - bot->GetLevel())) > 4)
         return true;
 
     if (bot->GetMapId() != master->GetMapId() || bot->GetDistance2d(master) >= 2 * sPlayerbotAIConfig->rpgDistance) {

--- a/src/strategy/actions/LfgActions.cpp
+++ b/src/strategy/actions/LfgActions.cpp
@@ -87,8 +87,8 @@ bool LfgJoinAction::JoinLFG()
     ItemCountByQuality visitor;
     IterateItems(&visitor, ITERATE_ITEMS_IN_EQUIP);
     bool random = urand(0, 100) < 20;
-    bool heroic = urand(0, 100) < 50 && (visitor.count[ITEM_QUALITY_EPIC] >= 3 || visitor.count[ITEM_QUALITY_RARE] >= 10) && bot->getLevel() >= 70;
-    bool rbotAId = !heroic && (urand(0, 100) < 50 && visitor.count[ITEM_QUALITY_EPIC] >= 5 && (bot->getLevel() == 60 || bot->getLevel() == 70 || bot->getLevel() == 80));
+    bool heroic = urand(0, 100) < 50 && (visitor.count[ITEM_QUALITY_EPIC] >= 3 || visitor.count[ITEM_QUALITY_RARE] >= 10) && bot->GetLevel() >= 70;
+    bool rbotAId = !heroic && (urand(0, 100) < 50 && visitor.count[ITEM_QUALITY_EPIC] >= 5 && (bot->GetLevel() == 60 || bot->GetLevel() == 70 || bot->GetLevel() == 80));
 
     LfgDungeonSet list;
     std::vector<uint32> selected;
@@ -103,7 +103,7 @@ bool LfgJoinAction::JoinLFG()
         if (!dungeon || (dungeon->TypeID != LFG_TYPE_RANDOM && dungeon->TypeID != LFG_TYPE_DUNGEON && dungeon->TypeID != LFG_TYPE_HEROIC && dungeon->TypeID != LFG_TYPE_RAID))
             continue;
 
-        uint32 botLevel = bot->getLevel();
+        uint32 botLevel = bot->GetLevel();
         if (dungeon->MinLevel && botLevel < dungeon->MinLevel)
             continue;
 
@@ -133,7 +133,7 @@ bool LfgJoinAction::JoinLFG()
             dungeon->type != LFG_TYPE_RAID))
             continue;
 
-        uint32 botLevel = bot->getLevel();
+        uint32 botLevel = bot->GetLevel();
         if (dungeon->MinLevel && botLevel < dungeon->MinLevel)
             continue;
 
@@ -173,7 +173,7 @@ bool LfgJoinAction::JoinLFG()
 
     LOG_INFO("playerbots", "Bot {} {}:{} <{}>: queues LFG, Dungeon as {} ({})",
         bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H",
-        bot->getLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
+        bot->GetLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
 
     /*if (lfgState->IsSingleRole())
     {
@@ -213,7 +213,7 @@ bool LfgJoinAction::JoinLFG()
 
         pState->SetType(LFG_TYPE_RANDOM_DUNGEON);
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: queues LFG, Random Dungeon as {} ({})",
-        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), _roles, dungeon->Name[0]);
+        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), _roles, dungeon->Name[0]);
         return true;
     }
     else if (heroic)
@@ -221,19 +221,19 @@ bool LfgJoinAction::JoinLFG()
         pState->SetType(LFG_TYPE_HEROIC_DUNGEON);
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: queues LFG, Heroic Dungeon as {} ({})",
         bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H",
-        bot->getLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
+        bot->GetLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
     }
     else if (rbotAId)
     {
         pState->SetType(LFG_TYPE_RAID);
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: queues LFG, RbotAId as {} ({})",
-        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
+        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
     }
     else
     {
         pState->SetType(LFG_TYPE_DUNGEON);
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: queues LFG, Dungeon as {} ({})",
-        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
+        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), _roles, many ? "several dungeons" : dungeon->Name[0]);
     }*/
 
     // Set RbotAId Browser comment
@@ -258,7 +258,7 @@ bool LfgRoleCheckAction::Execute(Event event)
         sLFGMgr->UpdateRoleCheck(group->GetGUID(), bot->GetGUID(), newRoles);
 
         LOG_INFO("playerbots", "Bot {} {}:{} <{}>: LFG roles checked",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
         return true;
     }
@@ -281,13 +281,13 @@ bool LfgAcceptAction::Execute(Event event)
         if (bot->IsInCombat() || bot->isDead())
         {
             LOG_INFO("playerbots", "Bot {} {}:{} <{}> is in combat and refuses LFG proposal {}",
-                bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), id);
+                bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), id);
             sLFGMgr->UpdateProposal(id, bot->GetGUID(), false);
             return true;
         }
 
         LOG_INFO("playerbots", "Bot {} {}:{} <{}> accepts LFG proposal {}",
-            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str(), id);
+            bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str(), id);
 
         botAI->GetAiObjectContext()->GetValue<uint32>("lfg proposal")->Set(0);
 
@@ -363,7 +363,7 @@ bool LfgJoinAction::isUseful()
         return false;
     }
 
-    if (bot->getLevel() < 15)
+    if (bot->GetLevel() < 15)
         return false;
 
     if ((botAI->GetMaster() && !GET_PLAYERBOT_AI(botAI->GetMaster())) || bot->GetGroup() && bot->GetGroup()->GetLeaderGUID() != bot->GetGUID())

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -402,7 +402,7 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
 
     //             out << std::to_string(bot->getRace()) << ",";
     //             out << std::to_string(bot->getClass()) << ",";
-    //             out << bot->getLevel() << ",";
+    //             out << bot->GetLevel() << ",";
     //             out << (entry ? -1 : entry);
 
     //             sPlayerbotAIConfig->log("bot_movement.csv", out.str().c_str());
@@ -559,7 +559,7 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
     //     startPosition.printWKT({ startPosition, movePosition }, out, 1);
     //     out << std::to_string(bot->getRace()) << ",";
     //     out << std::to_string(bot->getClass()) << ",";
-    //     out << bot->getLevel();
+    //     out << bot->GetLevel();
     //     out << 0;
 
     //     sPlayerbotAIConfig->log("bot_movement.csv", out.str().c_str());

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -39,7 +39,7 @@ bool ReleaseSpiritAction::Execute(Event event)
         context->GetValue<uint32>("death count")->Set(dCount + 1);
     }
 
-    LOG_INFO("playerbots", "Bot {} {}:{} <{}> released", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+    LOG_INFO("playerbots", "Bot {} {}:{} <{}> released", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     WorldPacket packet(CMSG_REPOP_REQUEST);
     packet << uint8(0);
@@ -86,13 +86,13 @@ bool AutoReleaseSpiritAction::Execute(Event event)
         context->GetValue<uint32>("death count")->Set(dCount + 1);
     }
 
-    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> auto released", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> auto released", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     WorldPacket packet(CMSG_REPOP_REQUEST);
     packet << uint8(0);
     bot->GetSession()->HandleRepopRequestOpcode(packet);
 
-    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> releases spirit", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> releases spirit", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     if (bot->InBattleground() && (time(NULL) - bg_gossip_time >= 15 || !bot->HasAura(SPELL_WAITING_FOR_RESURRECT)))
     {
@@ -164,7 +164,7 @@ bool AutoReleaseSpiritAction::isUseful()
 
 bool RepopAction::Execute(Event event)
 {
-    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> repops at graveyard", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> repops at graveyard", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     int64 deadTime;
 

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -55,7 +55,7 @@ bool ReviveFromCorpseAction::Execute(Event event)
         }
     }
 
-    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> revives at body", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> revives at body", bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     bot->GetMotionMaster()->Clear();
     bot->StopMoving();
@@ -91,7 +91,7 @@ bool FindCorpseAction::Execute(Event event)
         if (dCount >= 5)
         {
             // LOG_INFO("playerbots", "Bot {} {}:{} <{}>: died too many times, was revived and teleported",
-            //     bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+            //     bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
             context->GetValue<uint32>("death count")->Set(0);
             // sRandomPlayerbotMgr->RandomTeleportForLevel(bot);
             sRandomPlayerbotMgr->Revive(bot);
@@ -301,7 +301,7 @@ bool SpiritHealerAction::Execute(Event event)
             if (unit && unit->HasFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_SPIRITHEALER))
             {
                 LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> revives at spirit healer",
-                    bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName());
+                    bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
                 PlayerbotChatHandler ch(bot);
                 bot->ResurrectPlayer(0.5f);
                 bot->SpawnCorpseBones();
@@ -340,7 +340,7 @@ bool SpiritHealerAction::Execute(Event event)
     }
 
     LOG_INFO("playerbots", "Bot {} {}:{} <{}> can't find a spirit healer",
-        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName().c_str());
+        bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     botAI->TellError("Cannot find any spirit healer nearby");
     return false;

--- a/src/strategy/actions/SuggestWhatToDoAction.cpp
+++ b/src/strategy/actions/SuggestWhatToDoAction.cpp
@@ -88,7 +88,7 @@ void SuggestWhatToDoAction::instance()
     std::vector<std::string> allowedInstances;
     for (auto & instance : instances)
     {
-        if (bot->getLevel() >= instance.second) allowedInstances.push_back(instance.first);
+        if (bot->GetLevel() >= instance.second) allowedInstances.push_back(instance.first);
     }
 
     if (allowedInstances.empty()) return;
@@ -187,7 +187,7 @@ void SuggestWhatToDoAction::grindReputation()
     std::vector<std::string> allowedFactions;
     for (std::map<std::string, uint8>::iterator i = factions.begin(); i != factions.end(); ++i)
     {
-        if (bot->getLevel() >= i->second)
+        if (bot->GetLevel() >= i->second)
             allowedFactions.push_back(i->first);
     }
 

--- a/src/strategy/actions/TrainerAction.cpp
+++ b/src/strategy/actions/TrainerAction.cpp
@@ -168,7 +168,7 @@ bool MaintenanceAction::Execute(Event event)
     factory.InitSkills();
     factory.InitMounts();
     factory.InitGlyphs(true);
-    if (bot->getLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
+    if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
         factory.ApplyEnchantAndGemsNew();
     }
     bot->DurabilityRepairAll(false, 1.0f, false);
@@ -199,7 +199,7 @@ bool AutoGearAction::Execute(Event event)
         gs);
     factory.InitEquipment(true);
     factory.InitAmmo();
-    if (bot->getLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
+    if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel) {
         factory.ApplyEnchantAndGemsNew();
     }
     bot->DurabilityRepairAll(false, 1.0f, false);

--- a/src/strategy/actions/TravelAction.cpp
+++ b/src/strategy/actions/TravelAction.cpp
@@ -63,7 +63,7 @@ bool MoveToDarkPortalAction::Execute(Event event)
         if (bot->GetGroup()->GetLeaderGUID() != bot->GetGUID() && !GET_PLAYERBOT_AI(GET_PLAYERBOT_AI(bot)->GetGroupMaster()))
             return false;
 
-    if (bot->getLevel() > 57)
+    if (bot->GetLevel() > 57)
     {
         if ((bot->GetTeamId() == TEAM_ALLIANCE && bot->GetQuestStatus(10119) == QUEST_STATUS_NONE) || (bot->GetTeamId() == TEAM_HORDE && bot->GetQuestStatus(9407) == QUEST_STATUS_NONE))
         {
@@ -104,12 +104,12 @@ bool MoveToDarkPortalAction::Execute(Event event)
 
 bool MoveToDarkPortalAction::isUseful()
 {
-    return bot->getLevel() > 54;
+    return bot->GetLevel() > 54;
 }
 
 bool DarkPortalAzerothAction::Execute(Event event)
 {
-    if (bot->getLevel() > 57)
+    if (bot->GetLevel() > 57)
     {
         WorldPacket packet(CMSG_AREATRIGGER);
         packet << 4354;
@@ -122,7 +122,7 @@ bool DarkPortalAzerothAction::Execute(Event event)
 
 bool DarkPortalAzerothAction::isUseful()
 {
-    return bot->getLevel() > 57;
+    return bot->GetLevel() > 57;
 }
 
 bool MoveFromDarkPortalAction::Execute(Event event)

--- a/src/strategy/actions/WhoAction.cpp
+++ b/src/strategy/actions/WhoAction.cpp
@@ -108,7 +108,7 @@ std::string const WhoAction::QuerySpec(std::string const text)
     uint8 spec = AiFactory::GetPlayerSpecTab(bot);
 
     out << "|h|cffffffff" << chat->FormatRace(bot->getRace()) << " [" << (bot->getGender() == GENDER_MALE ? "M" : "F") << "] " << chat->FormatClass(bot, spec);
-    out << " (|h|cff00ff00" << (uint32)bot->getLevel() << "|h|cffffffff lvl), ";
+    out << " (|h|cff00ff00" << (uint32)bot->GetLevel() << "|h|cffffffff lvl), ";
     out << "|h|cff00ff00" << botAI->GetEquipGearScore(bot, false, false) << "|h|cffffffff GS (";
 
     ItemCountByQuality visitor;

--- a/src/strategy/actions/WorldBuffAction.cpp
+++ b/src/strategy/actions/WorldBuffAction.cpp
@@ -36,10 +36,10 @@ std::vector<uint32> WorldBuffAction::NeedWorldBuffs(Unit* unit)
         if (wb.classId != 0 && wb.classId != unit->getClass())
             continue;
 
-        if (wb.minLevel != 0 && wb.minLevel > unit->getLevel())
+        if (wb.minLevel != 0 && wb.minLevel > unit->GetLevel())
             continue;
 
-        if (wb.maxLevel != 0 && wb.maxLevel < unit->getLevel())
+        if (wb.maxLevel != 0 && wb.maxLevel < unit->GetLevel())
             continue;
 
         if (unit->HasAura(wb.spellId))

--- a/src/strategy/actions/XpGainAction.cpp
+++ b/src/strategy/actions/XpGainAction.cpp
@@ -54,7 +54,7 @@ void XpGainAction::GiveXP(uint32 xp, Unit* victim)
         return;
     }
 
-    uint32 level = bot->getLevel();
+    uint32 level = bot->GetLevel();
 
     // XP to money conversion processed in Player::RewardQuest
     if (level >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
@@ -80,7 +80,7 @@ void XpGainAction::GiveXP(uint32 xp, Unit* victim)
             bot->GiveLevel(level + 1);
         }
 
-        level = bot->getLevel();
+        level = bot->GetLevel();
         nextLvlXP = bot->GetUInt32Value(PLAYER_NEXT_LEVEL_XP);
     }
 

--- a/src/strategy/druid/DruidShapeshiftActions.cpp
+++ b/src/strategy/druid/DruidShapeshiftActions.cpp
@@ -22,7 +22,7 @@ NextAction** CastDireBearFormAction::getAlternatives()
 
 bool CastTravelFormAction::isUseful()
 {
-    bool firstmount = bot->getLevel() >= 20;
+    bool firstmount = bot->GetLevel() >= 20;
 
     // useful if no mount or with wsg flag
     return !bot->IsMounted() && (!firstmount || (bot->HasAura(23333) || bot->HasAura(23335) || bot->HasAura(34976))) && !botAI->HasAura("dash", bot);

--- a/src/strategy/generic/ConserveManaStrategy.cpp
+++ b/src/strategy/generic/ConserveManaStrategy.cpp
@@ -39,7 +39,7 @@
 //     if (mediumMana && dynamic_cast<CastBuffSpellAction*>(action))
 //         return 0.0f;
 
-//     if (target && ((int)target->getLevel() - (int)bot->getLevel()) >= 0)
+//     if (target && ((int)target->GetLevel() - (int)bot->GetLevel()) >= 0)
 //         return 1.0f;
 
 //     return 1.0f;

--- a/src/strategy/rogue/RogueTriggers.cpp
+++ b/src/strategy/rogue/RogueTriggers.cpp
@@ -59,7 +59,7 @@ bool StealthTrigger::IsActive()
 
 bool SapTrigger::IsPossible()
 {
-    return bot->getLevel() > 10 && bot->HasSpell(6770) && !bot->IsInCombat();
+    return bot->GetLevel() > 10 && bot->HasSpell(6770) && !bot->IsInCombat();
 }
 
 bool SprintTrigger::IsPossible()

--- a/src/strategy/triggers/GenericTriggers.cpp
+++ b/src/strategy/triggers/GenericTriggers.cpp
@@ -108,7 +108,7 @@ bool OutNumberedTrigger::IsActive()
     if (bot->GetGroup() && bot->GetGroup()->isRaidGroup())
         return false;
 
-    int32 botLevel = bot->getLevel();
+    int32 botLevel = bot->GetLevel();
     uint32 friendPower = 200;
     uint32 foePower = 0;
     for (auto& attacker : botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get())
@@ -117,7 +117,7 @@ bool OutNumberedTrigger::IsActive()
         if (!creature)
             continue;
 
-        int32 dLevel = creature->getLevel() - botLevel;
+        int32 dLevel = creature->GetLevel() - botLevel;
         if (dLevel > -10)
             foePower = std::max(100 + 10 * dLevel, dLevel * 200);
     }
@@ -131,7 +131,7 @@ bool OutNumberedTrigger::IsActive()
         if (!player || player == bot)
             continue;
 
-        int32 dLevel = player->getLevel() - botLevel;
+        int32 dLevel = player->GetLevel() - botLevel;
 
         if (dLevel > -10 && bot->GetDistance(player) < 10.0f)
             friendPower += std::max(200 + 20 * dLevel, dLevel * 200);

--- a/src/strategy/triggers/PvpTriggers.cpp
+++ b/src/strategy/triggers/PvpTriggers.cpp
@@ -84,7 +84,7 @@ bool BgInviteActiveTrigger::IsActive()
             if (ginfo.IsInvitedToBGInstanceGUID && ginfo.RemoveInviteTime)
             {
                 LOG_INFO("playerbots", "Bot {} <{}> ({} {}) : Invited to BG but not in BG",
-                    bot->GetGUID().ToString().c_str(), bot->GetName(), bot->getLevel(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H");
+                    bot->GetGUID().ToString().c_str(), bot->GetName(), bot->GetLevel(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H");
                 return true;
             }
         }

--- a/src/strategy/triggers/RpgTriggers.cpp
+++ b/src/strategy/triggers/RpgTriggers.cpp
@@ -425,7 +425,7 @@ bool RpgDuelTrigger::IsActive()
         return false;
 
     // Less spammy duels
-    if (bot->getLevel() < 3)
+    if (bot->GetLevel() < 3)
         return false;
 
     if (botAI->HasRealPlayerMaster())
@@ -450,10 +450,10 @@ bool RpgDuelTrigger::IsActive()
     if (!player)
         return false;
 
-    if (player->getLevel() > bot->getLevel() + 3)
+    if (player->GetLevel() > bot->GetLevel() + 3)
         return false;
 
-    if (bot->getLevel() > player->getLevel() + 10)
+    if (bot->GetLevel() > player->GetLevel() + 10)
         return false;
 
     // caster or target already have requested duel

--- a/src/strategy/triggers/StuckTriggers.cpp
+++ b/src/strategy/triggers/StuckTriggers.cpp
@@ -22,7 +22,7 @@ bool MoveStuckTrigger::IsActive()
     if (posVal->LastChangeDelay() > 5 * MINUTE)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in the same position for {} seconds",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), posVal->LastChangeDelay());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), posVal->LastChangeDelay());
 
         return true;
     }
@@ -45,7 +45,7 @@ bool MoveStuckTrigger::IsActive()
     if (longLog)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in the same position for 10mins",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), posVal->LastChangeDelay());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), posVal->LastChangeDelay());
     }
 
     return longLog;
@@ -68,7 +68,7 @@ bool MoveLongStuckTrigger::IsActive()
     if (grid.x_coord < 0 || grid.x_coord >= MAX_NUMBER_OF_GRIDS)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in grid {},{} on map {}",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), grid.x_coord, grid.y_coord, botPos.getMapId());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), grid.x_coord, grid.y_coord, botPos.getMapId());
 
         return true;
     }
@@ -76,7 +76,7 @@ bool MoveLongStuckTrigger::IsActive()
     if (grid.y_coord < 0 || grid.y_coord >= MAX_NUMBER_OF_GRIDS)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in grid {},{} on map {}",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), grid.x_coord, grid.y_coord, botPos.getMapId());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), grid.x_coord, grid.y_coord, botPos.getMapId());
 
         return true;
     }
@@ -84,7 +84,7 @@ bool MoveLongStuckTrigger::IsActive()
     if (cell.GridX() > 0 && cell.GridY() > 0 && !MMAP::MMapFactory::createOrGetMMapMgr()->loadMap(botPos.getMapId(), cell.GridX(), cell.GridY()))
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in unloaded grid {},{} on map {}",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), grid.x_coord, grid.y_coord, botPos.getMapId());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), grid.x_coord, grid.y_coord, botPos.getMapId());
 
         return true;
     }
@@ -94,7 +94,7 @@ bool MoveLongStuckTrigger::IsActive()
     if (posVal->LastChangeDelay() > 10 * MINUTE)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in the same position for {} seconds",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), posVal->LastChangeDelay());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), posVal->LastChangeDelay());
 
         return true;
     }
@@ -122,7 +122,7 @@ bool MoveLongStuckTrigger::IsActive()
     if (longLog)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in the same position for 15mins",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), posVal->LastChangeDelay());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), posVal->LastChangeDelay());
     }
 
     return longLog;
@@ -146,7 +146,7 @@ bool CombatStuckTrigger::IsActive()
     if (combatVal->LastChangeDelay() > 5 * MINUTE)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in combat for {} seconds",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), posVal->LastChangeDelay());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), posVal->LastChangeDelay());
 
         return true;
     }
@@ -172,7 +172,7 @@ bool CombatLongStuckTrigger::IsActive()
     if (combatVal->LastChangeDelay() > 15 * MINUTE)
     {
         // LOG_INFO("playerbots", "Bot {} {}:{} <{}> was in combat for {} seconds",
-        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->getLevel(), bot->GetName(), posVal->LastChangeDelay());
+        // bot->GetGUID().ToString().c_str(), bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(), posVal->LastChangeDelay());
 
         return true;
     }

--- a/src/strategy/values/AttackerCountValues.cpp
+++ b/src/strategy/values/AttackerCountValues.cpp
@@ -62,7 +62,7 @@ uint8 BalancePercentValue::Calculate()
             if (!player || !player->IsAlive())
                 continue;
 
-            playerLevel += player->getLevel();
+            playerLevel += player->GetLevel();
         }
     }
 
@@ -73,7 +73,7 @@ uint8 BalancePercentValue::Calculate()
         if (!creature || !creature->IsAlive())
             continue;
 
-        uint32 level = creature->getLevel();
+        uint32 level = creature->GetLevel();
 
         switch (creature->GetCreatureTemplate()->rank)
         {

--- a/src/strategy/values/BudgetValues.cpp
+++ b/src/strategy/values/BudgetValues.cpp
@@ -143,7 +143,7 @@ uint32 MoneyNeededForValue::Calculate()
 
 	uint32 moneyWanted = 0;
 
-	uint32 level = bot->getLevel();
+	uint32 level = bot->GetLevel();
 
     switch (needMoneyFor)
     {

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -78,7 +78,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
 		//if (!bot->InBattleground() && master && master->GetDistance(unit) >= sPlayerbotAIConfig->grindDistance && !sRandomPlayerbotMgr->IsRandomBot(bot))
             //continue;
 
-		if (!bot->InBattleground() && (int)unit->getLevel() - (int)bot->getLevel() > 4 && !unit->GetGUID().IsPlayer())
+		if (!bot->InBattleground() && (int)unit->GetLevel() - (int)bot->GetLevel() > 4 && !unit->GetGUID().IsPlayer())
 		    continue;
 
         // if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
@@ -160,7 +160,7 @@ bool GrindTargetValue::needForQuest(Unit* target)
         {
             QuestStatusData* questStatus = sTravelMgr->getQuestStatus(bot, questId);
 
-            if (questTemplate->GetQuestLevel() > bot->getLevel())
+            if (questTemplate->GetQuestLevel() > bot->GetLevel())
                 continue;
 
             for (int j = 0; j < QUEST_OBJECTIVES_COUNT; j++)

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -190,7 +190,7 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto)
 
     if (itemProto->Class == ITEM_CLASS_WEAPON && !sRandomItemMgr->CanEquipWeapon(bot->getClass(), itemProto))
         shouldEquip = false;
-    if (itemProto->Class == ITEM_CLASS_ARMOR && !sRandomItemMgr->CanEquipArmor(bot->getClass(), bot->getLevel(), itemProto))
+    if (itemProto->Class == ITEM_CLASS_ARMOR && !sRandomItemMgr->CanEquipArmor(bot->getClass(), bot->GetLevel(), itemProto))
         shouldEquip = false;
 
     Item* oldItem = bot->GetItemByPos(dest);
@@ -228,7 +228,7 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto)
     if (oldItemProto->Class == ITEM_CLASS_WEAPON && !sRandomItemMgr->CanEquipWeapon(bot->getClass(), oldItemProto))
         existingShouldEquip = false;
 
-    if (oldItemProto->Class == ITEM_CLASS_ARMOR && !sRandomItemMgr->CanEquipArmor(bot->getClass(), bot->getLevel(), oldItemProto))
+    if (oldItemProto->Class == ITEM_CLASS_ARMOR && !sRandomItemMgr->CanEquipArmor(bot->getClass(), bot->GetLevel(), oldItemProto))
         existingShouldEquip = false;
 
     // uint32 oldItemPower = sRandomItemMgr->GetLiveStatWeight(bot, oldItemProto->ItemId);

--- a/src/strategy/values/PvpValues.cpp
+++ b/src/strategy/values/PvpValues.cpp
@@ -177,7 +177,7 @@ BattlegroundTypeId RpgBgTypeValue::Calculate()
             if (!bg)
                 continue;
 
-            if (bot->getLevel() < bg->GetMinLevel())
+            if (bot->GetLevel() < bg->GetMinLevel())
                 continue;
 
             // check if already in queue

--- a/src/strategy/values/QuestValues.cpp
+++ b/src/strategy/values/QuestValues.cpp
@@ -136,7 +136,7 @@ questGiverMap QuestGiversValue::Calculate()
 
 std::vector<GuidPosition> ActiveQuestGiversValue::Calculate()
 {
-    questGiverMap qGivers = GAI_VALUE2(questGiverMap, "quest givers", bot->getLevel());
+    questGiverMap qGivers = GAI_VALUE2(questGiverMap, "quest givers", bot->GetLevel());
 
 	std::vector<GuidPosition> retQuestGivers;
 
@@ -406,7 +406,7 @@ uint32 DialogStatusValue::getDialogStatus(Player* bot, int32 questgiver, uint32 
 					{
 						dialogStatusNew = DIALOG_STATUS_REWARD_REP;
 					}
-					else if (lowLevelDiff < 0 || bot->getLevel() <= bot->GetQuestLevel(pQuest) + uint32(lowLevelDiff))
+					else if (lowLevelDiff < 0 || bot->GetLevel() <= bot->GetQuestLevel(pQuest) + uint32(lowLevelDiff))
 					{
 						dialogStatusNew = DIALOG_STATUS_AVAILABLE;
 					}


### PR DESCRIPTION
Changed all instances of `getLevel` to `GetLevel`
Reworked the command script to match how AzerothCore implements their commands

This will still work on the fork by @liyunfan1223 which was important to me but it also works on the latest commit as long as you have the playerbots code in it.

The latest commit of AzerothCore will compile with errors because of getLevel and the command script which is what prompted me to do this.