### PR TITLE
Fix bots attacking others despite being in a prohibited zone - Issue 227

### DIFF
--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -75,14 +75,6 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         return false;
     }
 
-    if (target->IsPlayer() && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
-    {
-        if (verbose)
-            botAI->TellError("I cannot attack players in prohbited Zones");
-
-        return false;
-    }
-
     std::ostringstream msg;
     msg << target->GetName();
 
@@ -107,6 +99,14 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         msg << " is dead";
         if (verbose)
             botAI->TellError(msg.str());
+
+        return false;
+    }
+
+    if ((target->IsPlayer() || target->IsPet()) && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
+    {
+        if (verbose)
+            botAI->TellError("I cannot attack others in PVP prohbited zones");
 
         return false;
     }

--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -89,9 +89,11 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
 
     if (!bot->IsWithinLOSInMap(target))
     {
-        msg << " is not on my sight";
+        msg << " is not in my sight";
         if (verbose)
             botAI->TellError(msg.str());
+        
+        return false;
     }
 
     if (target->isDead())
@@ -103,7 +105,7 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         return false;
     }
 
-    if ((target->IsPlayer() || target->IsPet()) && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
+    if (!bot->IsValidAttackTarget(target) && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
     {
         if (verbose)
             botAI->TellError("I cannot attack others in PvP prohibited zones");

--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -74,6 +74,15 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
     {
         return false;
     }
+
+    if (target->IsPlayer() && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
+    {
+        if (verbose)
+            botAI->TellError("I cannot attack players in prohbited Zones");
+
+        return false;
+    }
+
     std::ostringstream msg;
     msg << target->GetName();
 

--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -106,7 +106,7 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
     if ((target->IsPlayer() || target->IsPet()) && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
     {
         if (verbose)
-            botAI->TellError("I cannot attack others in PVP prohbited zones");
+            botAI->TellError("I cannot attack others in PvP prohibited zones");
 
         return false;
     }


### PR DESCRIPTION
Prevent bots to attack other players(bots) when in prohibited zones.
Fixes issue https://github.com/liyunfan1223/mod-playerbots/issues/227

In addition, it:
 - will prevent bots ability to kill other faction NPC's with the **do attack my target** command while they are near the target.
 - corrects the **out of sight** return.