### PR TITLE
Fix Crash q [ link item ]

### DIFF
--- a/src/ChatHelper.cpp
+++ b/src/ChatHelper.cpp
@@ -304,9 +304,13 @@ ItemIds ChatHelper::parseItems(std::string const text)
 
 std::string const ChatHelper::FormatQuest(Quest const* quest)
 {
+    if (!quest)
+    {
+        return "Invalid quest";
+    }
+
     std::ostringstream out;
-    out << "|cFFFFFF00|Hquest:" << quest->GetQuestId() << ':' << quest->GetQuestLevel() << "|h[" << quest->GetTitle()
-        << "]|h|r";
+    out << "|cFFFFFF00|Hquest:" << quest->GetQuestId() << ':' << quest->GetQuestLevel() << "|h[" << quest->GetTitle() << "]|h|r";
     return out.str();
 }
 


### PR DESCRIPTION
This PR adds a null pointer check to the ChatHelper::FormatQuest function to avoid a crash that occurred when trying to format a null quest. The crash occurred when the quest pointer was nullptr and the code tried to access the GetQuestId(), GetQuestLevel() and GetTitle() methods.

Changes:
Added a nullptr check to the beginning of the ChatHelper::FormatQuest function. Return of a standard error message ("Invalid quest") if the quest is null.

Impact:
Prevents crashes when formatting null quests.
Improves bot system stability when dealing with invalid quests.