### PR TITLE
Update PlayerbotAI.cpp

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -355,15 +355,18 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
         return;
 
     if (!bot->InBattleground() && !bot->inRandomLfgDungeon() && bot->GetGroup())
-    {
-        Player* leader = bot->GetGroup()->GetLeader();
-        PlayerbotAI* leaderAI = GET_PLAYERBOT_AI(leader);
-        if (leaderAI && !leaderAI->IsRealPlayer())
-        {
-            bot->RemoveFromGroup();
-            ResetStrategies();
-        }
-    }
+	{
+		Player* leader = bot->GetGroup()->GetLeader();
+		if (leader && leader != bot) // Checks if the leader is valid and is not the bot itself
+		{
+			PlayerbotAI* leaderAI = GET_PLAYERBOT_AI(leader);
+			if (leaderAI && !leaderAI->IsRealPlayer())
+			{
+				bot->RemoveFromGroup();
+				ResetStrategies();
+			}
+		}
+	}
 
     bool min = minimal;
     UpdateAIInternal(elapsed, min);


### PR DESCRIPTION
To avoid crashes, it is important to add nullability checks before trying to access the group leader and remove the bot from the group.