### PR TITLE
AllowActive prioritizing and bracket scaling based on bot activity 

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1462,10 +1462,6 @@ AiPlayerbot.RandombotsWalkingRPG.InDoors = 0
 # The default is 10. With 10% of all bots going active or inactive each minute.
 AiPlayerbot.BotActiveAlone = 100
 
-# Specify 1 for enabled, 0 for disabled.
-# The default is 1. Automatically adjusts 'BotActiveAlone' percentage based on server latency.
-AiPlayerbot.botActiveAloneAutoScale = 1
-
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...
 AiPlayerbot.PremadeAvoidAoe = 62234-4

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -241,6 +241,27 @@ enum class GuilderType : uint8
     VERY_LARGE = 250
 };
 
+enum class ActivePiorityType : uint8
+{
+    IS_REAL_PLAYER = 0,
+    HAS_REAL_PLAYER_MASTER = 1,
+    IN_GROUP_WITH_REAL_PLAYER = 2,
+    IN_INSTANCE = 3,
+    VISIBLE_FOR_PLAYER = 4,
+    IS_ALWAYS_ACTIVE = 5,
+    IN_COMBAT = 6,
+    IN_BG_QUEUE = 7,
+    IN_LFG = 8,
+    NEARBY_PLAYER = 9,
+    PLAYER_FRIEND = 10,
+    PLAYER_GUILD = 11,
+    IN_ACTIVE_AREA = 12,
+    IN_ACTIVE_MAP = 13,
+    IN_INACTIVE_MAP = 14,
+    IN_EMPTY_SERVER = 15,
+    MAX_TYPE
+};
+
 enum ActivityType
 {
     GRIND_ACTIVITY = 1,
@@ -250,8 +271,8 @@ enum ActivityType
     PACKET_ACTIVITY = 5,
     DETAILED_MOVE_ACTIVITY = 6,
     PARTY_ACTIVITY = 7,
-    ALL_ACTIVITY = 8,
-
+    REACT_ACTIVITY = 8,
+    ALL_ACTIVITY = 9,
     MAX_ACTIVITY_TYPE
 };
 
@@ -525,9 +546,10 @@ public:
     bool HasPlayerNearby(WorldPosition* pos, float range = sPlayerbotAIConfig->reactDistance);
     bool HasPlayerNearby(float range = sPlayerbotAIConfig->reactDistance);
     bool HasManyPlayersNearby(uint32 trigerrValue = 20, float range = sPlayerbotAIConfig->sightDistance);
+    ActivePiorityType GetPriorityType(ActivityType activityType);
+    std::pair<uint32, uint32> GetPriorityBracket(ActivePiorityType type);
     bool AllowActive(ActivityType activityType);
     bool AllowActivity(ActivityType activityType = ALL_ACTIVITY, bool checkNow = false);
-    uint32 AutoScaleActivity(uint32 mod);
 
     // Check if player is safe to use.
     bool IsSafe(Player* player);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -465,7 +465,6 @@ bool PlayerbotAIConfig::Initialize()
     playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
-    botActiveAloneAutoScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneAutoScale", true);
 
     enablePrototypePerformanceDiff = sConfigMgr->GetOption<bool>("AiPlayerbot.EnablePrototypePerformanceDiff", false);
     diffWithPlayer = sConfigMgr->GetOption<int32>("AiPlayerbot.DiffWithPlayer", 100);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -263,7 +263,6 @@ public:
     uint32 playerbotsXPrate;
     bool disableDeathKnightLogin;
     uint32 botActiveAlone;
-    bool botActiveAloneAutoScale;
 
     uint32 enablePrototypePerformanceDiff;
     uint32 diffWithPlayer;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1108,6 +1108,9 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
 
 bool RandomPlayerbotMgr::ProcessBot(Player* player)
 {
+    if (!player || !player->IsInWorld() || player->IsBeingTeleported() || player->GetSession()->isLogingOut())
+        return false;
+
     uint32 bot = player->GetGUID().GetCounter();
 
     if (player->InBattleground())


### PR DESCRIPTION
One of many to come.  

Found the issue together with @noisiver, basically backpressure of mapUpdate thread. The updateRequest are to many to process so the thread cant keep up and starts queueing them faster then processing. Thereby the memory goes up and up and up. Thereby bots actions where never executed or far to late as side-effects bots acting strange and or simple out of sync with the actual map.

@noisiver 
![ac_profile](https://github.com/user-attachments/assets/4995a5f4-082a-48ab-b181-a3a29ba232d2)


The main variables in this whole are part:

- CPU single core clock speed
- Amount of bots on the server
- The RandomBotUpdateInterval 
- The BotActiveAlone percentages and logic around it.
- Variables that effect the cluttering of bots and the amount of bots close to real players e.g.
          - AutoTeleportForLevel 
          - DisableRandomLevels
          - RandombotStartingLevel
          
          
Added/ported the two features to reduce the pressure backlog buildup of the MapUpdater thread.
