### PR TITLE
Optimize the check for PvP flag

### DIFF
--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -95,16 +95,6 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         return false;
     }
 
-    if (target->IsPlayer() && !target->IsPvP() && !target->IsFFAPvP() && (!bot->duel || bot->duel->Opponent != target || bot->duel->StartTime))
-    {
-        if (verbose)
-        {
-            botAI->TellError(Acore::StringFormat("%s is not flagged for pvp", target->GetName()));
-        }
-
-        return false;
-    }
-
     if (bot->IsMounted() && bot->IsWithinLOSInMap(target))
     {
         WorldPacket emptyPacket;

--- a/src/strategy/values/AttackersValue.cpp
+++ b/src/strategy/values/AttackersValue.cpp
@@ -180,7 +180,7 @@ bool AttackersValue::IsPossibleTarget(Unit* attacker, Player* bot, float range)
         !attacker->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE) &&
         bot->CanSeeOrDetect(attacker) &&
         !(sPlayerbotAIConfig->IsPvpProhibited(attacker->GetZoneId(), attacker->GetAreaId()) && (attacker->GetGUID().IsPlayer() || attacker->GetGUID().IsPet())) && 
-        !(attacker->IsPlayer() && !attacker->IsPvP() && !attacker->IsFFAPvP() && (!bot->duel || bot->duel->Opponent != attacker || bot->duel->StartTime)) &&
+        !(attacker->IsPlayer() && !attacker->IsPvP() && !attacker->IsFFAPvP() && (!bot->duel || bot->duel->Opponent != attacker)) &&
         (!c || (!c->IsInEvadeMode() && ((!isMemberBotGroup && botAI->HasStrategy("attack tagged", BOT_STATE_NON_COMBAT)) ||
         leaderHasThreat || (!c->hasLootRecipient() && (!c->GetVictim() || (c->GetVictim() && ((!c->GetVictim()->IsPlayer() || bot->IsInSameGroupWith(c->GetVictim()->ToPlayer())) ||
         (botAI->GetMaster() && c->GetVictim() == botAI->GetMaster()))))) || c->isTappedBy(bot))));

--- a/src/strategy/values/AttackersValue.cpp
+++ b/src/strategy/values/AttackersValue.cpp
@@ -180,6 +180,7 @@ bool AttackersValue::IsPossibleTarget(Unit* attacker, Player* bot, float range)
         !attacker->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE) &&
         bot->CanSeeOrDetect(attacker) &&
         !(sPlayerbotAIConfig->IsPvpProhibited(attacker->GetZoneId(), attacker->GetAreaId()) && (attacker->GetGUID().IsPlayer() || attacker->GetGUID().IsPet())) && 
+        !(attacker->IsPlayer() && !attacker->IsPvP() && !attacker->IsFFAPvP() && (!bot->duel || bot->duel->Opponent != attacker || bot->duel->StartTime)) &&
         (!c || (!c->IsInEvadeMode() && ((!isMemberBotGroup && botAI->HasStrategy("attack tagged", BOT_STATE_NON_COMBAT)) ||
         leaderHasThreat || (!c->hasLootRecipient() && (!c->GetVictim() || (c->GetVictim() && ((!c->GetVictim()->IsPlayer() || bot->IsInSameGroupWith(c->GetVictim()->ToPlayer())) ||
         (botAI->GetMaster() && c->GetVictim() == botAI->GetMaster()))))) || c->isTappedBy(bot))));


### PR DESCRIPTION
Moved the check for if players are flagged for PvP before attacking them. It's best if they never reach the attack action code if they won't be able to attack the target anyway. This looks to be the best solution.

Thank you @fuzzdeveloper for the help figuring this out.

I've done extensive tests in these areas:
- Walking around enemy bots both while being flagged for PvP and while not. Some of the bots were also flagged and some weren't to make sure it works in both cases.
- Being grouped up with bots and test the same as above as well as telling them to attack specific targets.
- Having the bots attack creatures to make sure that is unaffected.

I can't seem to test duels because even without any of this they won't actually attack me. They might take a swing at me but then they run off.

I'd appreciate if someone could give duels a whirl, someone who knows that duels worked for them before this.

Maybe @Jgoodwin64 could test that part?

If others feel like testing it all, that'd be great too. I figured I'd create the pull request so it could be seen and hopefully tested.