### PR TITLE
[performance] Added min-max botLevel to apply smartScale on. 

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1464,7 +1464,11 @@ AiPlayerbot.BotActiveAlone = 100
 
 # Specify smart scaling is enabled or not.
 # The default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
+# Only when botLevel is between WhenMinLevel and WhenMaxLevel.
 AiPlayerbot.botActiveAloneSmartScale = 1
+AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
+AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
+
 
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4288,7 +4288,9 @@ bool PlayerbotAI::AllowActive(ActivityType activityType)
 
     // GetPriorityBracket acitivity
     float activePerc = 100;
-    if (sPlayerbotAIConfig->botActiveAloneSmartScale)
+    if (sPlayerbotAIConfig->botActiveAloneSmartScale &&
+        bot->GetLevel() >= sPlayerbotAIConfig->botActiveAloneSmartScaleWhenMinLevel &&
+        bot->GetLevel() <= sPlayerbotAIConfig->botActiveAloneSmartScaleWhenMaxLevel)
     {
         std::pair<uint8, uint8> priorityBracket = GetPriorityBracket(type);
         if (!priorityBracket.second) return true; 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -466,6 +466,8 @@ bool PlayerbotAIConfig::Initialize()
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
     botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
+    botActiveAloneSmartScaleWhenMinLevel = sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
+    botActiveAloneSmartScaleWhenMaxLevel = sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel", 80);
 
     enablePrototypePerformanceDiff = sConfigMgr->GetOption<bool>("AiPlayerbot.EnablePrototypePerformanceDiff", false);
     diffWithPlayer = sConfigMgr->GetOption<int32>("AiPlayerbot.DiffWithPlayer", 100);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -264,6 +264,8 @@ public:
     bool disableDeathKnightLogin;
     uint32 botActiveAlone;
     bool botActiveAloneSmartScale;
+    uint32 botActiveAloneSmartScaleWhenMinLevel;
+    uint32 botActiveAloneSmartScaleWhenMaxLevel;
 
     uint32 enablePrototypePerformanceDiff;
     uint32 diffWithPlayer;


### PR DESCRIPTION
For those who prefer active and less active bots in a certain level bracket, by default 1 to 80.