### PR TITLE
Handle bot gear upgrades for multi-slot items

### DIFF
--- a/src/strategy/actions/EquipAction.cpp
+++ b/src/strategy/actions/EquipAction.cpp
@@ -88,7 +88,7 @@ void EquipAction::EquipItem(Item* item)
 
         if (!equippedBag)
         {
-            uint8 dstSlot = botAI->FindEquipSlot(item->GetTemplate(), NULL_SLOT, true);
+            uint8 dstSlot = botAI->FindEquipSlot(itemProto, NULL_SLOT, true);
             if (dstSlot == EQUIPMENT_SLOT_FINGER1 ||
                 dstSlot == EQUIPMENT_SLOT_TRINKET1 ||
                 dstSlot == EQUIPMENT_SLOT_MAINHAND)


### PR DESCRIPTION
Switch to using opcode "CMSG_AUTOEQUIP_ITEM_SLOT" to equip items to specific slots, rather than "right clicking" item upgrades using "CMSG_AUTOEQUIP_ITEM".
Fixes an issue with rings, trinkets and offhand weapons where the bot would only ever upgrade their first slot.

Also evaluate the above item types for equipping in both slots rather than just comparing to the first item.

Have tested with a range of rings of different itemlevels, as well as fury warrior (titan's grip) and rogue with daggers.