### PR TITLE
Make AutoScaleActivity further configurable

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1524,7 +1524,7 @@ AiPlayerbot.BotActiveAlone = 100
 AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
-AiPlayerbot.botActiveAloneDiffMethod = 1
+AiPlayerbot.botActiveAloneDiffMethod = 2
 AiPlayerbot.botActiveAloneDiffLimitFloor = 30
 AiPlayerbot.botActiveAloneDiffLimitCeiling = 60
 

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1514,9 +1514,21 @@ AiPlayerbot.BotActiveAlone = 100
 # Specify smart scaling is enabled or not.
 # The default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
 # Only when botLevel is between WhenMinLevel and WhenMaxLevel.
+#
+# AiPlayerbot.botActiveAloneDiffMethod
+# 1 = Compare DIFF against Average Update Time
+# 2 = Compare DIFF against Max Update Time (Spikes)
+#
+# AiPlayerbot.botActiveAloneDiffLimitFloor & Ceiling
+# Determines how much % bots are active in accordence to a floor and ceiling value.
+# This will dynamically adjust the amount of active bots to try to
+# keep the server performance within a specified floor and ceiling, DIFF-wise.
 AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
+AiPlayerbot.botActiveAloneDiffMethod = 2
+AiPlayerbot.botActiveAloneDiffLimitFloor = 40
+AiPlayerbot.botActiveAloneDiffLimitCeiling = 100
 
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...
@@ -1526,7 +1538,6 @@ AiPlayerbot.MinRandomBotsPriceChangeInterval = 7200
 AiPlayerbot.MaxRandomBotsPriceChangeInterval = 172800
 AiPlayerbot.MinRandomBotChangeStrategyTime = 180
 AiPlayerbot.MaxRandomBotChangeStrategyTime = 720
-
 
 # How often tasks are changed
 AiPlayerbot.MinGuildTaskChangeTime = 172800

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1514,21 +1514,12 @@ AiPlayerbot.BotActiveAlone = 100
 # Specify smart scaling is enabled or not.
 # The default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
 # Only when botLevel is between WhenMinLevel and WhenMaxLevel.
-#
-# AiPlayerbot.botActiveAloneDiffMethod
-# 1 = Compare DIFF against Average Update Time
-# 2 = Compare DIFF against Max Update Time (Spikes)
-#
-# AiPlayerbot.botActiveAloneDiffLimitFloor & Ceiling
-# Determines how much % bots are active in accordence to a floor and ceiling value.
-# This will dynamically adjust the amount of active bots to try to
-# keep the server performance within a specified floor and ceiling, DIFF-wise.
 AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
-AiPlayerbot.botActiveAloneDiffMethod = 2
-AiPlayerbot.botActiveAloneDiffLimitFloor = 40
-AiPlayerbot.botActiveAloneDiffLimitCeiling = 100
+AiPlayerbot.botActiveAloneDiffMethod = 1
+AiPlayerbot.botActiveAloneDiffLimitFloor = 30
+AiPlayerbot.botActiveAloneDiffLimitCeiling = 80
 
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1531,7 +1531,7 @@ AiPlayerbot.BotActiveAloneForceWhenInGuild = 1
 #   Method: 2 - Check against Max Diff (spikes)
 #
 #   LimitFloor - No active bot decrease below this DIFF
-#   LimitFCeiling - Max active bot decrease above this DIFF
+#   LimitCeiling - Max active bot decrease above this DIFF
 AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1541,8 +1541,8 @@ AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
 AiPlayerbot.botActiveAloneDiffMethod = 2
-AiPlayerbot.botActiveAloneDiffLimitFloor = 30
-AiPlayerbot.botActiveAloneDiffLimitCeiling = 60
+AiPlayerbot.botActiveAloneDiffLimitFloor = 40
+AiPlayerbot.botActiveAloneDiffLimitCeiling = 150
 
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1526,7 +1526,7 @@ AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
 AiPlayerbot.botActiveAloneDiffMethod = 1
 AiPlayerbot.botActiveAloneDiffLimitFloor = 30
-AiPlayerbot.botActiveAloneDiffLimitCeiling = 80
+AiPlayerbot.botActiveAloneDiffLimitCeiling = 60
 
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1514,6 +1514,13 @@ AiPlayerbot.BotActiveAlone = 100
 # Specify smart scaling is enabled or not.
 # The default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
 # Only when botLevel is between WhenMinLevel and WhenMaxLevel.
+#
+# AiPlayerbot.botActiveAloneDiff
+#   Method: 1 - Check against average Diff
+#   Method: 2 - Check against Max Diff (spikes)
+#
+#   LimitFloor - No active bot decrease below this DIFF
+#   LimitFCeiling - Max active bot decrease above this DIFF
 AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1540,9 +1540,9 @@ AiPlayerbot.BotActiveAloneForceWhenInGuild = 1
 AiPlayerbot.botActiveAloneSmartScale = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel = 1
 AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel = 80
-AiPlayerbot.botActiveAloneDiffMethod = 2
-AiPlayerbot.botActiveAloneDiffLimitFloor = 40
-AiPlayerbot.botActiveAloneDiffLimitCeiling = 150
+AiPlayerbot.botActiveAloneSmartScaleDiffMethod = 2
+AiPlayerbot.botActiveAloneSmartScaleDiffLimitFloor = 40
+AiPlayerbot.botActiveAloneSmartScaleDiffLimitCeiling = 150
 
 # Premade spell to avoid (undetected spells)
 # spellid-radius, ...

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4352,9 +4352,9 @@ bool PlayerbotAI::AllowActivity(ActivityType activityType, bool checkNow)
 
 uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
 {
-    uint32 diffLimitFloor = sPlayerbotAIConfig->botActiveAloneDiffLimitFloor;
-    uint32 diffLimitCeil = sPlayerbotAIConfig->botActiveAloneDiffLimitCeiling;
-    uint32 chkDiff = (sPlayerbotAIConfig->botActiveAloneDiffMethod == 2) 
+    uint32 diffLimitFloor = sPlayerbotAIConfig->botActiveAloneSmartScaleDiffLimitFloor;
+    uint32 diffLimitCeil = sPlayerbotAIConfig->botActiveAloneSmartScaleDiffLimitCeiling;
+    uint32 chkDiff = (sPlayerbotAIConfig->botActiveAloneSmartScaleDiffMethod == 2) 
         ? sWorldUpdateTime.GetMaxUpdateTime() 
         : sWorldUpdateTime.GetAverageUpdateTime();
 
@@ -4387,10 +4387,10 @@ uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
 
         return (mod * 1) / 10;
     }
-
-    if (chkDiff > diffLimitFloor + (3 * spread)) return (mod * 3) / 10;
-    if (chkDiff > diffLimitFloor + (2 * spread)) return (mod * 6) / 10;
-    if (chkDiff > diffLimitFloor + (1 * spread)) return (mod * 9) / 10;
+    if (chkDiff > diffLimitFloor + (3 * spread)) return (mod * 2) / 10;
+    if (chkDiff > diffLimitFloor + (2 * spread)) return (mod * 4) / 10;
+    if (chkDiff > diffLimitFloor + (1 * spread)) return (mod * 7) / 10;
+    if (chkDiff > diffLimitFloor + (0 * spread)) return (mod * 9) / 10;
 
     return mod;
 }

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4337,10 +4337,23 @@ bool PlayerbotAI::AllowActivity(ActivityType activityType, bool checkNow)
 
 uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
 {
-    uint32 maxDiff = sWorldUpdateTime.GetAverageUpdateTime();
+    uint32 diffLimitFloor = sPlayerbotAIConfig->botActiveAloneDiffLimitFloor;
+    uint32 diffLimitCeil = sPlayerbotAIConfig->botActiveAloneDiffLimitCeiling;
+    uint32 chkDiff = sWorldUpdateTime.GetAverageUpdateTime();  // By default check against average Diff
 
-    if (maxDiff > 500) return 0;
-    if (maxDiff > 250)
+    if (diffLimitFloor > diffLimitCeil)
+        diffLimitFloor = diffLimitCeil;
+
+    if (sPlayerbotAIConfig->botActiveAloneDiffMethod != 1)  // if set in config,
+        chkDiff = sWorldUpdateTime.GetMaxUpdateTime();  // check against 100th percentile (spikes)
+
+    if (chkDiff <= diffLimitFloor) return mod;
+    if (chkDiff >= diffLimitCeil) return 0;
+
+    uint32 diffRange = diffLimitCeil - diffLimitFloor;
+    double spread = (double)diffRange / 5;  // Calculate the equal spread between each number /w 5 steps
+
+    if (chkDiff > diffLimitFloor + (4 * spread))
     {
         if (Map* map = bot->GetMap())
         {
@@ -4358,12 +4371,12 @@ uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
             }
         }
 
-        return (mod * 1) / 10;
+        return (mod * 1 / 10);
     }
-    if (maxDiff > 200) return (mod * 3) / 10;
-    if (maxDiff > 150) return (mod * 5) / 10;
-    if (maxDiff > 100) return (mod * 6) / 10;
-    if (maxDiff > 75)  return (mod * 9) / 10;
+
+    if (chkDiff > diffLimitFloor + (3 * spread)) return (mod * 3) / 10;
+    if (chkDiff > diffLimitFloor + (2 * spread)) return (mod * 6) / 10;
+    if (chkDiff > diffLimitFloor + (1 * spread)) return (mod * 9) / 10;
 
     return mod;
 }

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4360,13 +4360,10 @@ uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
 {
     uint32 diffLimitFloor = sPlayerbotAIConfig->botActiveAloneDiffLimitFloor;
     uint32 diffLimitCeil = sPlayerbotAIConfig->botActiveAloneDiffLimitCeiling;
-    uint32 chkDiff = sWorldUpdateTime.GetAverageUpdateTime();  // By default check against average Diff
+    uint32 chkDiff = (sPlayerbotAIConfig->botActiveAloneDiffMethod == 2) ? sWorldUpdateTime.GetMaxUpdateTime() : sWorldUpdateTime.GetAverageUpdateTime();
 
     if (diffLimitFloor > diffLimitCeil)
         diffLimitFloor = diffLimitCeil;
-
-    if (sPlayerbotAIConfig->botActiveAloneDiffMethod != 1)  // if set in config,
-        chkDiff = sWorldUpdateTime.GetMaxUpdateTime();  // check against 100th percentile (spikes)
 
     if (chkDiff <= diffLimitFloor) return mod;
     if (chkDiff >= diffLimitCeil) return 0;

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4354,7 +4354,9 @@ uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
 {
     uint32 diffLimitFloor = sPlayerbotAIConfig->botActiveAloneDiffLimitFloor;
     uint32 diffLimitCeil = sPlayerbotAIConfig->botActiveAloneDiffLimitCeiling;
-    uint32 chkDiff = (sPlayerbotAIConfig->botActiveAloneDiffMethod == 2) ? sWorldUpdateTime.GetMaxUpdateTime() : sWorldUpdateTime.GetAverageUpdateTime();
+    uint32 chkDiff = (sPlayerbotAIConfig->botActiveAloneDiffMethod == 2) 
+        ? sWorldUpdateTime.GetMaxUpdateTime() 
+        : sWorldUpdateTime.GetAverageUpdateTime();
 
     if (diffLimitFloor > diffLimitCeil)
         diffLimitFloor = diffLimitCeil;

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4371,7 +4371,7 @@ uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
             }
         }
 
-        return (mod * 1 / 10);
+        return (mod * 1) / 10;
     }
 
     if (chkDiff > diffLimitFloor + (3 * spread)) return (mod * 3) / 10;

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -470,8 +470,8 @@ bool PlayerbotAIConfig::Initialize()
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
     botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
     botActiveAloneDiffMethod = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffMethod", 2);
-    botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 20);
-    botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 40);
+    botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 30);
+    botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 60);
     botActiveAloneSmartScaleWhenMinLevel =
         sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
     botActiveAloneSmartScaleWhenMaxLevel =

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -468,6 +468,7 @@ bool PlayerbotAIConfig::Initialize()
     playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
+    botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
     botActiveAloneDiffMethod = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffMethod", 2);
     botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 20);
     botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 40);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -477,8 +477,8 @@ bool PlayerbotAIConfig::Initialize()
     BotActiveAloneForceWhenInGuild = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenInGuild", 1);
     botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
     botActiveAloneDiffMethod = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffMethod", 2);
-    botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 30);
-    botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 60);
+    botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 40);
+    botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 150);
     botActiveAloneSmartScaleWhenMinLevel =
         sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
     botActiveAloneSmartScaleWhenMaxLevel =

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -476,13 +476,11 @@ bool PlayerbotAIConfig::Initialize()
     BotActiveAloneForceWhenIsFriend = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenIsFriend", 1);
     BotActiveAloneForceWhenInGuild = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenInGuild", 1);
     botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
-    botActiveAloneDiffMethod = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffMethod", 2);
-    botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 40);
-    botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 150);
-    botActiveAloneSmartScaleWhenMinLevel =
-        sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
-    botActiveAloneSmartScaleWhenMaxLevel =
-        sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel", 80);
+    botActiveAloneSmartScaleDiffMethod = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneSmartScaleDiffMethod", 2);
+    botActiveAloneSmartScaleDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneSmartScaleDiffLimitFloor", 40);
+    botActiveAloneSmartScaleDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneSmartScaleDiffLimitCeiling", 150);
+    botActiveAloneSmartScaleWhenMinLevel = sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
+    botActiveAloneSmartScaleWhenMaxLevel = sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMaxLevel", 80);
 
     randombotsWalkingRPG = sConfigMgr->GetOption<bool>("AiPlayerbot.RandombotsWalkingRPG", false);
     randombotsWalkingRPGInDoors = sConfigMgr->GetOption<bool>("AiPlayerbot.RandombotsWalkingRPG.InDoors", false);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -468,7 +468,9 @@ bool PlayerbotAIConfig::Initialize()
     playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
-    botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);
+    botActiveAloneDiffMethod = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffMethod", 2);
+    botActiveAloneDiffLimitFloor = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitFloor", 20);
+    botActiveAloneDiffLimitCeiling = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneDiffLimitCeiling", 40);
     botActiveAloneSmartScaleWhenMinLevel =
         sConfigMgr->GetOption<uint32>("AiPlayerbot.botActiveAloneSmartScaleWhenMinLevel", 1);
     botActiveAloneSmartScaleWhenMaxLevel =

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -264,6 +264,9 @@ public:
     uint32 playerbotsXPrate;
     bool disableDeathKnightLogin;
     uint32 botActiveAlone;
+    uint32 botActiveAloneDiffMethod;
+    uint32 botActiveAloneDiffLimitFloor;
+    uint32 botActiveAloneDiffLimitCeiling;
     bool botActiveAloneSmartScale;
     uint32 botActiveAloneSmartScaleWhenMinLevel;
     uint32 botActiveAloneSmartScaleWhenMaxLevel;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -264,17 +264,17 @@ public:
     uint32 playerbotsXPrate;
     bool disableDeathKnightLogin;
     uint32 botActiveAlone;
+    bool botActiveAloneSmartScale;
     uint32 botActiveAloneSmartScaleWhenMinLevel;
     uint32 botActiveAloneSmartScaleWhenMaxLevel;
     uint32 botActiveAloneDiffMethod;
     uint32 botActiveAloneDiffLimitFloor;
     uint32 botActiveAloneDiffLimitCeiling;
     uint32 BotActiveAloneWhenInRadius;
-    bool botActiveAloneSmartScale;
     bool BotActiveAloneForceWhenInZone;
     bool BotActiveAloneForceWhenInMap;
     bool BotActiveAloneForceWhenIsFriend;
-    bool BotActiveAloneForceWhenInGuild;
+    bool BotActiveAloneForceWhenInGuild;    
 
     bool freeMethodLoot;
     int32 lootRollLevel;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -263,20 +263,20 @@ public:
     bool disableRandomLevels;
     uint32 playerbotsXPrate;
     bool disableDeathKnightLogin;
+
     uint32 botActiveAlone;
+    uint32 BotActiveAloneForceWhenInRadius;
+    bool BotActiveAloneForceWhenInZone;
+    bool BotActiveAloneForceWhenInMap;
+    bool BotActiveAloneForceWhenIsFriend;
+    bool BotActiveAloneForceWhenInGuild; 
 
     bool botActiveAloneSmartScale;
     uint32 botActiveAloneSmartScaleWhenMinLevel;
     uint32 botActiveAloneSmartScaleWhenMaxLevel;
-    uint32 botActiveAloneDiffMethod;
-    uint32 botActiveAloneDiffLimitFloor;
-    uint32 botActiveAloneDiffLimitCeiling;
-    uint32 BotActiveAloneForceWhenInRadius;
-
-    bool BotActiveAloneForceWhenInZone;
-    bool BotActiveAloneForceWhenInMap;
-    bool BotActiveAloneForceWhenIsFriend;
-    bool BotActiveAloneForceWhenInGuild;    
+    uint32 botActiveAloneSmartScaleDiffMethod;
+    uint32 botActiveAloneSmartScaleDiffLimitFloor;
+    uint32 botActiveAloneSmartScaleDiffLimitCeiling;
 
     bool freeMethodLoot;
     int32 lootRollLevel;


### PR DESCRIPTION
These changes go further on the great work of @hermensbas and let you configure a floor-ceiling range DIFF-wise in which you'd like to have your server perform in respect to the amount of active bots. There's a 5-stage stepping calculated between these values, that logic pretty much stays the same.

The second addition is that one can now choose to compare against the AverageUpdateTime or MaxUpdateTime (spikes)
The benefit of comparing against MaxUpdateTime is that more efforts will be done to keep and try your server performance within set botActiveAloneDiffLimitCeiling.