### PR TITLE
Set _isBotInitializing if randomBotAutologin=0

### DIFF
--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -164,7 +164,10 @@ RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
         sPlayerbotCommandServer->Start();
         PrepareTeleportCache();
     }
-
+    if (!sPlayerbotAIConfig->randomBotAutologin)
+    {
+        setBotInitializing(false);
+    }
     BattlegroundData.clear();
 
     BgCheckTimer = 0;


### PR DESCRIPTION
Fix altbot long action interval when randomBotAutologin=0. (_isBotInitializing is always set to true)