### PR TITLE
Silence totalDps being uninitialized

### DIFF
--- a/src/strategy/values/EstimatedLifetimeValue.cpp
+++ b/src/strategy/values/EstimatedLifetimeValue.cpp
@@ -25,7 +25,7 @@ float EstimatedLifetimeValue::Calculate()
 
 float EstimatedGroupDpsValue::Calculate()
 {
-    float totalDps;
+    float totalDps = 0;
 
     std::vector<Player*> groupPlayer = {bot};
     if (Group* group = bot->GetGroup())


### PR DESCRIPTION
This is making debugging a terrible experience and produces warnings while compiling that shouldn't happen to begin with.