### PR TITLE
Add bots to transports

### DIFF
--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -849,6 +849,21 @@ void MovementAction::UpdateMovementState()
 
     if (bot->IsFlying())
         bot->UpdateSpeed(MOVE_FLIGHT, true);
+
+    Transport* newTransport = bot->GetMap()->GetTransportForPos(bot->GetPhaseMask(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot);
+    if (newTransport != bot->GetTransport())
+    {
+        LOG_DEBUG("playerbots", "Bot {} is on a transport", IsMovingAllowed());
+
+        if (bot->GetTransport())
+            bot->GetTransport()->RemovePassenger(bot, true);
+
+        if (newTransport)
+            newTransport->AddPassenger(bot, true);
+
+        bot->StopMovingOnCurrentPos();
+    }
+
     // Temporary speed increase in group
     //if (botAI->HasRealPlayerMaster())
         //bot->SetSpeedRate(MOVE_RUN, 1.1f);

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -853,7 +853,7 @@ void MovementAction::UpdateMovementState()
     Transport* newTransport = bot->GetMap()->GetTransportForPos(bot->GetPhaseMask(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot);
     if (newTransport != bot->GetTransport())
     {
-        LOG_DEBUG("playerbots", "Bot {} is on a transport", IsMovingAllowed());
+        LOG_DEBUG("playerbots", "Bot {} is on a transport", bot->GetName());
 
         if (bot->GetTransport())
             bot->GetTransport()->RemovePassenger(bot, true);


### PR DESCRIPTION
Add bots to transports they're on so they actually move with it. I've tested it with boats as well as airship and had no issues as a result of this change.

The bots sometimes have issues stepping onto airships because their pathing isn't perfect. As soon as they set foot on it and become a passenger that issue goes away.

Can be seen in action here: https://www.youtube.com/watch?v=WwfyZfSb6E4