### PR TITLE
Obsidian Sanctum implementation

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -1603,6 +1603,9 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         case 608:
             strategyName = "wotlk-vh";      // Violet Hold
             break;
+        case 615:
+            strategyName = "wotlk-os";      // Obsidian Sanctum
+            break;
         case 619:
             strategyName = "wotlk-ok";      // Ahn'kahet: The Old Kingdom
             break;

--- a/src/strategy/AiObjectContext.cpp
+++ b/src/strategy/AiObjectContext.cpp
@@ -24,6 +24,8 @@
 #include "raids/blackwinglair/RaidBwlTriggerContext.h"
 #include "raids/naxxramas/RaidNaxxActionContext.h"
 #include "raids/naxxramas/RaidNaxxTriggerContext.h"
+#include "raids/obsidiansanctum/RaidOsActionContext.h"
+#include "raids/obsidiansanctum/RaidOsTriggerContext.h"
 #include "raids/moltencore/RaidMcActionContext.h"
 #include "raids/moltencore/RaidMcTriggerContext.h"
 #include "raids/aq20/RaidAq20ActionContext.h"
@@ -48,6 +50,7 @@ AiObjectContext::AiObjectContext(PlayerbotAI* botAI) : PlayerbotAIAware(botAI)
     actionContexts.Add(new RaidBwlActionContext());
     actionContexts.Add(new RaidAq20ActionContext());
     actionContexts.Add(new RaidNaxxActionContext());
+    actionContexts.Add(new RaidOsActionContext());
     actionContexts.Add(new RaidUlduarActionContext());
     actionContexts.Add(new RaidIccActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
@@ -71,6 +74,7 @@ AiObjectContext::AiObjectContext(PlayerbotAI* botAI) : PlayerbotAIAware(botAI)
     triggerContexts.Add(new RaidBwlTriggerContext());
     triggerContexts.Add(new RaidAq20TriggerContext());
     triggerContexts.Add(new RaidNaxxTriggerContext());
+    triggerContexts.Add(new RaidOsTriggerContext());
     triggerContexts.Add(new RaidUlduarTriggerContext());
     triggerContexts.Add(new RaidIccTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());

--- a/src/strategy/raids/RaidStrategyContext.h
+++ b/src/strategy/raids/RaidStrategyContext.h
@@ -5,6 +5,7 @@
 #include "Strategy.h"
 #include "RaidBwlStrategy.h"
 #include "RaidNaxxStrategy.h"
+#include "RaidOsStrategy.h"
 #include "RaidMcStrategy.h"
 #include "RaidAq20Strategy.h"
 #include "RaidIccStrategy.h"
@@ -21,6 +22,7 @@ public:
         creators["bwl"] = &RaidStrategyContext::bwl;
         creators["aq20"] = &RaidStrategyContext::aq20;
         creators["naxx"] = &RaidStrategyContext::naxx;
+        creators["wotlk-os"] = &RaidStrategyContext::wotlk_os;
         creators["uld"] = &RaidStrategyContext::uld;
         creators["icc"] = &RaidStrategyContext::icc;
     }
@@ -30,6 +32,7 @@ private:
     static Strategy* bwl(PlayerbotAI* botAI) { return new RaidBwlStrategy(botAI); }
     static Strategy* aq20(PlayerbotAI* botAI) { return new RaidAq20Strategy(botAI); }
     static Strategy* naxx(PlayerbotAI* botAI) { return new RaidNaxxStrategy(botAI); }
+    static Strategy* wotlk_os(PlayerbotAI* botAI) { return new RaidOsStrategy(botAI); }
     static Strategy* uld(PlayerbotAI* botAI) { return new RaidUlduarStrategy(botAI); }
     static Strategy* icc(PlayerbotAI* botAI) { return new RaidIccStrategy(botAI); }
 };

--- a/src/strategy/raids/obsidiansanctum/RaidOsActionContext.h
+++ b/src/strategy/raids/obsidiansanctum/RaidOsActionContext.h
@@ -1,0 +1,30 @@
+#ifndef _PLAYERBOT_RAIDOSACTIONCONTEXT_H
+#define _PLAYERBOT_RAIDOSACTIONCONTEXT_H
+
+#include "Action.h"
+#include "NamedObjectContext.h"
+#include "RaidOsActions.h"
+
+class RaidOsActionContext : public NamedObjectContext<Action>
+{
+public:
+    RaidOsActionContext()
+    {
+        creators["sartharion tank position"] = &RaidOsActionContext::tank_position;
+        creators["avoid twilight fissure"] = &RaidOsActionContext::avoid_twilight_fissure;
+        creators["avoid flame tsunami"] = &RaidOsActionContext::avoid_flame_tsunami;
+        creators["sartharion attack priority"] = &RaidOsActionContext::attack_priority;
+        creators["enter twilight portal"] = &RaidOsActionContext::enter_twilight_portal;
+        creators["exit twilight portal"] = &RaidOsActionContext::exit_twilight_portal;
+    }
+
+private:
+    static Action* tank_position(PlayerbotAI* ai) { return new SartharionTankPositionAction(ai); }
+    static Action* avoid_twilight_fissure(PlayerbotAI* ai) { return new AvoidTwilightFissureAction(ai); }
+    static Action* avoid_flame_tsunami(PlayerbotAI* ai) { return new AvoidFlameTsunamiAction(ai); }
+    static Action* attack_priority(PlayerbotAI* ai) { return new SartharionAttackPriorityAction(ai); }
+    static Action* enter_twilight_portal(PlayerbotAI* ai) { return new EnterTwilightPortalAction(ai); }
+    static Action* exit_twilight_portal(PlayerbotAI* ai) { return new ExitTwilightPortalAction(ai); }
+};
+
+#endif

--- a/src/strategy/raids/obsidiansanctum/RaidOsActions.cpp
+++ b/src/strategy/raids/obsidiansanctum/RaidOsActions.cpp
@@ -1,0 +1,246 @@
+#include "RaidOsActions.h"
+#include "RaidOsTriggers.h"
+
+#include "Playerbots.h"
+
+bool SartharionTankPositionAction::Execute(Event event)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+
+    // Unit* shadron = AI_VALUE2(Unit*, "find target", "shadron");
+    // Unit* tenebron = AI_VALUE2(Unit*, "find target", "tenebron");
+    // Unit* vesperon = AI_VALUE2(Unit*, "find target", "vesperon");
+    Unit* shadron = nullptr;
+    Unit* tenebron = nullptr;
+    Unit* vesperon = nullptr;
+
+    // Detect incoming drakes before they are on aggro table
+    GuidVector targets = AI_VALUE(GuidVector, "possible targets no los");
+    for (auto& target : targets)
+    {
+        Unit* unit = botAI->GetUnit(target);
+        if (!unit) { continue; }
+
+        switch (unit->GetEntry())
+        {
+            case NPC_SHADRON:
+                shadron = unit;
+                continue;
+            case NPC_TENEBRON:
+                tenebron = unit;
+                continue;
+            case NPC_VESPERON:
+                vesperon = unit;
+                continue;
+            default:
+                continue;
+        }
+    }
+
+    Position currentPos = bot->GetPosition();
+    // Adjustable, this is the acceptable distance to stack point that will be accepted as "safe"
+    float looseDistance = 12.0f;
+
+    if (botAI->IsMainTank(bot))
+    {
+        if (bot->GetExactDist2d(SARTHARION_MAINTANK_POSITION.first, SARTHARION_MAINTANK_POSITION.second) > looseDistance)
+        {
+            return MoveTo(OS_MAP_ID, SARTHARION_MAINTANK_POSITION.first, SARTHARION_MAINTANK_POSITION.second, currentPos.GetPositionZ(),
+                false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+        }
+    }
+    // Offtank grab drakes
+    else if (shadron || tenebron || vesperon)
+    {
+        float triggerDistance = 100.0f;
+        // Prioritise threat before positioning
+        if (tenebron && bot->GetExactDist2d(tenebron) < triggerDistance &&
+            tenebron->GetTarget() != bot->GetGUID() && AI_VALUE(Unit*, "current target") != tenebron)
+        {
+            return Attack(tenebron);
+        }
+        if (shadron && bot->GetExactDist2d(shadron) < triggerDistance &&
+            shadron->GetTarget() != bot->GetGUID() && AI_VALUE(Unit*, "current target") != shadron)
+        {
+            return Attack(shadron);
+        }
+        if (vesperon && bot->GetExactDist2d(vesperon) < triggerDistance &&
+            vesperon->GetTarget() != bot->GetGUID() && AI_VALUE(Unit*, "current target") != vesperon)
+        {
+            return Attack(vesperon);
+        }
+
+        bool drakeInCombat = (tenebron && bot->GetExactDist2d(tenebron) < triggerDistance) ||
+                                (shadron && bot->GetExactDist2d(shadron) < triggerDistance) ||
+                                (vesperon && bot->GetExactDist2d(vesperon) < triggerDistance);
+        // Offtank has threat on drakes, check positioning
+        if (drakeInCombat && bot->GetExactDist2d(SARTHARION_OFFTANK_POSITION.first, SARTHARION_OFFTANK_POSITION.second) > looseDistance)
+        {
+            return MoveTo(OS_MAP_ID, SARTHARION_OFFTANK_POSITION.first, SARTHARION_OFFTANK_POSITION.second, currentPos.GetPositionZ(),
+                false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+        }
+    }
+    return false;
+}
+
+bool AvoidTwilightFissureAction::Execute(Event event)
+{
+    const float radius = 5.0f;
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit && unit->GetEntry() == NPC_TWILIGHT_FISSURE)
+        {
+            float currentDistance = bot->GetDistance2d(unit);
+            if (currentDistance < radius)
+            {
+                return MoveAway(unit, radius - currentDistance);
+            }
+        }
+    }
+    return false;
+}
+
+bool AvoidFlameTsunamiAction::Execute(Event event)
+{
+    // Adjustable, this is the acceptable distance to stack point that will be accepted as "safe"
+    float looseDistance = 4.0f;
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit && unit->GetEntry() == NPC_FLAME_TSUNAMI)
+        {
+            Position currentPos = bot->GetPosition();
+
+            // I think these are centrepoints for the wave segments. Either way they uniquely identify the wave
+            // direction as they have different coords for the left and right waves
+            // int casting is not a mistake, need to avoid FP errors somehow.
+            // I always saw these accurate to around 6 decimal places, but if there are issues,
+            // can switch this to abs comparison of floats which would technically be more robust.
+            int posY = (int) unit->GetPositionY();
+            if (posY == 505 || posY == 555)     // RIGHT WAVE
+            {
+                bool wavePassed = currentPos.GetPositionX() > unit->GetPositionX();
+                if (wavePassed)
+                {
+                    return false;
+                }
+
+                if (bot->GetExactDist2d(currentPos.GetPositionX(), TSUNAMI_RIGHT_SAFE_ALL) > looseDistance)
+                {
+                    return MoveTo(OS_MAP_ID, currentPos.GetPositionX(), TSUNAMI_RIGHT_SAFE_ALL, currentPos.GetPositionZ(),
+                        false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+                }
+            }
+            else    // LEFT WAVE
+            {
+                bool wavePassed = currentPos.GetPositionX() < unit->GetPositionX();
+                if (wavePassed)
+                {
+                    return false;
+                }
+
+                if (botAI->IsMelee(bot))
+                {
+                    if (bot->GetExactDist2d(currentPos.GetPositionX(), TSUNAMI_LEFT_SAFE_MELEE) > looseDistance)
+                    {
+                        return MoveTo(OS_MAP_ID, currentPos.GetPositionX(), TSUNAMI_LEFT_SAFE_MELEE, currentPos.GetPositionZ(),
+                            false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+                    }
+                }
+                else    // Ranged/healers
+                {
+                    if (bot->GetExactDist2d(currentPos.GetPositionX(), TSUNAMI_LEFT_SAFE_RANGED) > looseDistance)
+                    {
+                        return MoveTo(OS_MAP_ID, currentPos.GetPositionX(), TSUNAMI_LEFT_SAFE_RANGED, currentPos.GetPositionZ(),
+                            false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+bool SartharionAttackPriorityAction::Execute(Event event)
+{
+    Unit* sartharion = AI_VALUE2(Unit*, "find target", "sartharion");
+    Unit* shadron = AI_VALUE2(Unit*, "find target", "shadron");
+    Unit* tenebron = AI_VALUE2(Unit*, "find target", "tenebron");
+    Unit* vesperon = AI_VALUE2(Unit*, "find target", "vesperon");
+    Unit* acolyte = AI_VALUE2(Unit*, "find target", "acolyte of shadron");
+
+    Unit* target = nullptr;
+
+    if (acolyte)
+    {
+        target = acolyte;
+    }
+    else if (vesperon)
+    {
+        target = vesperon;
+    }
+    else if (tenebron)
+    {
+        target = tenebron;
+    }
+    else if (shadron)
+    {
+        target = shadron;
+    }
+    else if (sartharion)
+    {
+        target = sartharion;
+    }
+
+    if (target && AI_VALUE(Unit*, "current target") != target)
+    {
+        return Attack(target);
+    }
+
+    return false;
+}
+
+bool EnterTwilightPortalAction::Execute(Event event)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss || !boss->HasAura(SPELL_GIFT_OF_TWILIGHT_FIRE)) { return false; }
+
+    GameObject* portal = bot->FindNearestGameObject(GO_TWILIGHT_PORTAL, 100.0f);
+    if (!portal) { return false; }
+
+    if (!portal->IsAtInteractDistance(bot))
+    {
+        return MoveTo(portal, fmaxf(portal->GetInteractionDistance() - 1.0f, 0.0f));
+    }
+
+    // Go through portal
+    WorldPacket data1(CMSG_GAMEOBJ_USE);
+    data1 << portal->GetGUID();
+    bot->GetSession()->HandleGameObjectUseOpcode(data1);
+
+    return true;
+}
+
+bool ExitTwilightPortalAction::Execute(Event event)
+{
+    GameObject* portal = bot->FindNearestGameObject(GO_NORMAL_PORTAL, 100.0f);
+    if (!portal) { return false; }
+
+    if (!portal->IsAtInteractDistance(bot))
+    {
+        return MoveTo(portal, fmaxf(portal->GetInteractionDistance() - 1.0f, 0.0f));
+    }
+
+    // Go through portal
+    WorldPacket data1(CMSG_GAMEOBJ_USE);
+    data1 << portal->GetGUID();
+    bot->GetSession()->HandleGameObjectUseOpcode(data1);
+
+    return true;
+}

--- a/src/strategy/raids/obsidiansanctum/RaidOsActions.h
+++ b/src/strategy/raids/obsidiansanctum/RaidOsActions.h
@@ -1,0 +1,64 @@
+#ifndef _PLAYERBOT_RAIDOSACTIONS_H
+#define _PLAYERBOT_RAIDOSACTIONS_H
+
+#include "MovementActions.h"
+#include "AttackAction.h"
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+
+const float TSUNAMI_LEFT_SAFE_MELEE = 552.0f;
+const float TSUNAMI_LEFT_SAFE_RANGED = 504.0f;
+const float TSUNAMI_RIGHT_SAFE_ALL = 529.0f;
+const std::pair<float, float> SARTHARION_MAINTANK_POSITION = {3258.5f, 532.5f};
+const std::pair<float, float> SARTHARION_OFFTANK_POSITION = {3230.0f, 526.0f};
+const std::pair<float, float> SARTHARION_RANGED_POSITION = {3248.0f, 507.0f};
+
+class SartharionTankPositionAction : public AttackAction
+{
+public:
+    SartharionTankPositionAction(PlayerbotAI* botAI, std::string const name = "sartharion tank position")
+        : AttackAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class AvoidTwilightFissureAction : public MovementAction
+{
+public:
+    AvoidTwilightFissureAction(PlayerbotAI* botAI, std::string const name = "avoid twilight fissure")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class AvoidFlameTsunamiAction : public MovementAction
+{
+public:
+    AvoidFlameTsunamiAction(PlayerbotAI* botAI, std::string const name = "avoid flame tsunami")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class SartharionAttackPriorityAction : public AttackAction
+{
+public:
+    SartharionAttackPriorityAction(PlayerbotAI* botAI, std::string const name = "sartharion attack priority")
+        : AttackAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class EnterTwilightPortalAction : public MovementAction
+{
+public:
+    EnterTwilightPortalAction(PlayerbotAI* botAI, std::string const name = "enter twilight portal")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class ExitTwilightPortalAction : public MovementAction
+{
+public:
+    ExitTwilightPortalAction(PlayerbotAI* botAI, std::string const name = "exit twilight portal")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/strategy/raids/obsidiansanctum/RaidOsMultipliers.cpp
+++ b/src/strategy/raids/obsidiansanctum/RaidOsMultipliers.cpp
@@ -1,0 +1,49 @@
+#include "RaidOsMultipliers.h"
+
+#include "ChooseTargetActions.h"
+#include "DKActions.h"
+#include "DruidActions.h"
+#include "DruidBearActions.h"
+#include "FollowActions.h"
+#include "GenericActions.h"
+#include "GenericSpellActions.h"
+#include "MovementActions.h"
+#include "PaladinActions.h"
+#include "RaidOsActions.h"
+#include "RaidOsTriggers.h"
+#include "ReachTargetActions.h"
+#include "ScriptedCreature.h"
+#include "WarriorActions.h"
+
+float SartharionMultiplier::GetValue(Action* action)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return 1.0f; }
+
+    Unit* target = action->GetTarget();
+
+    if (botAI->IsMainTank(bot) && dynamic_cast<TankFaceAction*>(action))
+    {
+        // return 0.0f;
+    }
+
+    if (botAI->IsDps(bot) && dynamic_cast<DpsAssistAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    if (botAI->IsMainTank(bot) && target && target != boss &&
+        (dynamic_cast<TankAssistAction*>(action) || dynamic_cast<CastTauntAction*>(action) || dynamic_cast<CastDarkCommandAction*>(action) ||
+         dynamic_cast<CastHandOfReckoningAction*>(action) || dynamic_cast<CastGrowlAction*>(action)))
+    {
+        return 0.0f;
+    }
+
+    if (botAI->IsAssistTank(bot) && target && target == boss &&
+        (dynamic_cast<CastTauntAction*>(action) || dynamic_cast<CastDarkCommandAction*>(action) ||
+         dynamic_cast<CastHandOfReckoningAction*>(action) || dynamic_cast<CastGrowlAction*>(action)))
+    {
+        return 0.0f;
+    }
+    return 1.0f;
+}

--- a/src/strategy/raids/obsidiansanctum/RaidOsMultipliers.h
+++ b/src/strategy/raids/obsidiansanctum/RaidOsMultipliers.h
@@ -1,0 +1,16 @@
+
+#ifndef _PLAYERRBOT_RAIDOSMULTIPLIERS_H
+#define _PLAYERRBOT_RAIDOSMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class SartharionMultiplier : public Multiplier
+{
+public:
+    SartharionMultiplier(PlayerbotAI* ai) : Multiplier(ai, "sartharion") {}
+
+public:
+    virtual float GetValue(Action* action);
+};
+
+#endif

--- a/src/strategy/raids/obsidiansanctum/RaidOsStrategy.cpp
+++ b/src/strategy/raids/obsidiansanctum/RaidOsStrategy.cpp
@@ -1,0 +1,32 @@
+#include "RaidOsStrategy.h"
+#include "RaidOsMultipliers.h"
+#include "Strategy.h"
+
+void RaidOsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(
+        new TriggerNode("sartharion tank",
+                        NextAction::array(0, new NextAction("sartharion tank position", ACTION_MOVE), nullptr)));
+    triggers.push_back(
+        new TriggerNode("twilight fissure",
+                        NextAction::array(0, new NextAction("avoid twilight fissure", ACTION_RAID + 2), nullptr)));
+    triggers.push_back(
+        new TriggerNode("flame tsunami",
+                        NextAction::array(0, new NextAction("avoid flame tsunami", ACTION_RAID + 1), nullptr)));
+    triggers.push_back(
+        new TriggerNode("sartharion dps",
+                        NextAction::array(0, new NextAction("sartharion attack priority", ACTION_RAID), nullptr)));
+    // Flank dragon positioning
+    triggers.push_back(new TriggerNode("sartharion melee positioning",
+        NextAction::array(0, new NextAction("rear flank", ACTION_MOVE + 4), nullptr)));
+    
+    triggers.push_back(new TriggerNode("twilight portal enter",
+        NextAction::array(0, new NextAction("enter twilight portal", ACTION_RAID + 1), nullptr)));
+    triggers.push_back(new TriggerNode("twilight portal exit",
+        NextAction::array(0, new NextAction("exit twilight portal", ACTION_RAID + 1), nullptr)));
+}
+
+void RaidOsStrategy::InitMultipliers(std::vector<Multiplier*> &multipliers)
+{
+    multipliers.push_back(new SartharionMultiplier(botAI));
+}

--- a/src/strategy/raids/obsidiansanctum/RaidOsStrategy.h
+++ b/src/strategy/raids/obsidiansanctum/RaidOsStrategy.h
@@ -1,0 +1,17 @@
+#ifndef _PLAYERBOT_RAIDOSSTRATEGY_H
+#define _PLAYERBOT_RAIDOSSTRATEGY_H
+
+#include "AiObjectContext.h"
+#include "Multiplier.h"
+#include "Strategy.h"
+
+class RaidOsStrategy : public Strategy
+{
+public:
+    RaidOsStrategy(PlayerbotAI* ai) : Strategy(ai) {}
+    virtual std::string const getName() override { return "wotlk-os"; }
+    virtual void InitTriggers(std::vector<TriggerNode*> &triggers) override;
+    virtual void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+};
+
+#endif

--- a/src/strategy/raids/obsidiansanctum/RaidOsTriggerContext.h
+++ b/src/strategy/raids/obsidiansanctum/RaidOsTriggerContext.h
@@ -1,0 +1,32 @@
+#ifndef _PLAYERBOT_RAIDOSTRIGGERCONTEXT_H
+#define _PLAYERBOT_RAIDOSTRIGGERCONTEXT_H
+
+#include "AiObjectContext.h"
+#include "NamedObjectContext.h"
+#include "RaidOsTriggers.h"
+
+class RaidOsTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    RaidOsTriggerContext()
+    {
+        creators["sartharion tank"] = &RaidOsTriggerContext::sartharion_tank;
+        creators["flame tsunami"] = &RaidOsTriggerContext::flame_tsunami;
+        creators["twilight fissure"] = &RaidOsTriggerContext::twilight_fissure;
+        creators["sartharion dps"] = &RaidOsTriggerContext::sartharion_dps;
+        creators["sartharion melee positioning"] = &RaidOsTriggerContext::sartharion_melee;
+        creators["twilight portal enter"] = &RaidOsTriggerContext::twilight_portal_enter;
+        creators["twilight portal exit"] = &RaidOsTriggerContext::twilight_portal_exit;
+    }
+
+private:
+    static Trigger* sartharion_tank(PlayerbotAI* ai) { return new SartharionTankTrigger(ai); }
+    static Trigger* flame_tsunami(PlayerbotAI* ai) { return new FlameTsunamiTrigger(ai); }
+    static Trigger* twilight_fissure(PlayerbotAI* ai) { return new TwilightFissureTrigger(ai); }
+    static Trigger* sartharion_dps(PlayerbotAI* ai) { return new SartharionDpsTrigger(ai); }
+    static Trigger* sartharion_melee(PlayerbotAI* ai) { return new SartharionMeleePositioningTrigger(ai); }
+    static Trigger* twilight_portal_enter(PlayerbotAI* ai) { return new TwilightPortalEnterTrigger(ai); }
+    static Trigger* twilight_portal_exit(PlayerbotAI* ai) { return new TwilightPortalExitTrigger(ai); }
+};
+
+#endif

--- a/src/strategy/raids/obsidiansanctum/RaidOsTriggers.cpp
+++ b/src/strategy/raids/obsidiansanctum/RaidOsTriggers.cpp
@@ -1,0 +1,128 @@
+#include "RaidOsTriggers.h"
+
+#include "SharedDefines.h"
+
+bool SartharionTankTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+    
+    return botAI->IsTank(bot);
+}
+
+bool FlameTsunamiTrigger::IsActive()
+{
+    if (botAI->IsTank(bot)) { return false; }
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit)
+        {
+            if (unit->GetEntry() == NPC_FLAME_TSUNAMI)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool TwilightFissureTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit)
+        {
+            if (unit->GetEntry() == NPC_TWILIGHT_FISSURE)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool SartharionDpsTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+
+    return botAI->IsDps(bot);
+}
+
+bool SartharionMeleePositioningTrigger::IsActive()
+{
+    if (!botAI->IsMelee(bot) || !botAI->IsDps(bot)) { return false; }
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+
+    Unit* shadron = AI_VALUE2(Unit*, "find target", "shadron");
+    Unit* tenebron = AI_VALUE2(Unit*, "find target", "tenebron");
+    Unit* vesperon = AI_VALUE2(Unit*, "find target", "vesperon");
+
+    return !(shadron || tenebron || vesperon);
+}
+
+bool TwilightPortalEnterTrigger::IsActive()
+{
+    if (botAI->IsMainTank(bot) || botAI->IsHealAssistantOfIndex(bot, 0)) { return false; }
+
+    // In 25-man, take two healers in. Otherwise just take one
+    // if (bot->GetRaidDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL)
+    // {
+    //     if (botAI->IsHealAssistantOfIndex(bot, 0) || botAI->IsHealAssistantOfIndex(bot, 1))
+    //     {
+    //         return false;
+    //     }
+    // }
+    // else
+    // {
+    //     if (botAI->IsHealAssistantOfIndex(bot, 0))
+    //     {
+    //         return false;
+    //     }
+    // }
+    
+
+    // Don't enter portal until drakes are dead
+    if (bot->HasAura(SPELL_POWER_OF_SHADRON) ||
+        bot->HasAura(SPELL_POWER_OF_TENEBRON) ||
+        bot->HasAura(SPELL_POWER_OF_VESPERON))
+    {
+        return false;
+    }
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "sartharion");
+    if (!boss) { return false; }
+
+    // GuidVector objects = AI_VALUE(GuidVector, "nearest game objects no los");
+    // for (auto& object : objects)
+    // {
+    //     GameObject* go = botAI->GetGameObject(object);
+    //     if (go && go->GetEntry() == GO_TWILIGHT_PORTAL)
+    //     {
+    //         return true;
+    //     }
+    // }
+    return bool(bot->FindNearestGameObject(GO_TWILIGHT_PORTAL, 100.0f));
+}
+
+bool TwilightPortalExitTrigger::IsActive()
+{
+    return bot->HasAura(SPELL_TWILIGHT_SHIFT) && !AI_VALUE2(Unit*, "find target", "acolyte of shadron");
+}

--- a/src/strategy/raids/obsidiansanctum/RaidOsTriggers.h
+++ b/src/strategy/raids/obsidiansanctum/RaidOsTriggers.h
@@ -1,0 +1,120 @@
+#ifndef _PLAYERBOT_RAIDOSTRIGGERS_H
+#define _PLAYERBOT_RAIDOSTRIGGERS_H
+
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "Trigger.h"
+
+enum ObsidianSanctumIDs
+{
+    // Bosses
+    NPC_SARTHARION                              = 28860,
+    NPC_SHADRON                                 = 30451,
+    NPC_TENEBRON                                = 30452,
+    NPC_VESPERON                                = 30449,
+
+    // Mini-boss shared
+    SPELL_SHADOW_BREATH                         = 57570,
+    SPELL_SHADOW_FISSURE                        = 57579,
+    SPELL_SUMMON_TWILIGHT_WHELP                 = 58035,
+    SPELL_GIFT_OF_TWILIGHT_SHADOW               = 57835,
+    SPELL_TWILIGHT_TORMENT_VESPERON             = 57935,
+
+    // Sartharion
+    SPELL_SARTHARION_CLEAVE                     = 56909,
+    SPELL_SARTHARION_FLAME_BREATH               = 56908,
+    SPELL_SARTHARION_TAIL_LASH                  = 56910,
+    SPELL_CYCLONE_AURA_PERIODIC                 = 57598,
+    SPELL_LAVA_STRIKE_DUMMY                     = 57578,
+    SPELL_LAVA_STRIKE_DUMMY_TRIGGER             = 57697,
+    SPELL_LAVA_STRIKE_SUMMON                    = 57572,
+    SPELL_SARTHARION_PYROBUFFET                 = 56916,
+    SPELL_SARTHARION_BERSERK                    = 61632,
+    SPELL_SARTHARION_TWILIGHT_REVENGE           = 60639,
+
+    // Sartharion with drakes
+    SPELL_WILL_OF_SARTHARION                    = 61254,
+    SPELL_POWER_OF_TENEBRON                     = 61248,
+    SPELL_POWER_OF_VESPERON                     = 61251,
+    SPELL_POWER_OF_SHADRON                      = 58105,
+    SPELL_GIFT_OF_TWILIGHT_FIRE                 = 58766,
+
+    // Visuals
+    SPELL_EGG_MARKER_VISUAL                     = 58547,
+    SPELL_FLAME_TSUNAMI_VISUAL                  = 57494,
+
+    // Misc
+    SPELL_FADE_ARMOR                            = 60708,
+    SPELL_FLAME_TSUNAMI_DAMAGE_AURA             = 57492,
+    SPELL_FLAME_TSUNAMI_LEAP                    = 60241,
+    SPELL_SARTHARION_PYROBUFFET_TRIGGER         = 57557,
+
+    NPC_TWILIGHT_EGG                            = 30882,
+    NPC_TWILIGHT_WHELP                          = 30890,
+    NPC_DISCIPLE_OF_SHADRON                     = 30688,
+    NPC_DISCIPLE_OF_VESPERON                    = 30858,
+    NPC_ACOLYTE_OF_SHADRON                      = 31218,
+    NPC_ACOLYTE_OF_VESPERON                     = 31219,
+
+    // Sartharion fight
+    NPC_LAVA_BLAZE                              = 30643,
+    NPC_FLAME_TSUNAMI                           = 30616,
+    NPC_SAFE_AREA_TRIGGER                       = 30494,
+    NPC_TWILIGHT_FISSURE                        = 30641,
+    GO_TWILIGHT_PORTAL                          = 193988,
+    GO_NORMAL_PORTAL                            = 193989,
+    SPELL_TWILIGHT_SHIFT                        = 57874,
+};
+
+const uint32 OS_MAP_ID = 615;
+
+class SartharionTankTrigger : public Trigger
+{
+public:
+    SartharionTankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "sartharion tank") {}
+    bool IsActive() override;
+};
+
+class FlameTsunamiTrigger : public Trigger
+{
+public:
+    FlameTsunamiTrigger(PlayerbotAI* botAI) : Trigger(botAI, "flame tsunami") {}
+    bool IsActive() override;
+};
+
+class TwilightFissureTrigger : public Trigger
+{
+public:
+    TwilightFissureTrigger(PlayerbotAI* botAI) : Trigger(botAI, "twilight fissure") {}
+    bool IsActive() override;
+};
+
+class SartharionDpsTrigger : public Trigger
+{
+public:
+    SartharionDpsTrigger(PlayerbotAI* botAI) : Trigger(botAI, "sartharion dps") {}
+    bool IsActive() override;
+};
+
+class SartharionMeleePositioningTrigger : public Trigger
+{
+public:
+    SartharionMeleePositioningTrigger(PlayerbotAI* botAI) : Trigger(botAI, "sartharion melee positioning") {}
+    bool IsActive() override;
+};
+
+class TwilightPortalEnterTrigger : public Trigger
+{
+public:
+    TwilightPortalEnterTrigger(PlayerbotAI* botAI) : Trigger(botAI, "twilight portal enter") {}
+    bool IsActive() override;
+};
+
+class TwilightPortalExitTrigger : public Trigger
+{
+public:
+    TwilightPortalExitTrigger(PlayerbotAI* botAI) : Trigger(botAI, "twilight portal exit") {}
+    bool IsActive() override;
+};
+
+#endif


### PR DESCRIPTION
OS+2 implemented.
- Kill Vesperon before fight
- Mark Main Tank in raid interface

Offtank still needs a bit of work, and dps needs to stop running around once they're safe. But it's usable currently. I think this should probably work for OS+1 and OS+0 with no changes but I was more concerned about implementing +2.