### PR TITLE
Prevent bots attacking dummy targets at the Argent Tournament Grounds

### DIFF
--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -49,8 +49,15 @@ bool AttackAnythingAction::isUseful()
         return false;
 
     std::string const name = std::string(target->GetName());
-    if (!name.empty() && name.find("Dummy") != std::string::npos)  // Target is not a targetdummy
-        return false;
+    // Check for invalid targets: Dummy, Charge Target, Melee Target, Ranged Target
+    if (!name.empty() &&
+        (name.find("Dummy") != std::string::npos ||
+         name.find("Charge Target") != std::string::npos ||
+         name.find("Melee Target") != std::string::npos ||
+         name.find("Ranged Target") != std::string::npos))
+    {
+        return false;  // Target is one of the disallowed types
+    }
 
     // if (!ChooseRpgTargetAction::isFollowValid(bot, target))                               //Do not grind mobs far
     // away from master.


### PR DESCRIPTION
There was existing code to ignore practice targets (anything with Dummy in the name) so I've just added the names of practice targets located in the tournament grounds:

Charge Target
Melee Target
Ranged Target

I considered just using the phrase "Target", but it is too generic and there are 246 creature_template names containing Target, some of which may cause issues if the bots don't attack them.