### PR TITLE
Fix print about invalid format

### DIFF
--- a/src/strategy/actions/AcceptQuestAction.cpp
+++ b/src/strategy/actions/AcceptQuestAction.cpp
@@ -17,8 +17,8 @@ bool AcceptAllQuestsAction::ProcessQuest(Quest const* quest, Object* questGiver)
 
     if (botAI->HasStrategy("debug quest", BotState::BOT_STATE_NON_COMBAT) || botAI->HasStrategy("debug rpg", BotState::BOT_STATE_COMBAT))
     {
-        LOG_INFO("playerbots", "{} => Quest [ {} ] accepted", bot->GetName(), quest->GetTitle());
-        bot->Say("Quest [ " + text_quest + " ] accepted", LANG_UNIVERSAL);
+        LOG_INFO("playerbots", "{} => Quest [{}] accepted", bot->GetName(), quest->GetTitle());
+        bot->Say("Quest [" + text_quest + "] accepted", LANG_UNIVERSAL);
     }
 
     return true;
@@ -86,7 +86,7 @@ bool AcceptQuestAction::Execute(Event event)
     if (hasAccept)
     {
         std::stringstream ss;
-        ss << "AcceptQuestAction {" << qInfo->GetTitle() << "} - {" << std::to_string(qInfo->GetQuestId()) << "}";
+        ss << "AcceptQuestAction [" << qInfo->GetTitle() << "] - [" << std::to_string(qInfo->GetQuestId()) << "]";
         LOG_INFO("playerbots", "{}", ss.str().c_str());
         // botAI->TellMaster(ss.str());
     }


### PR DESCRIPTION
Replaced curly brackets with square brackets to silence a warning/error printed to the console when a bot accepts a quest.
Removed some empty spaces between the brackets and the name of a quest to match what the rest of the quest-related code prints.