### PR TITLE
Modified the botActiveAlone autoscale functionality

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1462,6 +1462,10 @@ AiPlayerbot.RandombotsWalkingRPG.InDoors = 0
 # The default is 10. With 10% of all bots going active or inactive each minute.
 AiPlayerbot.BotActiveAlone = 100
 
+# Specify 1 for enabled, 0 for disabled.
+# The default is 1. Automatically adjusts 'BotActiveAlone' percentage based on server latency.
+AiPlayerbot.botActiveAloneAutoScale = 1
+
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...
 AiPlayerbot.PremadeAvoidAoe = 62234-4

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -527,6 +527,7 @@ public:
     bool HasManyPlayersNearby(uint32 trigerrValue = 20, float range = sPlayerbotAIConfig->sightDistance);
     bool AllowActive(ActivityType activityType);
     bool AllowActivity(ActivityType activityType = ALL_ACTIVITY, bool checkNow = false);
+    uint32 AutoScaleActivity(uint32 mod);
 
     // Check if player is safe to use.
     bool IsSafe(Player* player);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -465,6 +465,7 @@ bool PlayerbotAIConfig::Initialize()
     playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
+    botActiveAloneAutoScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneAutoScale", true);
 
     enablePrototypePerformanceDiff = sConfigMgr->GetOption<bool>("AiPlayerbot.EnablePrototypePerformanceDiff", false);
     diffWithPlayer = sConfigMgr->GetOption<int32>("AiPlayerbot.DiffWithPlayer", 100);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -263,6 +263,7 @@ public:
     uint32 playerbotsXPrate;
     bool disableDeathKnightLogin;
     uint32 botActiveAlone;
+    bool botActiveAloneAutoScale;
 
     uint32 enablePrototypePerformanceDiff;
     uint32 diffWithPlayer;


### PR DESCRIPTION
botActiveAlone had a related feature which autoscales the botActiveAlone percentages when the value is lower then 100 implicitily.

Modifed and made the functionality explicit through the conf file, awarely enabled by default. Enabled to by default because it simplifies the configuration with better and more stabilized performance out of the box. Providing the server breathing space instead of locking up the resources, while still being able to disable to feature and enforce a specific value instead.