### PR TITLE
Fix LFG Join bug

### DIFF
--- a/src/strategy/actions/RpgAction.cpp
+++ b/src/strategy/actions/RpgAction.cpp
@@ -79,7 +79,7 @@ bool RpgAction::SetNextRpgAction()
                 {
                     NextAction* nextAction = nextActions[i];
 
-                    if (nextAction->getRelevance() > 2.0f)
+                    if (nextAction->getRelevance() > 5.0f)
                         continue;
 
                     if (!isChecked && !trigger->IsActive())
@@ -92,7 +92,7 @@ bool RpgAction::SetNextRpgAction()
                         continue;
 
                     actions.push_back(action);
-                    relevances.push_back((nextAction->getRelevance() - 1) * 1000);
+                    relevances.push_back((nextAction->getRelevance() - 1) * 500);
                 }
                 NextAction::destroy(nextActions);
             }


### PR DESCRIPTION
This PR adjusts the execution priority of bot actions in Dungeon Finder (DF), modifying the relevance logic to make responses faster. The relevance calculation formula was changed in RpgAction::SetNextRpgAction to reduce the delay between activating actions, especially to improve the acceptance time of bots in DF queues. With these changes, bots now accept vacancies in a more agile and efficient way, optimizing overall response time.