### PR TITLE
Fixed issue with random bots not respecting RandomBotFixedLevel

### DIFF
--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2248,7 +2248,7 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
     {
         bot->SetPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
     }
-    else if (!sPlayerbotAIConfig->randomBotFixedLevel)
+    else
     {
         bot->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
     }

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2243,6 +2243,15 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
 {
     LOG_INFO("playerbots", "{}/{} Bot {} logged in", playerBots.size(), sRandomPlayerbotMgr->GetMaxAllowedBotCount(),
              bot->GetName().c_str());
+    
+    if (sPlayerbotAIConfig->randomBotFixedLevel)
+    {
+        bot->SetPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
+    }
+    else if (!sPlayerbotAIConfig->randomBotFixedLevel)
+    {
+        bot->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
+    }
 }
 
 void RandomPlayerbotMgr::OnPlayerLogin(Player* player)


### PR DESCRIPTION
#713

Added check during random bot login for `RandomBotFixedLevel`, set `PLAYER_FLAGS_NO_XP_GAIN` if the config option is found, remove flag if it is not.