### PR TITLE
Hack Fix Crash OnBotLogin

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -176,7 +176,7 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
         botSession->LogoutPlayer(true);
         delete botSession;
     }
-    botLoading.erase(holder.GetGuid());
+    //botLoading.erase(holder.GetGuid());
 }
 
 void PlayerbotHolder::UpdateSessions()


### PR DESCRIPTION
Now prevents OnBotLogin Crash. However, to create Off char or the same bots via AddClass, Logout is necessary.