### PR TITLE
Fix new compiler errors

### DIFF
--- a/src/TravelMgr.cpp
+++ b/src/TravelMgr.cpp
@@ -10,6 +10,7 @@
 
 #include "CellImpl.h"
 #include "ChatHelper.h"
+#include "Corpse.h"
 #include "MMapFactory.h"
 #include "MapMgr.h"
 #include "PathGenerator.h"

--- a/src/TravelMgr.cpp
+++ b/src/TravelMgr.cpp
@@ -10,7 +10,6 @@
 
 #include "CellImpl.h"
 #include "ChatHelper.h"
-#include "Corpse.h"
 #include "MMapFactory.h"
 #include "MapMgr.h"
 #include "PathGenerator.h"

--- a/src/TravelMgr.h
+++ b/src/TravelMgr.h
@@ -10,6 +10,7 @@
 #include <random>
 
 #include "AiObject.h"
+#include "Corpse.h"
 #include "CreatureData.h"
 #include "GameObject.h"
 #include "GridDefines.h"


### PR DESCRIPTION
With the cleanups being done to the core, future merges of the AzerothCore master will cause errors because this include isn't there.