### PR TITLE
Change statement to a newly created one

### DIFF
--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -52,7 +52,7 @@ public:
 
     void OnDatabaseSelectIndexLogout(Player* player, uint32& statementIndex, uint32& statementParam) override
     {
-        statementIndex = CHAR_UPD_CHAR_ONLINE;
+        statementIndex = CHAR_UPD_CHAR_OFFLINE;
         statementParam = player->GetGUID().GetCounter();
     }
 


### PR DESCRIPTION
Added a new statement to the core to properly update the online status of players and bots when they log out.

This cannot be merged before the PR for the core is. It will produce compiler errors otherwise.

All the credit goes to @locchi93 for figuring this out and providing the simplest (and best) solution to the problem.