### PR TITLE
[WIP] New rpg strategy

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -588,6 +588,11 @@ AiPlayerbot.RandomBotGroupNearby = 0
 # Default: 1 (enabled)
 AiPlayerbot.AutoDoQuests = 1
 
+# Random Bots will behave more like real players (exprimental)
+# This option will override AutoDoQuests
+# Default: 0 (disabled)
+AiPlayerbot.EnableNewRpgStrategy = 0
+
 # Quest items to leave (do not destroy)
 AiPlayerbot.RandomBotQuestItems = "6948,5175,5176,5177,5178,16309,12382,13704,11000"
 

--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -631,7 +631,11 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
             // nonCombatEngine->addStrategy("group");
             // nonCombatEngine->addStrategy("guild");
 
-            if (sPlayerbotAIConfig->autoDoQuests)
+            if (sPlayerbotAIConfig->enableNewRpgStrategy)
+            {
+                nonCombatEngine->addStrategy("new rpg", false);
+            }
+            else if (sPlayerbotAIConfig->autoDoQuests)
             {
                 // nonCombatEngine->addStrategy("travel");
                 nonCombatEngine->addStrategy("rpg", false);

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -29,6 +29,7 @@
 #include "MotionMaster.h"
 #include "MoveSpline.h"
 #include "MoveSplineInit.h"
+#include "NewRpgStrategy.h"
 #include "ObjectGuid.h"
 #include "PerformanceMonitor.h"
 #include "Player.h"
@@ -774,7 +775,8 @@ void PlayerbotAI::Reset(bool full)
     bot->GetMotionMaster()->Clear();
     // bot->CleanupAfterTaxiFlight();
     InterruptSpell();
-
+    rpgInfo = NewRpgInfo();
+    
     if (full)
     {
         for (uint8 i = 0; i < BOT_STATE_MAX; i++)
@@ -4137,16 +4139,16 @@ bool PlayerbotAI::AllowActive(ActivityType activityType)
 {
     // only keep updating till initializing time has completed,
     // which prevents unneeded expensive GameTime calls.
-    if (_isBotInitializing)
-    {
-        _isBotInitializing = GameTime::GetUptime().count() < sPlayerbotAIConfig->maxRandomBots * 0.12;
+    // if (_isBotInitializing)
+    // {
+    //     _isBotInitializing = GameTime::GetUptime().count() < sPlayerbotAIConfig->maxRandomBots * 0.12;
 
-        // no activity allowed during bot initialization
-        if (_isBotInitializing)
-        {
-            return false;
-        }
-    }
+    //     // no activity allowed during bot initialization
+    //     if (_isBotInitializing)
+    //     {
+    //         return false;
+    //     }
+    // }
 
     // General exceptions
     if (activityType == PACKET_ACTIVITY)

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -21,6 +21,7 @@
 #include "PlayerbotTextMgr.h"
 #include "SpellAuras.h"
 #include "WorldPacket.h"
+#include "NewRpgStrategy.h"
 
 class AiObjectContext;
 class Creature;
@@ -572,6 +573,7 @@ public:
     std::set<uint32> GetCurrentIncompleteQuestIds();
     void PetFollow();
     static float GetItemScoreMultiplier(ItemQualities quality);
+    NewRpgInfo rpgInfo;
 
 private:
     static void _fillGearScoreData(Player* player, Item* item, std::vector<uint32>* gearScore, uint32& twoHandScore,
@@ -580,7 +582,7 @@ private:
 
     void HandleCommands();
     void HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);
-    bool _isBotInitializing = true;
+    bool _isBotInitializing = false;
 
 protected:
     Player* bot;

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -497,7 +497,8 @@ bool PlayerbotAIConfig::Initialize()
     autoLearnTrainerSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoLearnTrainerSpells", true);
     autoLearnQuestSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoLearnQuestSpells", false);
     autoTeleportForLevel = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoTeleportForLevel", false);
-    autoDoQuests = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoDoQuests", false);
+    autoDoQuests = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoDoQuests", true);
+    enableNewRpgStrategy = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableNewRpgStrategy", false);
     syncLevelWithPlayers = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncLevelWithPlayers", false);
     freeFood = sConfigMgr->GetOption<bool>("AiPlayerbot.FreeFood", true);
     randomBotGroupNearby = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotGroupNearby", true);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -280,6 +280,7 @@ public:
     bool autoUpgradeEquip;
     bool autoLearnTrainerSpells;
     bool autoDoQuests;
+    bool enableNewRpgStrategy;
     bool syncLevelWithPlayers;
     bool freeFood;
     bool autoLearnQuestSpells;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2661,15 +2661,17 @@ void RandomPlayerbotMgr::PrintStats()
     LOG_INFO("playerbots", "    In BG: {}", inBg);
     LOG_INFO("playerbots", "    In Rest: {}", rest);
     LOG_INFO("playerbots", "    Dead: {}", dead);
-
-    LOG_INFO("playerbots", "Bots rpg status:", dead);
-    LOG_INFO("playerbots", "    IDLE: {}", rpgStatusCount[NewRpgStatus::IDLE]);
-    LOG_INFO("playerbots", "    REST: {}", rpgStatusCount[NewRpgStatus::REST]);
-    LOG_INFO("playerbots", "    GO_GRIND: {}", rpgStatusCount[NewRpgStatus::GO_GRIND]);
-    LOG_INFO("playerbots", "    GO_INNKEEPER: {}", rpgStatusCount[NewRpgStatus::GO_INNKEEPER]);
-    LOG_INFO("playerbots", "    NEAR_RANDOM: {}", rpgStatusCount[NewRpgStatus::NEAR_RANDOM]);
-    LOG_INFO("playerbots", "    NEAR_NPC: {}", rpgStatusCount[NewRpgStatus::NEAR_NPC]);
-
+    if (sPlayerbotAIConfig->enableNewRpgStrategy)
+    {
+        LOG_INFO("playerbots", "Bots rpg status:", dead);
+        LOG_INFO("playerbots", "    IDLE: {}", rpgStatusCount[NewRpgStatus::IDLE]);
+        LOG_INFO("playerbots", "    REST: {}", rpgStatusCount[NewRpgStatus::REST]);
+        LOG_INFO("playerbots", "    GO_GRIND: {}", rpgStatusCount[NewRpgStatus::GO_GRIND]);
+        LOG_INFO("playerbots", "    GO_INNKEEPER: {}", rpgStatusCount[NewRpgStatus::GO_INNKEEPER]);
+        LOG_INFO("playerbots", "    NEAR_RANDOM: {}", rpgStatusCount[NewRpgStatus::NEAR_RANDOM]);
+        LOG_INFO("playerbots", "    NEAR_NPC: {}", rpgStatusCount[NewRpgStatus::NEAR_NPC]);
+    }
+    
     LOG_INFO("playerbots", "Bots engine:", dead);
     LOG_INFO("playerbots", "    Non-combat: {}", engine_noncombat);
     LOG_INFO("playerbots", "    Combat: {}", engine_combat);

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -192,6 +192,7 @@ private:
     time_t BgCheckTimer;
     time_t LfgCheckTimer;
     time_t PlayersCheckTimer;
+    time_t printStatsTimer;
     uint32 AddRandomBots();
     bool ProcessBot(uint32 bot);
     void ScheduleRandomize(uint32 bot, uint32 time);

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -171,6 +171,10 @@ public:
 
     void PrepareAddclassCache();
     std::map<uint8, std::vector<ObjectGuid>> addclassCache;
+    std::map<uint8, std::vector<WorldLocation>> locsPerLevelCache;
+    std::map<uint8, std::vector<WorldLocation>> allianceInnkeeperPerLevelCache;
+    std::map<uint8, std::vector<WorldLocation>> hordeInnkeeperPerLevelCache;
+    std::map<uint8, std::vector<WorldLocation>> bankerLocsPerLevelCache;
 protected:
     void OnBotLoginInternal(Player* const bot) override;
 
@@ -199,8 +203,7 @@ private:
 
     std::vector<Player*> players;
     uint32 processTicks;
-    std::map<uint8, std::vector<WorldLocation>> locsPerLevelCache;
-    std::map<uint8, std::vector<WorldLocation>> bankerLocsPerLevelCache;
+    
 
     // std::map<uint32, std::vector<WorldLocation>> rpgLocsCache;
     std::map<uint32, std::map<uint32, std::vector<WorldLocation>>> rpgLocsCacheLevel;

--- a/src/strategy/StrategyContext.h
+++ b/src/strategy/StrategyContext.h
@@ -31,6 +31,7 @@
 #include "MeleeCombatStrategy.h"
 #include "MoveFromGroupStrategy.h"
 #include "NamedObjectContext.h"
+#include "NewRpgStrategy.h"
 #include "NonCombatStrategy.h"
 #include "PassiveStrategy.h"
 #include "PullStrategy.h"
@@ -82,6 +83,7 @@ public:
         creators["reveal"] = &StrategyContext::reveal;
         creators["collision"] = &StrategyContext::collision;
         creators["rpg"] = &StrategyContext::rpg;
+        creators["new rpg"] = &StrategyContext::new_rpg;
         creators["travel"] = &StrategyContext::travel;
         creators["explore"] = &StrategyContext::explore;
         creators["map"] = &StrategyContext::map;
@@ -152,6 +154,7 @@ private:
     static Strategy* reveal(PlayerbotAI* botAI) { return new RevealStrategy(botAI); }
     static Strategy* collision(PlayerbotAI* botAI) { return new CollisionStrategy(botAI); }
     static Strategy* rpg(PlayerbotAI* botAI) { return new RpgStrategy(botAI); }
+    static Strategy* new_rpg(PlayerbotAI* botAI) { return new NewRpgStrategy(botAI); }
     static Strategy* travel(PlayerbotAI* botAI) { return new TravelStrategy(botAI); }
     static Strategy* explore(PlayerbotAI* botAI) { return new ExploreStrategy(botAI); }
     static Strategy* map(PlayerbotAI* botAI) { return new MapStrategy(botAI); }

--- a/src/strategy/actions/ActionContext.h
+++ b/src/strategy/actions/ActionContext.h
@@ -62,6 +62,7 @@
 #include "VehicleActions.h"
 #include "WorldBuffAction.h"
 #include "XpGainAction.h"
+#include "NewRpgAction.h"
 
 class PlayerbotAI;
 
@@ -240,6 +241,10 @@ public:
 
         creators["toggle pet spell"] = &ActionContext::toggle_pet_spell;
         creators["pet attack"] = &ActionContext::pet_attack; 
+
+        creators["new rpg status update"] = &ActionContext::new_rpg_status_update;
+        creators["new rpg go grind"] = &ActionContext::new_rpg_go_grind;
+        creators["new rpg move random"] = &ActionContext::new_rpg_move_random;
     }
 
 private:
@@ -415,6 +420,10 @@ private:
 
     static Action* toggle_pet_spell(PlayerbotAI* ai) { return new TogglePetSpellAutoCastAction(ai); }
     static Action* pet_attack(PlayerbotAI* ai) { return new PetAttackAction(ai); }
+
+    static Action* new_rpg_status_update(PlayerbotAI* ai) { return new NewRpgStatusUpdateAction(ai); }
+    static Action* new_rpg_go_grind(PlayerbotAI* ai) { return new NewRpgGoGrindAction(ai); }
+    static Action* new_rpg_move_random(PlayerbotAI* ai) { return new NewRpgMoveRandomAction(ai); }
 };
 
 #endif

--- a/src/strategy/actions/ActionContext.h
+++ b/src/strategy/actions/ActionContext.h
@@ -244,7 +244,9 @@ public:
 
         creators["new rpg status update"] = &ActionContext::new_rpg_status_update;
         creators["new rpg go grind"] = &ActionContext::new_rpg_go_grind;
+        creators["new rpg go innkeeper"] = &ActionContext::new_rpg_go_innkeeper;
         creators["new rpg move random"] = &ActionContext::new_rpg_move_random;
+        creators["new rpg move npc"] = &ActionContext::new_rpg_move_npc;
     }
 
 private:
@@ -423,7 +425,9 @@ private:
 
     static Action* new_rpg_status_update(PlayerbotAI* ai) { return new NewRpgStatusUpdateAction(ai); }
     static Action* new_rpg_go_grind(PlayerbotAI* ai) { return new NewRpgGoGrindAction(ai); }
+    static Action* new_rpg_go_innkeeper(PlayerbotAI* ai) { return new NewRpgGoInnKeeperAction(ai); }
     static Action* new_rpg_move_random(PlayerbotAI* ai) { return new NewRpgMoveRandomAction(ai); }
+    static Action* new_rpg_move_npc(PlayerbotAI* ai) { return new NewRpgMoveNpcAction(ai); }
 };
 
 #endif

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -38,6 +38,7 @@
 #include "LootStrategyAction.h"
 #include "MailAction.h"
 #include "NamedObjectContext.h"
+#include "NewRpgAction.h"
 #include "PassLeadershipToMasterAction.h"
 #include "PositionAction.h"
 #include "QueryItemUsageAction.h"
@@ -88,6 +89,7 @@ public:
         creators["reputation"] = &ChatActionContext::reputation;
         creators["log"] = &ChatActionContext::log;
         creators["los"] = &ChatActionContext::los;
+        creators["rpg status"] = &ChatActionContext::rpg_status;
         creators["aura"] = &ChatActionContext::aura;
         creators["drop"] = &ChatActionContext::drop;
         creators["clean quest log"] = &ChatActionContext::clean_quest_log;
@@ -258,6 +260,7 @@ private:
     static Action* reputation(PlayerbotAI* botAI) { return new TellReputationAction(botAI); }
     static Action* log(PlayerbotAI* botAI) { return new LogLevelAction(botAI); }
     static Action* los(PlayerbotAI* botAI) { return new TellLosAction(botAI); }
+    static Action* rpg_status(PlayerbotAI* botAI) { return new TellRpgStatusAction(botAI); }
     static Action* aura(PlayerbotAI* ai) { return new TellAuraAction(ai); }
     static Action* ll(PlayerbotAI* botAI) { return new LootStrategyAction(botAI); }
     static Action* ss(PlayerbotAI* botAI) { return new SkipSpellsListAction(botAI); }

--- a/src/strategy/actions/MovementActions.h
+++ b/src/strategy/actions/MovementActions.h
@@ -32,7 +32,7 @@ protected:
     bool MoveNear(uint32 mapId, float x, float y, float z, float distance = sPlayerbotAIConfig->contactDistance, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     bool MoveToLOS(WorldObject* target, bool ranged = false);
     bool MoveTo(uint32 mapId, float x, float y, float z, bool idle = false, bool react = false,
-                bool normal_only = false, bool exact_waypoint = false, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
+                bool normal_only = false, bool exact_waypoint = false, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL, bool lessDelay = false);
     bool MoveTo(WorldObject* target, float distance = 0.0f, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     bool MoveNear(WorldObject* target, float distance = sPlayerbotAIConfig->contactDistance, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     float GetFollowAngle();

--- a/src/strategy/actions/NewRpgAction.cpp
+++ b/src/strategy/actions/NewRpgAction.cpp
@@ -1,0 +1,214 @@
+#include "NewRpgAction.h"
+
+#include <cmath>
+
+#include "NewRpgStrategy.h"
+#include "ObjectGuid.h"
+#include "PathGenerator.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "Random.h"
+#include "RandomPlayerbotMgr.h"
+#include "Timer.h"
+#include "TravelMgr.h"
+#include "World.h"
+
+bool TellRpgStatusAction::Execute(Event event)
+{
+    std::string out = botAI->rpgInfo.ToString();
+    botAI->TellMasterNoFacing(out);
+    return true;
+}
+
+bool NewRpgStatusUpdateAction::Execute(Event event)
+{
+    NewRpgInfo& info = botAI->rpgInfo;
+    switch (info.status)
+    {
+        case NewRpgStatus::IDLE:
+        {
+            // // IDLE -> NEAR_NPC
+            // if (!info.lastNearNpc || info.lastNearNpc + setNpcInterval < getMSTime() && urand(1, 100) <= 50)
+            // {
+            //     info.lastNearNpc = getMSTime();
+            //     GuidVector possibleTargets = AI_VALUE(GuidVector, "possible rpg targets");
+            //     if (possibleTargets.empty())
+            //         break;
+            //     info.status = NewRpgStatus::NEAR_NPC;
+            // }
+            // IDLE -> GO_GRIND
+            if (!info.lastGrind || info.lastGrind + setGrindInterval < getMSTime())
+            {
+                info.lastGrind = getMSTime();
+                WorldPosition pos = SelectRandomGrindPos();
+                if (pos == WorldPosition())
+                    break;
+                info.status = NewRpgStatus::GO_GRIND;
+                info.grindPos = pos;
+                return true;
+            }
+            break;
+        }
+        case NewRpgStatus::GO_GRIND:
+        {
+            WorldPosition& originalPos = info.grindPos;
+            assert(info.grindPos != WorldPosition());
+            // GO_GRIND -> NEAR_RANDOM
+            if (bot->GetExactDist(originalPos) < 10.0f)
+            {
+                info.status = NewRpgStatus::NEAR_RANDOM;
+                info.grindPos = WorldPosition();
+                return true;
+            }
+            // just choose another grindPos
+            if (!info.lastGrind || info.lastGrind + setGrindInterval < getMSTime())
+            {
+                WorldPosition pos = SelectRandomGrindPos();
+                if (pos == WorldPosition())
+                    break;
+                info.status = NewRpgStatus::GO_GRIND;
+                info.lastGrind = getMSTime();
+                info.grindPos = pos;
+                return true;
+            }
+            break;
+        }
+        case NewRpgStatus::NEAR_RANDOM:
+        {
+            // NEAR_RANDOM -> GO_GRIND
+            if (!info.lastGrind || info.lastGrind + setGrindInterval < getMSTime())
+            {
+                WorldPosition pos = SelectRandomGrindPos();
+                if (pos == WorldPosition())
+                    break;
+                info.lastGrind = getMSTime();
+                botAI->rpgInfo.status = NewRpgStatus::GO_GRIND;
+                botAI->rpgInfo.grindPos = pos;
+                return true;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+    return false;
+}
+
+WorldPosition NewRpgStatusUpdateAction::SelectRandomGrindPos()
+{
+    const std::vector<WorldLocation>& locs = sRandomPlayerbotMgr->locsPerLevelCache[bot->GetLevel()];
+    std::vector<WorldLocation> lo_prepared_locs, hi_prepared_locs;
+    for (auto& loc : locs)
+    {
+        if (bot->GetMapId() != loc.GetMapId())
+            continue;
+
+        if (bot->GetExactDist(loc) < 500.0f)
+        {
+            hi_prepared_locs.push_back(loc);
+        }
+
+        if (bot->GetExactDist(loc) < 1500.0f)
+        {
+            lo_prepared_locs.push_back(loc);
+        }
+    }
+    WorldPosition dest;
+    if (urand(1, 100) <= 50 && !hi_prepared_locs.empty())
+    {
+        uint32 idx = urand(0, hi_prepared_locs.size() - 1);
+        dest = hi_prepared_locs[idx];
+    }
+    else if (!lo_prepared_locs.empty())
+    {
+        uint32 idx = urand(0, lo_prepared_locs.size() - 1);
+        dest = lo_prepared_locs[idx];
+    }
+    LOG_INFO("playerbots", "[New Rpg] Bot {} select random grind pos Map:{} X:{} Y:{} Z:{} ({}+{} available in {})",
+             bot->GetName(), dest.GetMapId(), dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(),
+             hi_prepared_locs.size(), lo_prepared_locs.size() - hi_prepared_locs.size(), locs.size());
+    return dest;
+}
+
+bool NewRpgGoFarAwayPosAction::MoveFarTo(WorldPosition dest)
+{
+    float dis = bot->GetExactDist(dest);
+    if (dis < pathFinderDis)
+    {
+        return MoveTo(dest.getMapId(), dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ());
+    }
+
+    int attempt = 10;
+    float minDelta = MAXFLOAT;
+    const float x = bot->GetPositionX();
+    const float y = bot->GetPositionY();
+    const float z = bot->GetPositionZ();
+    float rx, ry, rz;
+    bool found = false;
+    while (--attempt)
+    {
+        float angle = bot->GetAngle(&dest);
+        float delta = (rand_norm() - 0.5) * M_PI;
+        angle += delta;
+        float dis = rand_norm() * pathFinderDis;
+        float dx = x + cos(angle) * dis;
+        float dy = y + sin(angle) * dis;
+        float dz = z;
+        PathGenerator path(bot);
+        path.CalculatePath(dx, dy, dz);
+        // bool canReach = bot->GetMap()->CanReachPositionAndGetValidCoords(bot, x, y, z, dx, dy, dz, false);
+        bool canReach = path.GetPathType() & (PATHFIND_NORMAL | PATHFIND_INCOMPLETE);
+
+        if (canReach)
+        {
+            G3D::Vector3 endPos = path.GetPath().back();
+            if (fabs(delta) < minDelta)
+            {
+                found = true;
+                minDelta = fabs(delta);
+                rx = endPos.x;
+                ry = endPos.y;
+                rz = endPos.z;
+            }
+        }
+    }
+    if (found)
+    {
+        return MoveTo(bot->GetMapId(), rx, ry, rz, false, false, false, true);
+    }
+    // fallback to direct move
+    float angle = bot->GetAngle(&dest);
+    return MoveTo(bot->GetMapId(), x + cos(angle) * pathFinderDis, y + sin(angle) * pathFinderDis, z);
+}
+
+bool NewRpgGoGrindAction::Execute(Event event) { return MoveFarTo(botAI->rpgInfo.grindPos); }
+
+bool NewRpgMoveRandomAction::Execute(Event event)
+{
+    float distance = rand_norm() * moveStep;
+    Map* map = bot->GetMap();
+    const float x = bot->GetPositionX();
+    const float y = bot->GetPositionY();
+    const float z = bot->GetPositionZ();
+    int attempts = 5;
+    while (--attempts)
+    {
+        float angle = (float)rand_norm() * 2 * static_cast<float>(M_PI);
+        float dx = x + distance * cos(angle);
+        float dy = y + distance * sin(angle);
+        float dz = z;
+        if (!map->CheckCollisionAndGetValidCoords(bot, bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(),
+                                                  dx, dy, dz))
+            continue;
+
+        if (map->IsInWater(bot->GetPhaseMask(), dx, dy, dz, bot->GetCollisionHeight()))
+            continue;
+
+        bool moved = MoveTo(bot->GetMapId(), dx, dy, dz, false, false, false, true);
+        if (moved)
+            return true;
+    }
+
+    return false;
+}

--- a/src/strategy/actions/NewRpgAction.cpp
+++ b/src/strategy/actions/NewRpgAction.cpp
@@ -173,7 +173,7 @@ WorldPosition NewRpgStatusUpdateAction::SelectRandomGrindPos()
         uint32 idx = urand(0, lo_prepared_locs.size() - 1);
         dest = lo_prepared_locs[idx];
     }
-    LOG_INFO("playerbots", "[New Rpg] Bot {} select random grind pos Map:{} X:{} Y:{} Z:{} ({}+{} available in {})",
+    LOG_DEBUG("playerbots", "[New Rpg] Bot {} select random grind pos Map:{} X:{} Y:{} Z:{} ({}+{} available in {})",
              bot->GetName(), dest.GetMapId(), dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(),
              hi_prepared_locs.size(), lo_prepared_locs.size() - hi_prepared_locs.size(), locs.size());
     return dest;
@@ -202,7 +202,7 @@ WorldPosition NewRpgStatusUpdateAction::SelectRandomInnKeeperPos()
         uint32 idx = urand(0, prepared_locs.size() - 1);
         dest = prepared_locs[idx];
     }
-    LOG_INFO("playerbots", "[New Rpg] Bot {} select random inn keeper pos Map:{} X:{} Y:{} Z:{} ({} available in {})",
+    LOG_DEBUG("playerbots", "[New Rpg] Bot {} select random inn keeper pos Map:{} X:{} Y:{} Z:{} ({} available in {})",
              bot->GetName(), dest.GetMapId(), dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(),
              prepared_locs.size(), locs.size());
     return dest;

--- a/src/strategy/actions/NewRpgAction.h
+++ b/src/strategy/actions/NewRpgAction.h
@@ -1,0 +1,57 @@
+#ifndef _PLAYERBOT_NEWRPGACTION_H
+#define _PLAYERBOT_NEWRPGACTION_H
+
+#include "Duration.h"
+#include "MovementActions.h"
+#include "NewRpgStrategy.h"
+#include "TravelMgr.h"
+#include "PlayerbotAI.h"
+
+class TellRpgStatusAction : public Action
+{
+public:
+    TellRpgStatusAction(PlayerbotAI* botAI) : Action(botAI, "rpg status") {}
+
+    bool Execute(Event event) override;
+};
+
+class NewRpgStatusUpdateAction : public Action
+{
+public:
+    NewRpgStatusUpdateAction(PlayerbotAI* botAI) : Action(botAI, "new rpg status update") {}
+    bool Execute(Event event) override;
+protected:
+    const int32 setGrindInterval = 5 * 60 * 1000;
+    const int32 setNpcInterval = 5 * 60 * 1000;
+    WorldPosition SelectRandomGrindPos();
+};
+
+class NewRpgGoFarAwayPosAction : public MovementAction
+{
+public:
+    NewRpgGoFarAwayPosAction(PlayerbotAI* botAI, std::string name) : MovementAction(botAI, name) {}
+    // bool Execute(Event event) override;
+    bool MoveFarTo(WorldPosition dest);
+
+protected:
+    // WorldPosition dest;
+    float pathFinderDis = 70.0f; // path finder
+};
+
+class NewRpgGoGrindAction : public NewRpgGoFarAwayPosAction
+{
+public:
+    NewRpgGoGrindAction(PlayerbotAI* botAI) : NewRpgGoFarAwayPosAction(botAI, "new rpg go grind") {}
+    bool Execute(Event event) override;
+};
+
+class NewRpgMoveRandomAction : public MovementAction
+{
+public:
+    NewRpgMoveRandomAction(PlayerbotAI* botAI) : MovementAction(botAI, "new rpg move random") {}
+    bool Execute(Event event) override;
+protected:
+    const float moveStep = 50.0f;
+};
+
+#endif

--- a/src/strategy/actions/NewRpgAction.h
+++ b/src/strategy/actions/NewRpgAction.h
@@ -21,9 +21,13 @@ public:
     NewRpgStatusUpdateAction(PlayerbotAI* botAI) : Action(botAI, "new rpg status update") {}
     bool Execute(Event event) override;
 protected:
-    const int32 setGrindInterval = 5 * 60 * 1000;
-    const int32 setNpcInterval = 5 * 60 * 1000;
+    // const int32 setGrindInterval = 5 * 60 * 1000;
+    // const int32 setNpcInterval = 1 * 60 * 1000;
+    const int32 statusNearNpcDuration = 3 * 60 * 1000;
+    const int32 statusNearRandomDuration = 3 * 60 * 1000;
+    const int32 statusRestDuration = 1 * 60 * 1000;
     WorldPosition SelectRandomGrindPos();
+    WorldPosition SelectRandomInnKeeperPos();
 };
 
 class NewRpgGoFarAwayPosAction : public MovementAction
@@ -45,6 +49,14 @@ public:
     bool Execute(Event event) override;
 };
 
+class NewRpgGoInnKeeperAction : public NewRpgGoFarAwayPosAction
+{
+public:
+    NewRpgGoInnKeeperAction(PlayerbotAI* botAI) : NewRpgGoFarAwayPosAction(botAI, "new rpg go innkeeper") {}
+    bool Execute(Event event) override;
+};
+
+
 class NewRpgMoveRandomAction : public MovementAction
 {
 public:
@@ -52,6 +64,15 @@ public:
     bool Execute(Event event) override;
 protected:
     const float moveStep = 50.0f;
+};
+
+class NewRpgMoveNpcAction : public MovementAction
+{
+public:
+    NewRpgMoveNpcAction(PlayerbotAI* botAI) : MovementAction(botAI, "new rpg move npcs") {}
+    bool Execute(Event event) override;
+protected:
+    const uint32 stayTime = 8 * 1000;
 };
 
 #endif

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -188,7 +188,7 @@ bool FindCorpseAction::Execute(Event event)
 
             if (!moved)
             {
-                moved = botAI->DoSpecificAction("spirit healer");
+                moved = botAI->DoSpecificAction("spirit healer", Event(), true);
             }
         }
     }

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -347,16 +347,16 @@ bool SpiritHealerAction::Execute(Event event)
     if (moved)
         return true;
 
-    if (!botAI->HasActivePlayerMaster())
-    {
-        context->GetValue<uint32>("death count")->Set(dCount + 1);
-        return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
-    }
+    // if (!botAI->HasActivePlayerMaster())
+    // {
+    context->GetValue<uint32>("death count")->Set(dCount + 1);
+    return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
+    // }
 
-    LOG_INFO("playerbots", "Bot {} {}:{} <{}> can't find a spirit healer", bot->GetGUID().ToString().c_str(),
-             bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
+    // LOG_INFO("playerbots", "Bot {} {}:{} <{}> can't find a spirit healer", bot->GetGUID().ToString().c_str(),
+    //          bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
-    botAI->TellError("Cannot find any spirit healer nearby");
+    // botAI->TellError("Cannot find any spirit healer nearby");
     return false;
 }
 

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -106,6 +106,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("reputation");
     supported.push_back("log");
     supported.push_back("los");
+    supported.push_back("rpg status");
     supported.push_back("aura");
     supported.push_back("drop");
     supported.push_back("share");

--- a/src/strategy/generic/GrindingStrategy.cpp
+++ b/src/strategy/generic/GrindingStrategy.cpp
@@ -11,10 +11,10 @@ NextAction** GrindingStrategy::getDefaultActions() { return nullptr; }
 
 void GrindingStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 4.2f), nullptr)));
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 4.1f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 10.2f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 10.1f), nullptr)));
     triggers.push_back(
-        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 4.0f), nullptr)));
+        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 10.0f), nullptr)));
 }
 
 void MoveRandomStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/strategy/generic/NewRpgStrategy.cpp
+++ b/src/strategy/generic/NewRpgStrategy.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#include "NewRpgStrategy.h"
+
+#include "Playerbots.h"
+
+NewRpgStrategy::NewRpgStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+NextAction** NewRpgStrategy::getDefaultActions()
+{
+    return NextAction::array(0, new NextAction("new rpg status update", 5.0f), nullptr);
+}
+
+void NewRpgStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(
+        new TriggerNode("go grind status", NextAction::array(0, new NextAction("new rpg go grind", 1.0f), nullptr)));
+
+    triggers.push_back(
+        new TriggerNode("near random status", NextAction::array(0, new NextAction("new rpg move random", 1.0f), nullptr)));
+}
+
+void NewRpgStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    // multipliers.push_back(new RpgActionMultiplier(botAI));
+}

--- a/src/strategy/generic/NewRpgStrategy.cpp
+++ b/src/strategy/generic/NewRpgStrategy.cpp
@@ -18,9 +18,15 @@ void NewRpgStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(
         new TriggerNode("go grind status", NextAction::array(0, new NextAction("new rpg go grind", 1.0f), nullptr)));
+    
+    triggers.push_back(
+        new TriggerNode("go innkeeper status", NextAction::array(0, new NextAction("new rpg go innkeeper", 1.0f), nullptr)));
 
     triggers.push_back(
         new TriggerNode("near random status", NextAction::array(0, new NextAction("new rpg move random", 1.0f), nullptr)));
+
+    triggers.push_back(
+        new TriggerNode("near npc status", NextAction::array(0, new NextAction("new rpg move npc", 1.0f), nullptr)));
 }
 
 void NewRpgStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)

--- a/src/strategy/generic/NewRpgStrategy.h
+++ b/src/strategy/generic/NewRpgStrategy.h
@@ -52,27 +52,34 @@ struct NewRpgInfo
         {
             case NewRpgStatus::GO_GRIND:
                 out << "GO_GRIND";
+                out << "\nGrindPos: " << grindPos.GetMapId() << " " << grindPos.GetPositionX() << " " << grindPos.GetPositionY() << " " << grindPos.GetPositionZ();
+                out << "\nlastGoGrind: " << lastGoGrind;
                 break;
             case NewRpgStatus::GO_INNKEEPER:
                 out << "GO_INNKEEPER";
+                out << "\nInnKeeperPos: " << innKeeperPos.GetMapId() << " " << innKeeperPos.GetPositionX() << " " << innKeeperPos.GetPositionY() << " " << innKeeperPos.GetPositionZ();
+                out << "\nlastGoInnKeeper: " << lastGoInnKeeper;
                 break;
             case NewRpgStatus::NEAR_NPC:
                 out << "NEAR_NPC";
+                out << "\nNpcPos: " << npcPos.GetMapId() << " " << npcPos.GetPositionX() << " " << npcPos.GetPositionY() << " " << npcPos.GetPositionZ();
+                out << "\nlastNearNpc: " << lastNearNpc;
+                out << "\nlastReachNpc: " << lastReachNpc;
                 break;
             case NewRpgStatus::NEAR_RANDOM:
                 out << "NEAR_RANDOM";
+                out << "\nlastNearNpc: " << lastNearRandom;
                 break;
             case NewRpgStatus::IDLE:
                 out << "IDLE";
                 break;
             case NewRpgStatus::REST:
                 out << "REST";
+                out << "\nlastNearNpc: " << lastRest;
                 break;
             default:
                 out << "UNKNOWN";
         }
-        out << "\nGrindPos: " << grindPos.GetMapId() << " " << grindPos.GetPositionX() << " " << grindPos.GetPositionY() << " " << grindPos.GetPositionZ();
-        out << "\nlastGoGrind: " << lastGoGrind;
         return out.str();
     }
 };

--- a/src/strategy/generic/NewRpgStrategy.h
+++ b/src/strategy/generic/NewRpgStrategy.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_NEWRPGSTRATEGY_H
+#define _PLAYERBOT_NEWRPGSTRATEGY_H
+
+#include <cstdint>
+#include "Strategy.h"
+#include "TravelMgr.h"
+
+class PlayerbotAI;
+
+enum class NewRpgStatus
+{
+    // Going to far away place
+    GO_GRIND,
+    GO_INNKEEPER,
+    // Exploring nearby
+    NEAR_RANDOM,
+    NEAR_NPC,
+    // Idling
+    IDLE
+};
+
+struct NewRpgInfo
+{
+    NewRpgStatus status{NewRpgStatus::IDLE};
+    WorldPosition grindPos{};
+    uint32 lastGrind{0};
+    uint32 lastNearNpc{0};
+    std::string ToString()
+    {
+        std::stringstream out;
+        out << "Status: ";
+        switch (status)
+        {
+            case NewRpgStatus::GO_GRIND:
+                out << "GO_GRIND";
+                break;
+            case NewRpgStatus::GO_INNKEEPER:
+                out << "GO_INNKEEPER";
+                break;
+            case NewRpgStatus::NEAR_NPC:
+                out << "NEAR_NPC";
+                break;
+            case NewRpgStatus::NEAR_RANDOM:
+                out << "NEAR_RANDOM";
+                break;
+            case NewRpgStatus::IDLE:
+                out << "IDLE";
+                break;
+        }
+        out << "\nGrindPos: " << grindPos.GetMapId() << " " << grindPos.GetPositionX() << " " << grindPos.GetPositionY() << " " << grindPos.GetPositionZ();
+        out << "\nLastGrind: " << lastGrind;
+        return out.str();
+    }
+};
+
+class NewRpgStrategy : public Strategy
+{
+public:
+    NewRpgStrategy(PlayerbotAI* botAI);
+
+    std::string const getName() override { return "new rpg"; }
+    NextAction** getDefaultActions() override;
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*>& multipliers) override;
+};
+
+#endif

--- a/src/strategy/generic/NewRpgStrategy.h
+++ b/src/strategy/generic/NewRpgStrategy.h
@@ -20,16 +20,30 @@ enum class NewRpgStatus
     // Exploring nearby
     NEAR_RANDOM,
     NEAR_NPC,
-    // Idling
+    // Taking a break
+    REST,
+    // Initial status
     IDLE
 };
 
 struct NewRpgInfo
 {
     NewRpgStatus status{NewRpgStatus::IDLE};
+    // NewRpgStatus::GO_GRIND
     WorldPosition grindPos{};
-    uint32 lastGrind{0};
+    uint32 lastGoGrind{0};
+    // NewRpgStatus::GO_INNKEEPER
+    WorldPosition innKeeperPos{};
+    uint32 lastGoInnKeeper{0};
+    // NewRpgStatus::NEAR_NPC
+    GuidPosition npcPos{};
     uint32 lastNearNpc{0};
+    uint32 lastReachNpc{0};
+    // NewRpgStatus::NEAR_RANDOM
+    uint32 lastNearRandom{0};
+    // NewRpgStatus::REST
+    uint32 lastRest{0};
+
     std::string ToString()
     {
         std::stringstream out;
@@ -51,9 +65,14 @@ struct NewRpgInfo
             case NewRpgStatus::IDLE:
                 out << "IDLE";
                 break;
+            case NewRpgStatus::REST:
+                out << "REST";
+                break;
+            default:
+                out << "UNKNOWN";
         }
         out << "\nGrindPos: " << grindPos.GetMapId() << " " << grindPos.GetPositionX() << " " << grindPos.GetPositionY() << " " << grindPos.GetPositionZ();
-        out << "\nLastGrind: " << lastGrind;
+        out << "\nlastGoGrind: " << lastGoGrind;
         return out.str();
     }
 };

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -24,6 +24,7 @@ public:
         creators["reputation"] = &ChatTriggerContext::reputation;
         creators["log"] = &ChatTriggerContext::log;
         creators["los"] = &ChatTriggerContext::los;
+        creators["rpg status"] = &ChatTriggerContext::rpg_status;
         creators["aura"] = &ChatTriggerContext::aura;
         creators["drop"] = &ChatTriggerContext::drop;
         creators["share"] = &ChatTriggerContext::share;
@@ -211,6 +212,7 @@ private:
     static Trigger* reputation(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "reputation"); }
     static Trigger* log(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "log"); }
     static Trigger* los(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "los"); }
+    static Trigger* rpg_status(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg status"); }
     static Trigger* aura(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "aura"); }
     static Trigger* loot_all(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "add all loot"); }
     static Trigger* release(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "release"); }

--- a/src/strategy/triggers/NewRpgTrigger.cpp
+++ b/src/strategy/triggers/NewRpgTrigger.cpp
@@ -1,0 +1,4 @@
+#include "NewRpgTriggers.h"
+#include "PlayerbotAI.h"
+
+bool NewRpgStatusTrigger::IsActive() { return status == botAI->rpgInfo.status; }

--- a/src/strategy/triggers/NewRpgTriggers.h
+++ b/src/strategy/triggers/NewRpgTriggers.h
@@ -1,0 +1,20 @@
+#ifndef _PLAYERBOT_NEWRPGTRIGGERS_H
+#define _PLAYERBOT_NEWRPGTRIGGERS_H
+
+#include "NewRpgStrategy.h"
+#include "Trigger.h"
+
+class NewRpgStatusTrigger : public Trigger
+{
+public:
+    NewRpgStatusTrigger(PlayerbotAI* botAI, NewRpgStatus status = NewRpgStatus::IDLE)
+        : Trigger(botAI, "new rpg status"), status(status)
+    {
+    }
+    bool IsActive() override;
+
+protected:
+    NewRpgStatus status;
+};
+
+#endif

--- a/src/strategy/triggers/TriggerContext.h
+++ b/src/strategy/triggers/TriggerContext.h
@@ -12,6 +12,8 @@
 #include "LfgTriggers.h"
 #include "LootTriggers.h"
 #include "NamedObjectContext.h"
+#include "NewRpgStrategy.h"
+#include "NewRpgTriggers.h"
 #include "PvpTriggers.h"
 #include "RaidNaxxTriggers.h"
 #include "RpgTriggers.h"
@@ -213,6 +215,8 @@ public:
         creators["rpg craft"] = &TriggerContext::rpg_craft;
         creators["rpg trade useful"] = &TriggerContext::rpg_trade_useful;
         creators["rpg duel"] = &TriggerContext::rpg_duel;
+        creators["go grind status"] = &TriggerContext::go_grind_status;
+        creators["near random status"] = &TriggerContext::near_random_status;
     }
 
 private:
@@ -402,6 +406,8 @@ private:
     static Trigger* rpg_craft(PlayerbotAI* botAI) { return new RpgCraftTrigger(botAI); }
     static Trigger* rpg_trade_useful(PlayerbotAI* botAI) { return new RpgTradeUsefulTrigger(botAI); }
     static Trigger* rpg_duel(PlayerbotAI* botAI) { return new RpgDuelTrigger(botAI); }
+    static Trigger* go_grind_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::GO_GRIND); }
+    static Trigger* near_random_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::NEAR_RANDOM); }
 };
 
 #endif

--- a/src/strategy/triggers/TriggerContext.h
+++ b/src/strategy/triggers/TriggerContext.h
@@ -216,7 +216,9 @@ public:
         creators["rpg trade useful"] = &TriggerContext::rpg_trade_useful;
         creators["rpg duel"] = &TriggerContext::rpg_duel;
         creators["go grind status"] = &TriggerContext::go_grind_status;
+        creators["go innkeeper status"] = &TriggerContext::go_innkeeper_status;
         creators["near random status"] = &TriggerContext::near_random_status;
+        creators["near npc status"] = &TriggerContext::near_npc_status;
     }
 
 private:
@@ -407,7 +409,9 @@ private:
     static Trigger* rpg_trade_useful(PlayerbotAI* botAI) { return new RpgTradeUsefulTrigger(botAI); }
     static Trigger* rpg_duel(PlayerbotAI* botAI) { return new RpgDuelTrigger(botAI); }
     static Trigger* go_grind_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::GO_GRIND); }
+    static Trigger* go_innkeeper_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::GO_INNKEEPER); }
     static Trigger* near_random_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::NEAR_RANDOM); }
+    static Trigger* near_npc_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::NEAR_NPC); }
 };
 
 #endif

--- a/src/strategy/values/DpsTargetValue.cpp
+++ b/src/strategy/values/DpsTargetValue.cpp
@@ -298,8 +298,9 @@ Unit* DpsTargetValue::Calculate()
         return rti;
 
     // FindLeastHpTargetStrategy strategy(botAI);
+    Group* group = bot->GetGroup();
     float dps = AI_VALUE(float, "estimated group dps");
-    if (botAI->IsCaster(bot))
+    if (group && botAI->IsCaster(bot))
     {
         CasterFindTargetSmartStrategy strategy(botAI, dps);
         return TargetValue::FindTarget(&strategy);

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -52,7 +52,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
 
     float distance = 0;
     Unit* result = nullptr;
-    std::unordered_map<uint32, bool> needForQuestMap;
+    // std::unordered_map<uint32, bool> needForQuestMap;
 
     for (ObjectGuid const guid : targets)
     {
@@ -99,18 +99,18 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
 		if (!bot->InBattleground() && (int)unit->GetLevel() - (int)bot->GetLevel() > 4 && !unit->GetGUID().IsPlayer())
 		    continue;
 
-        if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
-            needForQuestMap[unit->GetEntry()] = needForQuest(unit);
+        // if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
+        //     needForQuestMap[unit->GetEntry()] = needForQuest(unit);
 
-        if (!needForQuestMap[unit->GetEntry()])
-        {
-            Creature* creature = dynamic_cast<Creature*>(unit);
-            if ((urand(0, 100) < 60 || (context->GetValue<TravelTarget*>("travel target")->Get()->isWorking() &&
-                context->GetValue<TravelTarget*>("travel target")->Get()->getDestination()->getName() != "GrindTravelDestination")))
-            {
-                continue;
-            }
-        }
+        // if (!needForQuestMap[unit->GetEntry()])
+        // {
+        //     Creature* creature = dynamic_cast<Creature*>(unit);
+        //     if ((urand(0, 100) < 60 || (context->GetValue<TravelTarget*>("travel target")->Get()->isWorking() &&
+        //         context->GetValue<TravelTarget*>("travel target")->Get()->getDestination()->getName() != "GrindTravelDestination")))
+        //     {
+        //         continue;
+        //     }
+        // }
 
         if (Creature* creature = unit->ToCreature())
             if (CreatureTemplate const* CreatureTemplate = creature->GetCreatureTemplate())
@@ -142,8 +142,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
         else
         {
             float newdistance = bot->GetDistance(unit);
-            if (!result || (newdistance < distance &&
-                            urand(0, abs(distance - newdistance)) > sPlayerbotAIConfig->sightDistance * 0.1))
+            if (!result || (newdistance < distance))
             {
                 distance = newdistance;
                 result = unit;

--- a/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
+++ b/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
@@ -48,7 +48,7 @@ private:
     {
         return new ActionNode("summon succubus",
                               /*P*/ nullptr,
-                              /*A*/ NextAction::array(0, new NextAction("summon imp"), nullptr),
+                              /*A*/ NextAction::array(0, new NextAction("summon voidwalker"), nullptr),
                               /*C*/ nullptr);
     }
     static ActionNode* summon_felhunter([[maybe_unused]] PlayerbotAI* botAI)


### PR DESCRIPTION
I plan to implement a new rpg strategy for rndbots from scratch as the old rpg strategy has the following problems and is hard to modify.
- Bots are directly teleported to the mob's location instead of moving there by itself, lacking the ability to make long distances movement.
- Too less teleportation points causing the bot to be unevenly distributed on the map.
- Bots are overly attracted to friendly NPCs, causing most bots to just move between NPCs meaninglessly.
- Excessive overhead is incurred when selecting an rpg target.

Todo:
- [x] Now they can go to distant locations for grinding, and the distribution on the map is more even.
- [x] Multiple states are designed to control the behavior of bots to make them more purposeful, such as going to the grind location, returning to the innkeeper, exploring surrounding NPCs, etc.
- [x] Control the status of bots according to probability and simulate real servers. 
- [ ] Bots are now teleported to a innkeeper location, which means it always starts from a innkeeper.
- [ ] Set the proportion of bots in capital cities to simulate real servers.

Optional:
- [ ] Cancle teleport and make it entirely up to the bot to move and transport to the appropriate leveling location.
- [ ] Quest-related behaviors, such as accepting tasks, trying to complete some simple quests (such as kill mob, pick gameobject) and choosing approptiate rewards.
- [ ] More careful grind target selection strategies and group behavior to avoid death.