### PR TITLE
Initial playerbot creation and balancing optimizations (side-effects partially mitigates server OOM)

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -728,7 +728,7 @@ AiPlayerbot.FastReactInBG = 1
 #
 
 # All In seconds
-AiPlayerbot.RandomBotUpdateInterval = 1
+AiPlayerbot.RandomBotUpdateInterval = 10
 AiPlayerbot.RandomBotCountChangeMinInterval = 1800
 AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 AiPlayerbot.MinRandomBotInWorldTime = 3600

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -156,7 +156,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotAutologin = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotAutologin", true);
     minRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBots", 50);
     maxRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBots", 200);
-    randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 1);
+    randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 10);
     randomBotCountChangeMinInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMinInterval", 30 * MINUTE);
     randomBotCountChangeMaxInterval =


### PR DESCRIPTION
Optimizations for the logic around RandomBotUpdateInterval before, during, after balancing bots process.

A boost will be applied when bots are added, till maxAllowedBots has been reached.  The booster is applied to the RandomBotUpdateInterval so the bots are balanced out quickly and teleported to the corresponding level locations. When this process is completed it will fallback to the configured updateInterval to lower the server resource pressure, and only use the resources required for the bots to function as excepted.

When the server is being rebalanced by playerbot commands the mechanism will be applied again. This will also help abit in regard of the server OOM situation (#537).

I went from 3200 bots OOM in 1-2 hours to 3200 bots around 8-9 hours, and gained 20% less cpu usage throughout.