### PR TITLE
Allow bots to trade conjured items

### DIFF
--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -207,7 +207,7 @@ bool TradeStatusAction::CheckTrade()
     for (uint32 slot = 0; slot < TRADE_SLOT_TRADED_COUNT; ++slot)
     {
         Item* item = bot->GetTradeData()->GetItem((TradeSlots)slot);
-        if (item && !item->GetTemplate()->SellPrice)
+        if (item && !item->GetTemplate()->SellPrice && !item->GetTemplate()->IsConjuredConsumable())
         {
             std::ostringstream out;
             out << chat->FormatItem(item->GetTemplate()) << " - This is not for sale";


### PR DESCRIPTION
Since they didn't have any sell value you couldn't get a bot to give you a healthstone or conjured food/water.  This change allows them to be traded to you without altering any of the other logic for bot trades.

Fixes issue #452 