### PR TITLE
Fix Bug Bot blocked in PT

### DIFF
--- a/src/strategy/actions/LeaveGroupAction.cpp
+++ b/src/strategy/actions/LeaveGroupAction.cpp
@@ -30,6 +30,8 @@ bool PartyCommandAction::Execute(Event event)
     Player* master = GetMaster();
     if (master && member == master->GetName())
         return Leave(bot);
+	
+	botAI->Reset();
 
     return false;
 }
@@ -62,6 +64,8 @@ bool UninviteAction::Execute(Event event)
         if (bot->GetGUID() == guid)
             return Leave(bot);
     }
+	
+	botAI->Reset();
 
     return false;
 }
@@ -160,6 +164,8 @@ bool LeaveFarAwayAction::isUseful()
     {
         return true;
     }
+	
+	botAI->Reset();
 
     return false;
 }


### PR DESCRIPTION
After leaving PT, the Bot was stuck in a Group, stopped and without receiving invites from other players. Ideally, use the LeaveGroupOnLogout.Enabled = 1 setting in Worldserver.conf so that after the player leaves the game, the Bots are not stuck in Raid.