### PR TITLE
botActiveAlone: added new botActiveAlone confguration option

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1514,6 +1514,7 @@ AiPlayerbot.BotActiveAlone = 100
 # Force botActiveAlone when bot is ... of real player
 AiPlayerbot.BotActiveAloneForceWhenInRadius = 150;
 AiPlayerbot.BotActiveAloneForceWhenInZone = 1;
+AiPlayerbot.BotActiveAloneForceWhenInMap = 0;
 AiPlayerbot.BotActiveAloneForceWhenIsFriend = 1;
 AiPlayerbot.BotActiveAloneForceWhenInGuild = 1;
 

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4172,6 +4172,15 @@ bool PlayerbotAI::AllowActive(ActivityType activityType)
         }
     }
 
+    // bot map has active players.
+    if (sPlayerbotAIConfig->BotActiveAloneForceWhenInMap)
+    {
+        if (HasRealPlayers(bot->GetMap()))
+        {
+            return true;
+        }
+    }
+
     // bot zone has active players.
     if (sPlayerbotAIConfig->BotActiveAloneForceWhenInZone)
     {

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -470,6 +470,7 @@ bool PlayerbotAIConfig::Initialize()
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
     BotActiveAloneWhenInRadius = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAloneWhenInRadius", 150);
     BotActiveAloneForceWhenInZone = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenInZone", 1);
+    BotActiveAloneForceWhenInMap = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenInMap", 0);
     BotActiveAloneForceWhenIsFriend = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenIsFriend", 1);
     BotActiveAloneForceWhenInGuild = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenInGuild", 1);
     botActiveAloneSmartScale = sConfigMgr->GetOption<bool>("AiPlayerbot.botActiveAloneSmartScale", 1);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -266,6 +266,7 @@ public:
     uint32 botActiveAlone;
     uint32 BotActiveAloneWhenInRadius;
     bool BotActiveAloneForceWhenInZone;
+    bool BotActiveAloneForceWhenInMap;
     bool BotActiveAloneForceWhenIsFriend;
     bool BotActiveAloneForceWhenInGuild;
     bool botActiveAloneSmartScale;


### PR DESCRIPTION
Added force all bots active when real players in the map, by default disabled.