### PR TITLE
Add a config option for dropping obsolete quests

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -368,6 +368,10 @@ AiPlayerbot.SyncQuestWithPlayer = 1
 # Default: 0 (disabled)
 AiPlayerbot.SyncQuestForPlayer = 0
 
+# Bots will drop obsolete quests
+# Default: 1 (enabled)
+AiPlayerbot.DropObsoleteQuests = 1
+
 #
 #
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -491,6 +491,7 @@ bool PlayerbotAIConfig::Initialize()
     twoRoundsGearInit = sConfigMgr->GetOption<bool>("AiPlayerbot.TwoRoundsGearInit", false);
     syncQuestWithPlayer = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncQuestWithPlayer", true);
     syncQuestForPlayer = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncQuestForPlayer", false);
+    dropObsoleteQuests = sConfigMgr->GetOption<bool>("AiPlayerbot.DropObsoleteQuests", true);
     autoTrainSpells = sConfigMgr->GetOption<std::string>("AiPlayerbot.AutoTrainSpells", "yes");
     autoPickTalents = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoPickTalents", true);
     autoUpgradeEquip = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoUpgradeEquip", false);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -275,6 +275,7 @@ public:
     bool twoRoundsGearInit;
     bool syncQuestWithPlayer;
     bool syncQuestForPlayer;
+    bool dropObsoleteQuests;
     std::string autoTrainSpells;
     bool autoPickTalents;
     bool autoUpgradeEquip;

--- a/src/strategy/actions/DropQuestAction.cpp
+++ b/src/strategy/actions/DropQuestAction.cpp
@@ -68,6 +68,11 @@ bool CleanQuestLogAction::Execute(Event event)
         return false;
     }
 
+    if (!sPlayerbotAIConfig->dropObsoleteQuests)
+    {
+        return false;
+    }
+
     // Only output this message if "debug rpg" strategy is enabled
     if (botAI->HasStrategy("debug rpg", BotState::BOT_STATE_COMBAT))
     {


### PR DESCRIPTION
This needs testing and I don't have the time to do it right now. Until that has been done it shouldn't be merged.

I decided not to add a print when the option is disabled since it runs every so often and it would most likely get very annoying.

This is helpful when completing quests for reputation and so on. The quests are often grey/gray when doing it and they'll constantly drop them unless it's possible to disable it.