### PR TITLE
Fix Crash The Nexux

### DIFF
--- a/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
+++ b/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
@@ -54,9 +54,16 @@ bool FirebombSpreadAction::Execute(Event event)
         {
             continue;
         }
-        if (bot->GetExactDist2d(botAI->GetUnit(member)) < targetDist)
+
+        Unit* unit = botAI->GetUnit(member);
+        if (!unit) 
         {
-            return MoveAway(botAI->GetUnit(member), targetDist);
+            continue;
+        }
+
+        if (bot->GetExactDist2d(unit) < targetDist)
+        {
+            return MoveAway(unit, targetDist);
         }
     }
     return false;


### PR DESCRIPTION
Log Crash: 00007FF7750C05ED  00000028A47FEA10  FirebombSpreadAction::Execute+1AD  E:\Server\Azeroth\modules\mod-playerbots\src\strategy\dungeons\wotlk\nexus\NexusActions.cpp line 58

This PR fixes a possible crash in the FirebombSpreadAction::Execute function, located in the NexusActions.cpp file, which occurred due to the lack of checking for null pointers when accessing group members.

Main changes: Added a null pointer check to ensure botAI->GetUnit(member) returns a valid unit before calling functions like GetExactDist2d and MoveAway. If botAI->GetUnit(member) returns nullptr, execution ignores the specific member, avoiding access to an invalid pointer that could cause a server crash.