### PR TITLE
Add check to make sure there are races available for a class before generation

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -166,7 +166,7 @@ Player* RandomPlayerbotFactory::CreateRandomBot(WorldSession* session, uint8 cls
         }
     }
 
-    if (raceOptions.size() == 0)
+    if (raceOptions.empty())
     {
         LOG_ERROR("playerbots", "No races available for class: {}", cls);
         return nullptr;

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -168,7 +168,7 @@ Player* RandomPlayerbotFactory::CreateRandomBot(WorldSession* session, uint8 cls
 
     if (raceOptions.size() == 0)
     {
-        LOG_ERROR("playerbots", "No race available for class: {}", cls);
+        LOG_ERROR("playerbots", "No races available for class: {}", cls);
         return nullptr;
     }
 

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -165,6 +165,13 @@ Player* RandomPlayerbotFactory::CreateRandomBot(WorldSession* session, uint8 cls
             raceOptions.push_back(race);
         }
     }
+
+    if (raceOptions.size() == 0)
+    {
+        LOG_ERROR("playerbots", "No race available for class: {}", cls);
+        return nullptr;
+    }
+
     uint8 race = raceOptions[urand(0, raceOptions.size() - 1)];
 
     const auto raceAndGender = CombineRaceAndGender(gender, race);


### PR DESCRIPTION
The server will crash if the character generation tries to create a shaman on the alliance side or a paladin on the horde side while expansion is set to 0. This should mitigate that and stop it from crashing.