### PR TITLE
WSG fixes

### DIFF
--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -22,6 +22,7 @@
 #include "Event.h"
 #include "Playerbots.h"
 #include "PositionValue.h"
+#include "PvpTriggers.h"
 #include "ServerFacade.h"
 #include "Vehicle.h"
 
@@ -1771,7 +1772,10 @@ std::string const BGTactics::HandleConsoleCommandPrivate(WorldSession* session, 
         Creature* wpCreature = player->SummonCreature(15631, c->GetPositionX(), c->GetPositionY(), c->GetPositionZ(), 0,
                                                       TEMPSUMMON_TIMED_DESPAWN, 15000u);
         wpCreature->SetOwnerGUID(player->GetGUID());
-        return fmt::format("Showing location of Creature {}", num);
+        float distance = player->GetDistance(c);
+        float exactDistance = player->GetExactDist(c);
+        return fmt::format("Showing Creature {} location={:.3f},{:.3f},{:.3f} distance={} exactDistance={}",
+            num, c->GetPositionX(), c->GetPositionY(), c->GetPositionZ(), distance, exactDistance);
     }
 
     if (!strncmp(cmd, "showobject=", 11))
@@ -1787,7 +1791,10 @@ std::string const BGTactics::HandleConsoleCommandPrivate(WorldSession* session, 
         Creature* wpCreature = player->SummonCreature(15631, o->GetPositionX(), o->GetPositionY(), o->GetPositionZ(), 0,
                                                       TEMPSUMMON_TIMED_DESPAWN, 15000u);
         wpCreature->SetOwnerGUID(player->GetGUID());
-        return fmt::format("Showing location of GameObject {}", num);
+        float distance = player->GetDistance(o);
+        float exactDistance = player->GetExactDist(o);
+        return fmt::format("Showing GameObject {} location={:.3f},{:.3f},{:.3f} distance={} exactDistance={}",
+            num, o->GetPositionX(), o->GetPositionY(), o->GetPositionZ(), distance, exactDistance);
     }
 
     return "usage: showpath(=[num]) / showcreature=[num] / showobject=[num]";
@@ -2266,8 +2273,7 @@ bool BGTactics::Execute(Event event)
 
         // NOTE: can't use IsInCombat() when in vehicle as player is stuck in combat forever while in vehicle (ac bug?)
         bool inCombat = bot->GetVehicle() ? (bool)AI_VALUE(Unit*, "enemy player target") : bot->IsInCombat();
-        if (inCombat && !(bot->HasAura(BG_WS_SPELL_WARSONG_FLAG) || bot->HasAura(BG_WS_SPELL_SILVERWING_FLAG) ||
-                          bot->HasAura(BG_EY_NETHERSTORM_FLAG_SPELL)))
+        if (inCombat && !PlayerHasFlag::IsCapturingFlag(bot))
         {
             // bot->GetMotionMaster()->MovementExpired();
             return false;
@@ -3886,10 +3892,7 @@ bool BGTactics::moveToObjectiveWp(BattleBotPath* const& currentPath, uint32 curr
 
     // NOTE: can't use IsInCombat() when in vehicle as player is stuck in combat forever while in vehicle (ac bug?)
     bool inCombat = bot->GetVehicle() ? (bool)AI_VALUE(Unit*, "enemy player target") : bot->IsInCombat();
-    if ((currentPoint == lastPointInPath) ||
-        (inCombat && !(bot->HasAura(BG_WS_SPELL_WARSONG_FLAG) || bot->HasAura(BG_WS_SPELL_SILVERWING_FLAG) ||
-                       bot->HasAura(BG_EY_NETHERSTORM_FLAG_SPELL))) ||
-        !bot->IsAlive())
+    if (currentPoint == lastPointInPath || (inCombat && !PlayerHasFlag::IsCapturingFlag(bot)) || !bot->IsAlive())
     {
         // Path is over.
         // std::ostringstream out;

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -2053,13 +2053,13 @@ bool BGTactics::wsgPaths()
                 return true;
             }
 
-            if (bot->GetPositionX() > 1071.f)  // move the ramp up a piece
+            if (bot->GetPositionX() > 1059.f)  // move the ramp up a piece
             {
-                MoveTo(bg->GetMapId(), 1070.089478f, 1538.054443f, 332.460388f);
+                MoveTo(bg->GetMapId(), 1057.551f, 1546.271f, 326.864f);
                 return true;
             }
 
-            if (bot->GetPositionX() > 1050.2f)  // move the ramp up a piece
+            if (bot->GetPositionX() > 1051.2f)  // move the ramp up a piece
             {
                 MoveTo(bg->GetMapId(), 1050.089478f, 1538.054443f, 332.460388f);
                 return true;

--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -11,11 +11,11 @@
 #include "Playerbots.h"
 #include "PossibleRpgTargetsValue.h"
 #include "ServerFacade.h"
+#include "PvpTriggers.h"
 
 bool AttackEnemyPlayerAction::isUseful()
 {
-    // if carry flag, do not start fight
-    if (bot->HasAura(23333) || bot->HasAura(23335) || bot->HasAura(34976))
+    if (PlayerHasFlag::IsCapturingFlag(bot))
         return false;
 
     return !sPlayerbotAIConfig->IsPvpProhibited(bot->GetZoneId(), bot->GetAreaId());
@@ -25,7 +25,7 @@ bool AttackEnemyFlagCarrierAction::isUseful()
 {
     Unit* target = context->GetValue<Unit*>("enemy flag carrier")->Get();
     return target && sServerFacade->IsDistanceLessOrEqualThan(sServerFacade->GetDistance2d(bot, target), 75.0f) &&
-           (bot->HasAura(23333) || bot->HasAura(23335) || bot->HasAura(34976));
+           PlayerHasFlag::IsCapturingFlag(bot);
 }
 
 bool AttackAnythingAction::isUseful()
@@ -124,8 +124,7 @@ bool AttackAnythingAction::isPossible() { return AttackAction::isPossible() && G
 
 bool DpsAssistAction::isUseful()
 {
-    // if carry flag, do not start fight
-    if (bot->HasAura(23333) || bot->HasAura(23335) || bot->HasAura(34976))
+    if (PlayerHasFlag::IsCapturingFlag(bot))
         return false;
 
     return true;

--- a/src/strategy/actions/VehicleActions.cpp
+++ b/src/strategy/actions/VehicleActions.cpp
@@ -44,13 +44,12 @@ bool EnterVehicleAction::Execute(Event event)
         if (vehicleBase->GetVehicleKit()->IsVehicleInUse())
             continue;
 
-        // if (fabs(bot->GetPositionZ() - vehicleBase->GetPositionZ()) < 20.0f)
+        float dist = sServerFacade->GetDistance2d(bot, vehicleBase);
+        if (dist > 40.0f)
+            continue;
 
-        // if (sServerFacade->GetDistance2d(bot, vehicle) > 100.0f)
-        //    continue;
-
-        if (sServerFacade->GetDistance2d(bot, vehicleBase) > INTERACTION_DISTANCE)
-            return MoveTo(vehicleBase, INTERACTION_DISTANCE - 1.0f);
+        if (dist > INTERACTION_DISTANCE)
+            return MoveTo(vehicleBase);
 
         bot->EnterVehicle(vehicleBase);
 

--- a/src/strategy/triggers/PvpTriggers.h
+++ b/src/strategy/triggers/PvpTriggers.h
@@ -26,12 +26,15 @@ public:
     bool IsActive() override;
 };
 
+// NOTE this trigger is only active when bot is actively returning flag
+// (not when hiding in base because enemy has flag too)
 class PlayerHasFlag : public Trigger
 {
 public:
     PlayerHasFlag(PlayerbotAI* botAI) : Trigger(botAI, "player has flag") {}
 
     bool IsActive() override;
+    static bool IsCapturingFlag(Player* bot);
 };
 
 class EnemyFlagCarrierNear : public Trigger


### PR DESCRIPTION
Makes sense that I'd eventually come full circle back to WSG at some point, I fixed some minor path issues (was only 2 nodes, though they were having a significant impact on gameplay).

Also made it so all the triggers/conditions that cause WSG flag carrier to avoid combat are now using same method, this method allows flag carrier to engage in combat when both these conditions are met:
- Both teams have each others flag (meaning bot can't cap the flag)
- Bot is within 36 units of their flag return point (which is where they'll be hiding when waiting for flag to return)

When these conditions are true the bot has no need to move as fast-as-possible back to base because they're already there, instead the priority should be on staying alive until flag is returned.