### PR TITLE
Optimized performance: init first level and teleport assignment

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -728,14 +728,14 @@ AiPlayerbot.FastReactInBG = 1
 #
 
 # All In seconds
-AiPlayerbot.RandomBotUpdateInterval = 20
+AiPlayerbot.RandomBotUpdateInterval = 1
 AiPlayerbot.RandomBotCountChangeMinInterval = 1800
 AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 AiPlayerbot.MinRandomBotInWorldTime = 3600
-AiPlayerbot.MaxRandomBotInWorldTime = 43200
-AiPlayerbot.MinRandomBotRandomizeTime = 302400
+AiPlayerbot.MaxRandomBotInWorldTime = 1209600
+AiPlayerbot.MinRandomBotRandomizeTime = 7200
 AiPlayerbot.MaxRandomBotRandomizeTime = 1209600
-AiPlayerbot.RandomBotsPerInterval = 500
+AiPlayerbot.RandomBotsPerInterval = 60
 AiPlayerbot.MinRandomBotReviveTime = 60
 AiPlayerbot.MaxRandomBotReviveTime = 300
 AiPlayerbot.MinRandomBotTeleportInterval = 3600

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1014,26 +1014,26 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
     if (isLogginIn)
         return false;
 
+    uint32 randomTime;
     if (!player)
     {
         AddPlayerBot(botGUID, 0);
-        SetEventValue(bot, "login", 1, sPlayerbotAIConfig->randomBotUpdateInterval);
+        SetEventValue(bot, "login", 1,
+                      std::max(1, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 0.2)));
 
-        uint32 randomTime =
-            urand(sPlayerbotAIConfig->minRandomBotReviveTime, sPlayerbotAIConfig->maxRandomBotReviveTime);
+        randomTime = urand(std::max(5, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval)),
+                                  std::max(15, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 2.2)));
         SetEventValue(bot, "update", 1, randomTime);
 
         // do not randomize or teleport immediately after server start (prevent lagging)
         if (!GetEventValue(bot, "randomize"))
         {
-            randomTime = urand(sPlayerbotAIConfig->randomBotUpdateInterval * 5,
-                               sPlayerbotAIConfig->randomBotUpdateInterval * 20);
-            ScheduleRandomize(bot, randomTime);
+            ScheduleRandomize(bot, std::max(3, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 0.5)));
         }
         if (!GetEventValue(bot, "teleport"))
         {
-            randomTime = urand(sPlayerbotAIConfig->randomBotUpdateInterval * 5,
-                               sPlayerbotAIConfig->randomBotUpdateInterval * 20);
+            randomTime = urand(std::max(7, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 0.8)),
+                               std::max(14, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 2)));
             ScheduleTeleport(bot, randomTime);
         }
         return true;
@@ -1076,8 +1076,9 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         if (update)
             ProcessBot(player);
 
-        uint32 randomTime =
-            urand(sPlayerbotAIConfig->minRandomBotReviveTime, sPlayerbotAIConfig->maxRandomBotReviveTime);
+        randomTime = urand(
+            sPlayerbotAIConfig->minRandomBotReviveTime,
+            sPlayerbotAIConfig->maxRandomBotReviveTime);
         SetEventValue(bot, "update", 1, randomTime);
 
         return true;


### PR DESCRIPTION
Optimization in regard the speed of first level assigned of new bots and their first teleportedForLevel.

- No more, or atleast less, cluttering of new bots the init areas.
- Faster deployment of new bots without, or atleast alot less, laggs.
- Makes more use of the available resources
- No laggs during init regardless how many bots
- Always able to logon during init
- Has huge impact with new bots, abit less with existing bots.

The bot calculations: https://www.programiz.com/online-compiler/24XijdM0dwvDF

Tests:
- Startup with all bots cleared
- Startup with half assigned bots
- Startup with existing bots
- AMD 5700X,  Intel 9500T,  AMD 6900HT (mobile)
- 50 bots, 500 bots, 1500 bots, 3200 bots, 5000 bots.

Example: https://www.youtube.com/watch?v=n6P5-ppu-7Q

Used settings:
Worldserver.conf:
#-------------------------------------------------------------------
# performance
#-------------------------------------------------------------------
PreloadAllNonInstancedMapGrids  = 0
SetAllCreaturesWithWaypointMovementActive = 0
DontCacheRandomMovementPaths = 0

ThreadPool = 8
Network.Threads = 1

MapUpdate.Threads = 6
MapUpdateInterval = 100
MinWorldUpdateTime = 10

LoginDatabase.WorkerThreads     = 1
WorldDatabase.WorkerThreads     = 1
CharacterDatabase.WorkerThreads = 1

LoginDatabase.SynchThreads     = 1
WorldDatabase.SynchThreads     = 2
CharacterDatabase.SynchThreads = 4


authserver.conf:
#-------------------------------------------------------------------
# performance
#-------------------------------------------------------------------
LoginDatabase.WorkerThreads = 4
LoginDatabase.SynchThreads = 4

playerbot.config (although not rlly relevant)
#-------------------------------------------------------------------
# performance related
#-------------------------------------------------------------------
PlayerbotsDatabase.WorkerThreads = 1
PlayerbotsDatabase.SynchThreads = 6