### PR TITLE
Dual-wield item comparison fixes

### DIFF
--- a/src/strategy/actions/EquipAction.cpp
+++ b/src/strategy/actions/EquipAction.cpp
@@ -89,9 +89,21 @@ void EquipAction::EquipItem(Item* item)
         if (!equippedBag)
         {
             uint8 dstSlot = botAI->FindEquipSlot(itemProto, NULL_SLOT, true);
+            bool have2HWeapon = false;
+            bool isValidTGWeapon = false;
+            if (dstSlot == EQUIPMENT_SLOT_MAINHAND)
+            {
+                Item* currentWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                have2HWeapon = currentWeapon && currentWeapon->GetTemplate()->InventoryType == INVTYPE_2HWEAPON;
+                isValidTGWeapon = itemProto->SubClass == ITEM_SUBCLASS_WEAPON_AXE2 ||
+                                  itemProto->SubClass == ITEM_SUBCLASS_WEAPON_MACE2 ||
+                                  itemProto->SubClass == ITEM_SUBCLASS_WEAPON_SWORD2;
+            }
+            
             if (dstSlot == EQUIPMENT_SLOT_FINGER1 ||
                 dstSlot == EQUIPMENT_SLOT_TRINKET1 ||
-                dstSlot == EQUIPMENT_SLOT_MAINHAND)
+                (dstSlot == EQUIPMENT_SLOT_MAINHAND && bot->CanDualWield() &&
+                    ((itemProto->InventoryType != INVTYPE_2HWEAPON && !have2HWeapon) || (bot->CanTitanGrip() && isValidTGWeapon))))
             {
                 Item* const equippedItems[2] = {
                     bot->GetItemByPos(INVENTORY_SLOT_BAG_0, dstSlot),

--- a/src/strategy/actions/EquipAction.cpp
+++ b/src/strategy/actions/EquipAction.cpp
@@ -88,7 +88,7 @@ void EquipAction::EquipItem(Item* item)
 
         if (!equippedBag)
         {
-            uint8 dstSlot = botAI->FindEquipSlot(item->GetTemplate(), NULL_SLOT, true);
+            uint8 dstSlot = botAI->FindEquipSlot(itemProto, NULL_SLOT, true);
             if (dstSlot == EQUIPMENT_SLOT_FINGER1 ||
                 dstSlot == EQUIPMENT_SLOT_TRINKET1 ||
                 dstSlot == EQUIPMENT_SLOT_MAINHAND)

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -207,11 +207,26 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto)
 
     uint8 possibleSlots = 1;
     uint8 dstSlot = botAI->FindEquipSlot(itemProto, NULL_SLOT, true);
-    if (dstSlot == EQUIPMENT_SLOT_FINGER1 ||
-        dstSlot == EQUIPMENT_SLOT_TRINKET1 ||
-        dstSlot == EQUIPMENT_SLOT_MAINHAND)
+    if (dstSlot == EQUIPMENT_SLOT_FINGER1 || dstSlot == EQUIPMENT_SLOT_TRINKET1)
     {
         possibleSlots = 2;
+    }
+
+    // Check weapon case separately to keep things a bit cleaner
+    bool have2HWeapon = false;
+    bool isValidTGWeapon = false;
+    if (dstSlot == EQUIPMENT_SLOT_MAINHAND)
+    {
+        Item* currentWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+        have2HWeapon = currentWeapon && currentWeapon->GetTemplate()->InventoryType == INVTYPE_2HWEAPON;
+        isValidTGWeapon = itemProto->SubClass == ITEM_SUBCLASS_WEAPON_AXE2 ||
+                          itemProto->SubClass == ITEM_SUBCLASS_WEAPON_MACE2 ||
+                          itemProto->SubClass == ITEM_SUBCLASS_WEAPON_SWORD2;
+        
+        if (bot->CanDualWield() && ((itemProto->InventoryType != INVTYPE_2HWEAPON && !have2HWeapon) || (bot->CanTitanGrip() && isValidTGWeapon)))
+        {
+            possibleSlots = 2;
+        }
     }
 
     for (uint8 i = 0; i < possibleSlots; i++)


### PR DESCRIPTION
Fix issue in #695:
- Casters will no longer try and equip items in offhand when using a 2h weapon eg. staff

Code is a bit messy and there are a number of bugs:
- Bots will not shuffle around upgrades all in one action - if you are trying to upgrade multiple slots at once, you may need to do these one at a time.
- In my testing with various item tiers on a mage, some blue items were being preferred over some early Naxx epics. From what I could tell, this was because the 1h caster sword had a slightly higher physical dps than the naxx caster item, which is obviously meaningless for a mage. This is not caused by this PR, but rather an existing issue with how items are evaluated and scored
- Titan's Grip warriors will not equip their offhands correctly immediately after learning Titan's Grip and require a relog. This is likely due to the character data being commited to the db on logout.
- Attackers who can use 2h but prefer to DW may not gear correctly (enh shaman or fury warrior pre-TG), especially if they start with a 2h and continue upgrading it, as any 1h weapon will likely not out-score their 2h.
- Casters have a similar issue - if a caster currently has an average 2h staff and acquires a better 1h weapon, they will likely not equip it as it doesn't "beat" the staff on it's own. The bot doesn't really factor in the combined stats from the OH I don't think - this becomes even more complex when the bot doesn't have a OH to pair with the 1h weapon.
- Trinkets do not seem to be evaluated properly or at all

Most of these are greater issues with the bot gearing process and will need to be resolved separately. This PR should at least fix the immediate issues mentioned in #695.