### PR TITLE
[performance] enable autoscale by default again on top of latest changes

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1454,13 +1454,16 @@ AiPlayerbot.RandombotsWalkingRPG = 0
 AiPlayerbot.RandombotsWalkingRPG.InDoors = 0
 
 # Specify percent of active bots
-# The default is 10. With 10% of all bots going active or inactive each minute.
+# The default is 10. With 10% of all bots going active or inactive each minute. Regardless
+# This value is only applied to inactive areas where no real-players are detected, when
+# real-players are nearby, friend, group, guild, bg, instances etc the value is always
+# enforced to 100%
 AiPlayerbot.BotActiveAlone = 100
 
 # Specify smart scaling is enabled or not.
 # The default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
 # Only when botLevel is between WhenMinLevel and WhenMaxLevel.
-AiPlayerbot.botActiveAloneSmartScale = 0
+AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -465,7 +465,7 @@ bool PlayerbotAIConfig::Initialize()
     playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
-    botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 0);
+    botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
     botActiveAloneSmartScaleWhenMinLevel =
         sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
     botActiveAloneSmartScaleWhenMaxLevel =


### PR DESCRIPTION
Follow-up for #709

Bots in group with real players, friends, guilds, instances, bg, bgqueue, 300yard will are always enforced at 100% only the 
wandering bots in inactive areas are effected by the botAloneActivity value. This always has been a case.

Ive added friends, guilds and zones where real players. Ive been running 5k bots server for a while now with these settings giving the expected and wanted results out of the box. The other options obviously gives room to enforce activity which is most cases is not needed at all since the autoscale is actually working as intended now.