### PR TITLE
Toggle to disable or enable playerbot emote in battleground

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1275,6 +1275,9 @@ AiPlayerbot.RandomBotTalk = 0
 # Enable playerbot emote
 AiPlayerbot.RandomBotEmote = 0
 
+#Enable playerbot emote in battleground
+AiPlayerbot.RandomBotEmoteBattleground = 1
+
 # Enable dungeon suggestions for random bots
 AiPlayerbot.RandomBotSuggestDungeons = 1
 

--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -687,11 +687,13 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
     if (player->InBattleground() && player->GetBattleground())
     {
         nonCombatEngine->addStrategies("nc", "chat", "default", "buff", "food", "mount", "pvp", "dps assist",
-                                       "attack tagged", "emote", nullptr);
+                                       "attack tagged", nullptr);
         nonCombatEngine->removeStrategy("custom::say");
         nonCombatEngine->removeStrategy("travel");
         nonCombatEngine->removeStrategy("rpg");
         nonCombatEngine->removeStrategy("grind");
+        if (sPlayerbotAIConfig->randomBotEmoteBattleground)
+            nonCombatEngine->addStrategy("emote");
 
         BattlegroundTypeId bgType = player->GetBattlegroundTypeId();
         if (bgType == BATTLEGROUND_RB)

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -162,6 +162,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotJoinLfg = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotJoinLfg", true);
     randomBotTalk = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotTalk", false);
     randomBotEmote = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotEmote", false);
+    randomBotEmoteBattleground = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotEmoteBattleground", true);
     randomBotSuggestDungeons = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotSuggestDungeons", true);
     randomBotGuildTalk = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotGuildTalk", false);
     suggestDungeonsInLowerCaseRandomly =

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -97,6 +97,7 @@ public:
     bool randomBotJoinLfg;
     bool randomBotTalk;
     bool randomBotEmote;
+    bool randomBotEmoteBattleground;
     bool randomBotSuggestDungeons;
     bool randomBotGuildTalk;
     bool suggestDungeonsInLowerCaseRandomly;


### PR DESCRIPTION
Add toggle to enable or disable playerbot emoting in battlegrounds.