### PR TITLE
[performance] bots scale idle fix

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -728,7 +728,7 @@ AiPlayerbot.FastReactInBG = 1
 #
 
 # All In seconds
-AiPlayerbot.RandomBotUpdateInterval = 1
+AiPlayerbot.RandomBotUpdateInterval = 20
 AiPlayerbot.RandomBotCountChangeMinInterval = 1800
 AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 AiPlayerbot.MinRandomBotInWorldTime = 3600

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -580,6 +580,7 @@ private:
 
     void HandleCommands();
     void HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);
+    bool _isBotInitializing = true;
 
 protected:
     Player* bot;

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -241,30 +241,6 @@ enum class GuilderType : uint8
     VERY_LARGE = 250
 };
 
-enum class ActivePiorityType : uint8
-{
-    IS_REAL_PLAYER = 0,
-    HAS_REAL_PLAYER_MASTER = 1,
-    IN_GROUP_WITH_REAL_PLAYER = 2,
-    IN_INSTANCE = 3,
-    IS_ALWAYS_ACTIVE = 4,
-    IN_COMBAT = 5,
-    IN_BG_QUEUE = 6,
-    IN_LFG = 7,
-    IN_REACT_DISTANCE = 8,
-    NEARBY_PLAYER_300 = 9,
-    NEARBY_PLAYER_600 = 10,
-    NEARBY_PLAYER_900 = 11,
-    PLAYER_FRIEND = 12,
-    PLAYER_GUILD = 13,
-    IN_VERY_ACTIVE_AREA = 14,
-    IN_ACTIVE_MAP = 15,
-    IN_NOT_ACTIVE_MAP = 16,
-    IN_EMPTY_SERVER = 17,
-    ALLOWED_PARTY_ACTIVITY = 18,
-    DEFAULT
-};
-
 enum ActivityType
 {
     GRIND_ACTIVITY = 1,
@@ -274,8 +250,8 @@ enum ActivityType
     PACKET_ACTIVITY = 5,
     DETAILED_MOVE_ACTIVITY = 6,
     PARTY_ACTIVITY = 7,
-    REACT_ACTIVITY = 8,
-    ALL_ACTIVITY = 9,
+    ALL_ACTIVITY = 8,
+
     MAX_ACTIVITY_TYPE
 };
 
@@ -549,10 +525,9 @@ public:
     bool HasPlayerNearby(WorldPosition* pos, float range = sPlayerbotAIConfig->reactDistance);
     bool HasPlayerNearby(float range = sPlayerbotAIConfig->reactDistance);
     bool HasManyPlayersNearby(uint32 trigerrValue = 20, float range = sPlayerbotAIConfig->sightDistance);
-    ActivePiorityType GetPriorityType(ActivityType activityType);
     bool AllowActive(ActivityType activityType);
     bool AllowActivity(ActivityType activityType = ALL_ACTIVITY, bool checkNow = false);
-    uint32 SmartScaleActivity(ActivePiorityType type, uint32 botActiveAlonePerc);
+    uint32 AutoScaleActivity(uint32 mod);
 
     // Check if player is safe to use.
     bool IsSafe(Player* player);
@@ -579,7 +554,6 @@ public:
     void ResetJumpDestination() { jumpDestination = Position(); }
 
     bool CanMove();
-    bool IsTaxiFlying();
     bool IsInRealGuild();
     static std::vector<std::string> dispel_whitelist;
     bool EqualLowercaseName(std::string s1, std::string s2);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -156,7 +156,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotAutologin = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotAutologin", true);
     minRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBots", 50);
     maxRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBots", 200);
-    randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 1);
+    randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 20);
     randomBotCountChangeMinInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMinInterval", 30 * MINUTE);
     randomBotCountChangeMaxInterval =

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -26,6 +26,7 @@
 #include "RandomPlayerbotMgr.h"
 #include "ScriptMgr.h"
 #include "cs_playerbots.h"
+#include "cmath"
 
 class PlayerbotsDatabaseScript : public DatabaseScript
 {
@@ -96,6 +97,16 @@ public:
         {
             sPlayerbotsMgr->AddPlayerbotData(player, false);
             sRandomPlayerbotMgr->OnPlayerLogin(player);
+
+            if (sPlayerbotAIConfig->enabled || sPlayerbotAIConfig->randomBotAutologin)
+            {
+                std::string roundedTime =
+                    std::to_string(std::ceil((sPlayerbotAIConfig->maxRandomBots * 0.13 / 60) * 10) / 10.0);
+                roundedTime = roundedTime.substr(0, roundedTime.find('.') + 2);
+
+                ChatHandler(player->GetSession()).SendSysMessage(
+                    "Playerbots: bot initialization at server startup will require '" + roundedTime + "' minutes.");
+            }
         }
     }
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -40,7 +40,6 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "World.h"
-#include "GameTime.h"
 
 void PrintStatsThread() { sRandomPlayerbotMgr->PrintStats(); }
 
@@ -296,6 +295,15 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
     if (!sPlayerbotAIConfig->randomBotAutologin || !sPlayerbotAIConfig->enabled)
         return;
 
+    /*if (sPlayerbotAIConfig->enablePrototypePerformanceDiff)
+    {
+        LOG_INFO("playerbots", "---------------------------------------");
+        LOG_INFO("playerbots",
+                 "PROTOTYPE: Playerbot performance enhancements are active. Issues and instability may occur.");
+        LOG_INFO("playerbots", "---------------------------------------");
+        ScaleBotActivity();
+    }*/
+
     uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
     if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig->minRandomBots ||
                                 maxAllowedBotCount > sPlayerbotAIConfig->maxRandomBots))
@@ -313,17 +321,11 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
 
     uint32 onlineBotFocus = 75;
     if (onlineBotCount < (uint32)(sPlayerbotAIConfig->minRandomBots * 90 / 100))
-    {
         onlineBotFocus = 25;
-    }
-
-    setBotInitializing(
-        //onlineBotCount < maxAllowedBotCount && <-- these fields are incorrect when using bot amount min/max are not equal.
-        GameTime::GetUptime().count() < sPlayerbotAIConfig->maxRandomBots * 0.12);
 
     // when server is balancing bots then boost (decrease value of) the nextCheckDelay till
     // onlineBotCount reached the AllowedBotCount.
-    uint32 updateIntervalTurboBoost = isBotInitializing() ? 1 : sPlayerbotAIConfig->randomBotUpdateInterval;
+    uint32 updateIntervalTurboBoost = onlineBotCount < maxAllowedBotCount ? 1 : sPlayerbotAIConfig->randomBotUpdateInterval;
     SetNextCheckDelay(updateIntervalTurboBoost * (onlineBotFocus + 25) * 10);
 
     PerformanceMonitorOperation* pmo = sPerformanceMonitor->start(
@@ -406,6 +408,26 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
         LogPlayerLocation();
     }
 }
+
+//void RandomPlayerbotMgr::ScaleBotActivity()
+//{
+//    float activityPercentage = getActivityPercentage();
+//
+//    // if (activityPercentage >= 100.0f || activityPercentage <= 0.0f) pid.reset(); //Stop integer buildup during
+//    // max/min activity
+//
+//    //    % increase/decrease                   wanted diff                                         , avg diff
+//    float activityPercentageMod = pid.calculate(
+//        sRandomPlayerbotMgr->GetPlayers().empty() ? sPlayerbotAIConfig->diffEmpty : sPlayerbotAIConfig->diffWithPlayer,
+//        sWorldUpdateTime.GetAverageUpdateTime());
+//
+//    activityPercentage = activityPercentageMod + 50;
+//
+//    // Cap the percentage between 0 and 100.
+//    activityPercentage = std::max(0.0f, std::min(100.0f, activityPercentage));
+//
+//    setActivityPercentage(activityPercentage);
+//}
 
 uint32 RandomPlayerbotMgr::AddRandomBots()
 {
@@ -996,7 +1018,6 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
     if (isLogginIn)
         return false;
 
-    
     uint32 randomTime;
     if (!player)
     {
@@ -1004,21 +1025,23 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         randomTime = urand(1, 2);
         SetEventValue(bot, "login", 1, randomTime);
 
-        uint32 updateIntervalTurboBoost = isBotInitializing() ? 1 : sPlayerbotAIConfig->randomBotUpdateInterval;
-        randomTime = urand(std::max(5, static_cast<int>(updateIntervalTurboBoost * 0.5)),
-                        std::max(12, static_cast<int>(updateIntervalTurboBoost * 2)));
+        randomTime = urand(
+            std::max(5, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 0.5)),
+            std::max(12, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 2)));
         SetEventValue(bot, "update", 1, randomTime);
 
         // do not randomize or teleport immediately after server start (prevent lagging)
         if (!GetEventValue(bot, "randomize"))
         {
-            randomTime = urand(3, std::max(4, static_cast<int>(updateIntervalTurboBoost * 0.4)));
+            randomTime = urand(
+                3,std::max(4, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 0.4)));
             ScheduleRandomize(bot, randomTime);
         }
         if (!GetEventValue(bot, "teleport"))
         {
-            randomTime = urand(std::max(7, static_cast<int>(updateIntervalTurboBoost * 0.7)),
-                            std::max(14, static_cast<int>(updateIntervalTurboBoost * 1.4)));
+            randomTime = urand(
+                std::max(7, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 0.7)),
+                std::max(14, static_cast<int>(sPlayerbotAIConfig->randomBotUpdateInterval * 1.4)));
             ScheduleTeleport(bot, randomTime);
         }
 
@@ -1088,9 +1111,6 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
 
 bool RandomPlayerbotMgr::ProcessBot(Player* player)
 {
-    if (!player || !player->IsInWorld() || player->IsBeingTeleported() || player->GetSession()->isLogingOut())
-        return false;
-
     uint32 bot = player->GetGUID().GetCounter();
 
     if (player->InBattleground())
@@ -1245,7 +1265,9 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
     if (botAI)
     {              
         // ignore when in when taxi with boat/zeppelin and has players nearby
-        if (botAI->IsTaxiFlying() && botAI->HasPlayerNearby())
+        if (bot->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && 
+                bot->HasUnitState(UNIT_STATE_IGNORE_PATHFINDING) && 
+                    botAI->HasPlayerNearby())
             return;
     }
 

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -178,6 +178,7 @@ private:
     // pid values are set in constructor
     botPID pid = botPID(1, 50, -50, 0, 0, 0);
     float activityMod = 0.25;
+    bool _isBotInitializing = true;
     uint32 GetEventValue(uint32 bot, std::string const event);
     std::string const GetEventData(uint32 bot, std::string const event);
     uint32 SetEventValue(uint32 bot, std::string const event, uint32 value, uint32 validIn,

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -103,7 +103,8 @@ public:
     void LogPlayerLocation();
     void UpdateAIInternal(uint32 elapsed, bool minimal = false) override;
 
-//private:
+private:
+    //void ScaleBotActivity();
 
 public:
     uint32 activeBots = 0;
@@ -163,10 +164,10 @@ public:
         return BattleMastersCache;
     }
 
+    float getActivityMod() { return activityMod; }
+    float getActivityPercentage() { return activityMod * 100.0f; }
+    void setActivityPercentage(float percentage) { activityMod = percentage / 100.0f; }
     static uint8 GetTeamClassIdx(bool isAlliance, uint8 claz) { return isAlliance * 20 + claz; }
-
-    bool isBotInitializing() const { return _isBotInitializing; }
-    void setBotInitializing(bool completed) { _isBotInitializing = completed; }
 
     void PrepareAddclassCache();
     std::map<uint8, std::vector<ObjectGuid>> addclassCache;
@@ -176,7 +177,7 @@ protected:
 private:
     // pid values are set in constructor
     botPID pid = botPID(1, 50, -50, 0, 0, 0);
-    bool _isBotInitializing = true;
+    float activityMod = 0.25;
     uint32 GetEventValue(uint32 bot, std::string const event);
     std::string const GetEventData(uint32 bot, std::string const event);
     uint32 SetEventValue(uint32 bot, std::string const event, uint32 value, uint32 validIn,


### PR DESCRIPTION
Rebuild the scaling logic, tested with various hardware and config setups with rotationBots, without rotationBots, min/max equal and not equals. 10, 50, 2000, 4000, 5000 bots. 

1. idle bots 'fix'
2. gentle scaling when performance is on expected levels
3. hard scaling when performance isnt sufficient
4. init phase;  seperated allowedActive and login and first randomize and teleport boosters
5. init phase; added system call for expected init time of bots.
6. pushed the updateInterval back to 20 and compensated with booters to temporary lowering it for the init phase.