### PR TITLE
[performance] bots kept idle always instead only during server/bots initialization as side-effect of another bug 

### DIFF
--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -315,8 +315,8 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
     }
 
     setBotInitializing(
-        onlineBotCount < maxAllowedBotCount &&
-        GameTime::GetUptime().count() < sPlayerbotAIConfig->maxRandomBots * 0.15);
+        //onlineBotCount < maxAllowedBotCount && <-- these fields are incorrect when using bot amount min/max are not equal.
+        GameTime::GetUptime().count() < sPlayerbotAIConfig->maxRandomBots * 0.12);
 
     // when server is balancing bots then boost (decrease value of) the nextCheckDelay till
     // onlineBotCount reached the AllowedBotCount.


### PR DESCRIPTION
When AiPlayerbot.MinRandomBots  and AiPlayerbot.MaxRandomBots are not equal in value the
'onlineBotCount < maxAllowedBotCount' return false positive. As result the autoscale thinks the bots are always initializing and keeps the bots inactive. 

For now removing the botCount check till that is fixed.