### PR TITLE
Fix bots dropping quests that are green

### DIFF
--- a/src/strategy/actions/DropQuestAction.cpp
+++ b/src/strategy/actions/DropQuestAction.cpp
@@ -118,7 +118,7 @@ bool CleanQuestLogAction::Execute(Event event)
         }
 
         // Check if the quest is trivial (grey) for the bot
-        if ((botLevel - questLevel) >= trivialLevel)
+        if ((botLevel - questLevel) > trivialLevel)
         {
             // Output only if "debug rpg" strategy is enabled
             if (botAI->HasStrategy("debug rpg", BotState::BOT_STATE_COMBAT))


### PR DESCRIPTION
This needs testing in the lower levels but at 40 and above they should no longer drop quests that actually are green.

I've tested this at level 80 with green quests, the bots were dropping them whenever I accepted them while farming reputation, but as soon as I changed this they stopped doing that.