### PR TITLE
Fix bots looting quest objects

### DIFF
--- a/src/LootObjectStack.cpp
+++ b/src/LootObjectStack.cpp
@@ -96,7 +96,7 @@ void LootObject::Refresh(Player* bot, ObjectGuid lootGUID)
 
             if (IsNeededForQuest(bot, itemId))
             {
-                this->guid = guid;
+                this->guid = lootGUID;
                 return;
             }
             isQuestItemOnly |= itemId > 0;


### PR DESCRIPTION
This will allow bots to loot quest objects (quest items from objects on the ground) for quests they have.