### PR TITLE
Fix the level when a quest becomes trivial (grey/gray)

### DIFF
--- a/src/strategy/actions/DropQuestAction.cpp
+++ b/src/strategy/actions/DropQuestAction.cpp
@@ -101,8 +101,24 @@ bool CleanQuestLogAction::Execute(Event event)
             questLevel = botLevel;
         }
 
+        // Set the level difference for when a quest becomes trivial
+        // This was determined by using the Lua code the client uses
+        int32 trivialLevel = 5;
+        if (botLevel >= 40)
+        {
+            trivialLevel = 8;
+        }
+        else if (botLevel >= 30)
+        {
+            trivialLevel = 7;
+        }
+        else if (botLevel >= 20)
+        {
+            trivialLevel = 6;
+        }
+
         // Check if the quest is trivial (grey) for the bot
-        if ((botLevel - questLevel) >= 5)
+        if ((botLevel - questLevel) >= trivialLevel)
         {
             // Output only if "debug rpg" strategy is enabled
             if (botAI->HasStrategy("debug rpg", BotState::BOT_STATE_COMBAT))


### PR DESCRIPTION
I got these numbers by using the clients Lua API. These are guaranteed to be correct.

This feature needs a config option but I'm not going to add one with this change. Perhaps I'll add one in the future if no one else does.