### PR TITLE
Ulduar-Razorscale strategy

### DIFF
--- a/src/strategy/raids/ulduar/RaidUlduarActionContext.h
+++ b/src/strategy/raids/ulduar/RaidUlduarActionContext.h
@@ -17,11 +17,25 @@ public:
     {
         creators["flame leviathan vehicle"] = &RaidUlduarActionContext::flame_leviathan_vehicle;
         creators["flame leviathan enter vehicle"] = &RaidUlduarActionContext::flame_leviathan_enter_vehicle;
+        creators["razorscale avoid devouring flames"] = &RaidUlduarActionContext::razorscale_avoid_devouring_flames;
+        creators["razorscale avoid sentinel"] = &RaidUlduarActionContext::razorscale_avoid_sentinel;
+        creators["razorscale ignore flying alone"] = &RaidUlduarActionContext::razorscale_ignore_flying_alone;
+        creators["razorscale avoid whirlwind"] = &RaidUlduarActionContext::razorscale_avoid_whirlwind;
+        creators["razorscale grounded"] = &RaidUlduarActionContext::razorscale_grounded;
+        creators["razorscale harpoon action"] = &RaidUlduarActionContext::razorscale_harpoon_action;
+        creators["razorscale fuse armor action"] = &RaidUlduarActionContext::razorscale_fuse_armor_action;
     }
 
 private:
     static Action* flame_leviathan_vehicle(PlayerbotAI* ai) { return new FlameLeviathanVehicleAction(ai); }
     static Action* flame_leviathan_enter_vehicle(PlayerbotAI* ai) { return new FlameLeviathanEnterVehicleAction(ai); }
+    static Action* razorscale_avoid_devouring_flames(PlayerbotAI* ai) { return new RazorscaleAvoidDevouringFlameAction(ai); }
+    static Action* razorscale_avoid_sentinel(PlayerbotAI* ai) { return new RazorscaleAvoidSentinelAction(ai); }
+    static Action* razorscale_ignore_flying_alone(PlayerbotAI* ai) { return new RazorscaleIgnoreBossAction(ai); }
+    static Action* razorscale_avoid_whirlwind(PlayerbotAI* ai) { return new RazorscaleAvoidWhirlwindAction(ai); }
+    static Action* razorscale_grounded(PlayerbotAI* ai) { return new RazorscaleGroundedAction(ai); }
+    static Action* razorscale_harpoon_action(PlayerbotAI* ai) { return new RazorscaleHarpoonAction(ai); }
+    static Action* razorscale_fuse_armor_action(PlayerbotAI* ai) { return new RazorscaleFuseArmorAction(ai); }
 };
 
 #endif

--- a/src/strategy/raids/ulduar/RaidUlduarActions.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarActions.cpp
@@ -440,6 +440,12 @@ bool RazorscaleAvoidDevouringFlameAction::Execute(Event event)
         }
     }
 
+    // Off tanks are following the main tank during grounded and should prioritise stacking
+    if (razorscaleHelper.IsGroundPhase() && (botAI->IsTank(bot) && !botAI->IsMainTank(bot)))
+    {
+        return false;
+    }
+
     // Handle movement from flames
     if (closestDistance < safeDistance)
     {
@@ -477,11 +483,6 @@ bool RazorscaleAvoidSentinelAction::Execute(Event event)
 {
     bool isTank = botAI->IsTank(bot);
     bool isMainTank = botAI->IsMainTank(bot);
-    if (isTank && !isMainTank)
-    {
-        return false;
-    }
-
     bool isRanged = botAI->IsRanged(bot);
     const float radius = 8.0f;
 
@@ -512,37 +513,75 @@ bool RazorscaleAvoidSentinelAction::Execute(Event event)
         }
     }
 
-    // Mark the lowest-health sentinel with Skull if main tank
-    if (isMainTank && lowestHealthSentinel)
+    // Check if the main tank is a human player
+    Unit* mainTankUnit = AI_VALUE(Unit*, "main tank");
+    Player* mainTank = mainTankUnit ? mainTankUnit->ToPlayer() : nullptr;
+    
+    if (mainTank && !GET_PLAYERBOT_AI(mainTank)) // Main tank is a real player
+    {
+        // Iterate through the first 3 bot tanks to assign the Skull marker
+        for (int i = 0; i < 3; ++i)
+        {
+            if (botAI->IsAssistTankOfIndex(bot, i) && GET_PLAYERBOT_AI(bot)) // Bot is a valid tank
+            {
+                Group* group = bot->GetGroup();
+                if (group && lowestHealthSentinel)
+                {
+                    int8 skullIndex = 7; // Skull
+                    ObjectGuid currentSkullTarget = group->GetTargetIcon(skullIndex);
+    
+                    // If there's no skull set yet, or the skull is on a different target, set the sentinel
+                    if (!currentSkullTarget || (lowestHealthSentinel->GetGUID() != currentSkullTarget))
+                    {
+                        group->SetTargetIcon(skullIndex, bot->GetGUID(), lowestHealthSentinel->GetGUID());
+                    }
+                }
+                break; // Stop after finding the first valid bot tank
+            }
+        }
+    }
+    else if (isMainTank && lowestHealthSentinel) // Bot is the main tank
     {
         Group* group = bot->GetGroup();
         if (group)
         {
             int8 skullIndex = 7; // Skull
             ObjectGuid currentSkullTarget = group->GetTargetIcon(skullIndex);
-            if (currentSkullTarget && lowestHealthSentinel->GetGUID() != currentSkullTarget)
+    
+            // If there's no skull set yet, or the skull is on a different target, set the sentinel
+            if (!currentSkullTarget || (lowestHealthSentinel->GetGUID() != currentSkullTarget))
             {
                 group->SetTargetIcon(skullIndex, bot->GetGUID(), lowestHealthSentinel->GetGUID());
             }
         }
     }
 
+
     return movedAway; // Return true if moved
 }
 
 bool RazorscaleAvoidSentinelAction::isUseful()
 {
-    bool isTank = botAI->IsTank(bot);
     bool isMainTank = botAI->IsMainTank(bot);
-    if (isTank && !isMainTank)
-    {
-        return false;
-    }
-
-    // Main tank always tries to mark sentinel
+    Unit* mainTankUnit = AI_VALUE(Unit*, "main tank");
+    Player* mainTank = mainTankUnit ? mainTankUnit->ToPlayer() : nullptr;
+    
+    // If this bot is the main tank, it should always try to mark
     if (isMainTank)
     {
         return true;
+    }
+    
+    // If the main tank is a human, check if this bot is one of the first three valid bot tanks
+    if (mainTank && !GET_PLAYERBOT_AI(mainTank)) // Main tank is a human player
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            if (botAI->IsAssistTankOfIndex(bot, i) && GET_PLAYERBOT_AI(bot)) // Bot is a valid tank
+            {
+                return true; // This bot should assist with marking
+            }
+        }
     }
 
     bool isRanged = botAI->IsRanged(bot);
@@ -621,30 +660,62 @@ bool RazorscaleIgnoreBossAction::isUseful()
     Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
     if (!boss)
     {
-        return false; 
+        return false;
     }
 
     // Check if the boss is flying
     if (boss->GetPositionZ() >= RazorscaleBossHelper::RAZORSCALE_FLYING_Z_THRESHOLD)
     {
-        bool isMainTank = botAI->IsMainTank(bot);
         // Check if the bot is outside the designated area
-        if (bot->GetDistance2d(RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X, RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y) > RazorscaleBossHelper::RAZORSCALE_ARENA_RADIUS + 25.0f)
+        if (bot->GetDistance2d(
+                RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
+                RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y) > RazorscaleBossHelper::RAZORSCALE_ARENA_RADIUS + 25.0f)
+        {
+            return true; // Movement to the center is the top priority for all bots
+        }
+
+        if (!botAI->IsTank(bot))
+        {
+            return false;
+        }
+        
+        Group* group = bot->GetGroup();
+        if (!group)
+        {
+            return false;
+        }
+
+        // Check if the boss is already set as the moon marker
+        int8 moonIndex = 4; // Moon marker index
+        ObjectGuid currentMoonTarget = group->GetTargetIcon(moonIndex);
+        if (currentMoonTarget == boss->GetGUID())
+        {
+            return false; // Moon marker is already correctly set, no further action needed
+        }
+
+        // Proceed to tank-specific logic
+        Unit* mainTankUnit = AI_VALUE(Unit*, "main tank");
+        Player* mainTank = mainTankUnit ? mainTankUnit->ToPlayer() : nullptr;
+
+        // If this bot is the main tank, it needs to set the moon marker
+        if (mainTankUnit == bot)
         {
             return true;
         }
-        // Check moon mark if main tank
-        if (isMainTank)
+
+        // If the main tank is a human, check if this bot is the lowest-indexed bot tank
+        if (mainTank && !GET_PLAYERBOT_AI(mainTank)) // Main tank is a human player
         {
-            Group* group = bot->GetGroup();
-            if (group)
+        for (int i = 0; i < 3; ++i) // Only iterate through the first 3 indexes
             {
-                int8 moonIndex = 4;
-                ObjectGuid currentMoonTarget = group->GetTargetIcon(moonIndex);
-                return currentMoonTarget != boss->GetGUID();
+                if (botAI->IsAssistTankOfIndex(bot, i) && GET_PLAYERBOT_AI(bot)) // Valid bot tank
+                {
+                    return true; // This bot should assign the marker
+                }
             }
         }
     }
+
     return false;
 }
 
@@ -653,13 +724,20 @@ bool RazorscaleIgnoreBossAction::Execute(Event event)
     Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
     if (!boss)
     {
-        return false; 
+        return false;
     }
 
-    bool isMainTank = botAI->IsMainTank(bot);
-    if (!isMainTank)
+    Group* group = bot->GetGroup();
+    if (!group)
     {
-        // Move non-tanks inside
+        return false;
+    }
+
+    // Check if the bot is outside the designated area and move inside first
+    if (bot->GetDistance2d(
+            RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
+            RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y) > RazorscaleBossHelper::RAZORSCALE_ARENA_RADIUS + 25.0f)
+    {
         return MoveInside(
             ULDUAR_MAP_ID,
             RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
@@ -670,22 +748,43 @@ bool RazorscaleIgnoreBossAction::Execute(Event event)
         );
     }
 
-    Group* group = bot->GetGroup();
-    if (!group)
+    if (!botAI->IsTank(bot))
     {
         return false;
     }
 
-    // Assign moon rti to boss
+    // Check if the boss is already set as the moon marker
     int8 moonIndex = 4;
     ObjectGuid currentMoonTarget = group->GetTargetIcon(moonIndex);
-    if (currentMoonTarget != boss->GetGUID())
+    if (currentMoonTarget == boss->GetGUID())
+    {
+        return false; // Moon marker is already correctly set
+    }
+
+    // Get the main tank and determine role
+    Unit* mainTankUnit = AI_VALUE(Unit*, "main tank");
+    Player* mainTank = mainTankUnit ? mainTankUnit->ToPlayer() : nullptr;
+
+    // If the main tank is a human, assign the moon marker using the lowest-indexed bot tank
+    if (mainTank && !GET_PLAYERBOT_AI(mainTank)) // Main tank is a real player
+    {
+        for (int i = 0; i < 3; ++i) // Only iterate through the first 3 indexes
+        {
+            if (botAI->IsAssistTankOfIndex(bot, i) && GET_PLAYERBOT_AI(bot)) // Bot is a valid tank
+            {
+                group->SetTargetIcon(moonIndex, bot->GetGUID(), boss->GetGUID());
+                SetNextMovementDelay(1000);
+                break; // Assign the moon marker and stop
+            }
+        }
+    }
+    else if (mainTankUnit == bot) // If this bot is the main tank
     {
         group->SetTargetIcon(moonIndex, bot->GetGUID(), boss->GetGUID());
         SetNextMovementDelay(1000);
     }
 
-    // Move main tank inside
+    // Tanks move inside the arena
     return MoveInside(
         ULDUAR_MAP_ID,
         RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
@@ -792,10 +891,35 @@ bool RazorscaleGroundedAction::Execute(Event event)
     if (!group)
         return false;
 
-    if (botAI->IsMainTank(bot))
+    Unit* mainTankUnit = AI_VALUE(Unit*, "main tank");
+    Player* mainTank = mainTankUnit ? mainTankUnit->ToPlayer() : nullptr;
+    
+    if (mainTank && !GET_PLAYERBOT_AI(mainTank)) // Main tank is a human player
+    {
+        // Iterate through the first 3 bot tanks to handle the moon marker
+        for (int i = 0; i < 3; ++i)
+        {
+            if (botAI->IsAssistTankOfIndex(bot, i) && GET_PLAYERBOT_AI(bot)) // Bot is a valid tank
+            {
+                int8 moonIndex = 4;
+                ObjectGuid currentMoonTarget = group->GetTargetIcon(moonIndex);
+    
+                // If the moon marker is set to the boss, reset it
+                if (currentMoonTarget == boss->GetGUID())
+                {
+                    group->SetTargetIcon(moonIndex, bot->GetGUID(), ObjectGuid::Empty);
+                    SetNextMovementDelay(1000);
+                    return true;
+                }
+            }
+        }
+    }
+    else if (botAI->IsMainTank(bot)) // Bot is the main tank
     {
         int8 moonIndex = 4;
         ObjectGuid currentMoonTarget = group->GetTargetIcon(moonIndex);
+    
+        // If the moon marker is set to the boss, reset it
         if (currentMoonTarget == boss->GetGUID())
         {
             group->SetTargetIcon(moonIndex, bot->GetGUID(), ObjectGuid::Empty);
@@ -804,24 +928,12 @@ bool RazorscaleGroundedAction::Execute(Event event)
         }
     }
 
-    if (botAI->IsTank(bot))
-    {
-        Player* mainTank = nullptr;
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            Player* member = ref->GetSource();
-            if (member && botAI->IsMainTank(member))
-            {
-                mainTank = member;
-                break;
-            }
-        }
 
-        if (mainTank)
-        {
+    if (mainTank && (botAI->IsTank(bot) && !botAI->IsMainTank(bot)))
+    {
+
             constexpr float followDistance = 2.0f;
             return MoveNear(mainTank, followDistance, MovementPriority::MOVEMENT_COMBAT);
-        }
     }
 
     if (botAI->IsRanged(bot))

--- a/src/strategy/raids/ulduar/RaidUlduarActions.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarActions.cpp
@@ -661,7 +661,7 @@ bool RazorscaleIgnoreBossAction::Execute(Event event)
     {
         // Move non-tanks inside
         return MoveInside(
-            RazorscaleBossHelper::ULDUAR_MAP_ID,
+            ULDUAR_MAP_ID,
             RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
             RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y,
             bot->GetPositionZ(),
@@ -687,7 +687,7 @@ bool RazorscaleIgnoreBossAction::Execute(Event event)
 
     // Move main tank inside
     return MoveInside(
-        RazorscaleBossHelper::ULDUAR_MAP_ID,
+        ULDUAR_MAP_ID,
         RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
         RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y,
         bot->GetPositionZ(),
@@ -843,7 +843,7 @@ bool RazorscaleGroundedAction::Execute(Event event)
             // If at the initial landing position, use 12-yard radius with a
             // 20 yard offset on the Y axis so everyone is behind the boss
             return MoveInside(
-                RazorscaleBossHelper::ULDUAR_MAP_ID,
+                ULDUAR_MAP_ID,
                 RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
                 RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y - 20.0f,
                 bot->GetPositionZ(),
@@ -854,7 +854,7 @@ bool RazorscaleGroundedAction::Execute(Event event)
 
         // Otherwise, move inside a 12-yard radius around the arena center
         return MoveInside(
-            RazorscaleBossHelper::ULDUAR_MAP_ID,
+            ULDUAR_MAP_ID,
             RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_X,
             RazorscaleBossHelper::RAZORSCALE_ARENA_CENTER_Y,
             bot->GetPositionZ(),

--- a/src/strategy/raids/ulduar/RaidUlduarActions.h
+++ b/src/strategy/raids/ulduar/RaidUlduarActions.h
@@ -11,6 +11,10 @@
 #include "RaidUlduarBossHelper.h"
 #include "Vehicle.h"
 
+//
+//  Flame Leviathan
+//
+
 class FlameLeviathanVehicleAction : public MovementAction
 {
 public:
@@ -40,6 +44,66 @@ protected:
     bool EnterVehicle(Unit* vehicleBase, bool moveIfFar);
     bool ShouldEnter(Unit* vehicleBase);
     bool AllMainVehiclesOnUse();
+};
+
+//
+//  Razorscale
+//
+
+class RazorscaleAvoidDevouringFlameAction : public MovementAction
+{
+public:
+    RazorscaleAvoidDevouringFlameAction(PlayerbotAI* botAI) : MovementAction(botAI, "razorscale avoid devouring flames") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+class RazorscaleAvoidSentinelAction : public MovementAction
+{
+public:
+    RazorscaleAvoidSentinelAction(PlayerbotAI* botAI) : MovementAction(botAI, "razorscale avoid sentinel") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+class RazorscaleIgnoreBossAction : public AttackAction
+{
+public:
+    RazorscaleIgnoreBossAction(PlayerbotAI* botAI) : AttackAction(botAI, "razorscale ignore flying alone") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+class RazorscaleAvoidWhirlwindAction : public MovementAction
+{
+public:
+    RazorscaleAvoidWhirlwindAction(PlayerbotAI* botAI) : MovementAction(botAI, "razorscale avoid whirlwind") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+class RazorscaleGroundedAction : public AttackAction
+{
+public:
+    RazorscaleGroundedAction(PlayerbotAI* botAI) : AttackAction(botAI, "razorscale grounded") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+class RazorscaleHarpoonAction : public MovementAction
+{
+public:
+    RazorscaleHarpoonAction(PlayerbotAI* botAI) : MovementAction(botAI, "razorscale harpoon action") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+class RazorscaleFuseArmorAction : public MovementAction
+{
+public:
+    RazorscaleFuseArmorAction(PlayerbotAI* botAI) : MovementAction(botAI, "razorscale fuse armor action") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
 };
 
 #endif

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -184,5 +184,14 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
     // Assign the single main tank
     group->SetGroupMemberFlag(newMainTank->GetGUID(), true, MEMBER_FLAG_MAINTANK);
 
+    // Notify if the new main tank is a real player
+    if (GET_PLAYERBOT_AI(newMainTank)->IsRealPlayer())
+    {
+        const std::string playerName = newMainTank->GetName();
+        const auto text = BOT_TEXT2("%s please taunt Razorscale now!", { playerName });
+        botAI->Say(text);
+    }
+
     _lastRoleSwapTime = std::time(nullptr);
 }
+

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -133,8 +133,24 @@ bool RazorscaleBossHelper::AreRolesAssigned() const
 
 bool RazorscaleBossHelper::CanSwapRoles() const
 {
+    // Identify the GUID of the current bot
+    ObjectGuid botGuid = bot->GetGUID();
+    if (!botGuid)
+        return false;
+
+    // If no entry exists yet for this bot, initialize it to 0
+    auto it = _lastRoleSwapTime.find(botGuid);
+    if (it == _lastRoleSwapTime.end())
+    {
+        _lastRoleSwapTime[botGuid] = 0;
+        it = _lastRoleSwapTime.find(botGuid);
+    }
+
+    // Compare the current time against the stored time
     std::time_t currentTime = std::time(nullptr);
-    return (currentTime - _lastRoleSwapTime) >= _roleSwapCooldown;
+    std::time_t lastSwapTime = it->second;
+
+    return (currentTime - lastSwapTime) >= _roleSwapCooldown;
 }
 
 void RazorscaleBossHelper::AssignRolesBasedOnHealth()

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -188,7 +188,7 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
     if (GET_PLAYERBOT_AI(newMainTank)->IsRealPlayer())
     {
         const std::string playerName = newMainTank->GetName();
-        const auto text = BOT_TEXT2("%s please taunt Razorscale now!", { playerName });
+        const std::string text = playerName + ", please taunt Razorscale now!";
         botAI->Say(text);
     }
 

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -1,0 +1,188 @@
+#include "RaidUlduarBossHelper.h"
+#include "ObjectAccessor.h"
+#include "GameObject.h"
+#include "Group.h"
+#include "ScriptedCreature.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "World.h"
+
+std::unordered_map<ObjectGuid, time_t> RazorscaleBossHelper::_harpoonCooldowns;
+
+bool RazorscaleBossHelper::UpdateBossAI()
+{
+    _boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (_boss)
+    {
+        Group* group = bot->GetGroup();
+        if (group && !AreRolesAssigned())
+        {
+            AssignRolesBasedOnHealth();
+        }
+        return true;
+    }
+    return false;
+}
+
+Unit* RazorscaleBossHelper::GetBoss() const
+{
+    return _boss;
+}
+
+bool RazorscaleBossHelper::IsGroundPhase() const
+{
+    return _boss && _boss->IsAlive() &&
+           (_boss->GetPositionZ() <= RAZORSCALE_FLYING_Z_THRESHOLD) &&
+           (_boss->GetHealthPct() < 50.0f) &&
+           !_boss->HasAura(SPELL_STUN_AURA);
+}
+
+bool RazorscaleBossHelper::IsFlyingPhase() const
+{
+    return _boss && (!IsGroundPhase() || _boss->GetPositionZ() >= RAZORSCALE_FLYING_Z_THRESHOLD);
+}
+
+bool RazorscaleBossHelper::IsHarpoonFired(uint32 chainSpellId) const
+{
+    return _boss && _boss->HasAura(chainSpellId);
+}
+
+bool RazorscaleBossHelper::IsHarpoonReady(GameObject* harpoonGO)
+{
+    if (!harpoonGO)
+        return false;
+
+    auto it = _harpoonCooldowns.find(harpoonGO->GetGUID());
+    if (it != _harpoonCooldowns.end())
+    {
+        time_t currentTime = std::time(nullptr);
+        time_t elapsedTime = currentTime - it->second;
+        if (elapsedTime < HARPOON_COOLDOWN_DURATION)
+            return false;
+    }
+
+    return harpoonGO->GetGoState() == GO_STATE_READY;
+}
+
+void RazorscaleBossHelper::SetHarpoonOnCooldown(GameObject* harpoonGO)
+{
+    if (!harpoonGO)
+        return;
+
+    time_t currentTime = std::time(nullptr);
+    _harpoonCooldowns[harpoonGO->GetGUID()] = currentTime;
+}
+
+GameObject* RazorscaleBossHelper::FindNearestHarpoon(float x, float y, float z) const
+{
+    GameObject* nearestHarpoon = nullptr;
+    float minDistanceSq = std::numeric_limits<float>::max();
+
+    for (const auto& harpoon : GetHarpoonData())
+    {
+        if (GameObject* harpoonGO = bot->FindNearestGameObject(harpoon.gameObjectEntry, 200.0f))
+        {
+            float dx = harpoonGO->GetPositionX() - x;
+            float dy = harpoonGO->GetPositionY() - y;
+            float dz = harpoonGO->GetPositionZ() - z;
+            float distanceSq = dx * dx + dy * dy + dz * dz;
+
+            if (distanceSq < minDistanceSq)
+            {
+                minDistanceSq = distanceSq;
+                nearestHarpoon = harpoonGO;
+            }
+        }
+    }
+
+    return nearestHarpoon;
+}
+
+const std::vector<RazorscaleBossHelper::HarpoonData>& RazorscaleBossHelper::GetHarpoonData()
+{
+    static const std::vector<HarpoonData> harpoonData =
+    {
+        { GO_RAZORSCALE_HARPOON_1, SPELL_CHAIN_1 },
+        { GO_RAZORSCALE_HARPOON_2, SPELL_CHAIN_2 },
+        { GO_RAZORSCALE_HARPOON_3, SPELL_CHAIN_3 },
+        { GO_RAZORSCALE_HARPOON_4, SPELL_CHAIN_4 },
+    };
+    return harpoonData;
+}
+
+bool RazorscaleBossHelper::AreRolesAssigned() const
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member)
+            continue;
+
+        if (botAI->IsMainTank(member))
+            return true;
+    }
+
+    return false;
+}
+
+bool RazorscaleBossHelper::CanSwapRoles() const
+{
+    std::time_t currentTime = std::time(nullptr);
+    return (currentTime - _lastRoleSwapTime) >= _roleSwapCooldown;
+}
+
+void RazorscaleBossHelper::AssignRolesBasedOnHealth()
+{
+    if (!CanSwapRoles())
+        return;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return;
+
+    // Gather all tank bots in the group, excluding those with Fuse Armor
+    std::vector<Player*> tankBots;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || !botAI->IsTank(member) || !member->IsAlive())
+            continue;
+
+        Aura* fuseArmor = member->GetAura(SPELL_FUSEARMOR);
+        if (fuseArmor && fuseArmor->GetStackAmount() >= FUSEARMOR_THRESHOLD)
+            continue;
+
+        tankBots.push_back(member);
+    }
+
+    if (tankBots.empty())
+        return;
+
+    // Sort tanks by max health descending
+    std::sort(tankBots.begin(), tankBots.end(),
+        [](Player* a, Player* b)
+        {
+            return a->GetMaxHealth() > b->GetMaxHealth();
+        }
+    );
+
+    Player* newMainTank = tankBots[0];
+
+    // Remove all MAINTANK flags
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (member && botAI->IsMainTank(member))
+            group->SetGroupMemberFlag(member->GetGUID(), false, MEMBER_FLAG_MAINTANK);
+    }
+
+    // Assign the single main tank
+    group->SetGroupMemberFlag(newMainTank->GetGUID(), true, MEMBER_FLAG_MAINTANK);
+
+    _lastRoleSwapTime = std::time(nullptr);
+}

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -1,3 +1,4 @@
+#include "ChatHelper.h"
 #include "RaidUlduarBossHelper.h"
 #include "ObjectAccessor.h"
 #include "GameObject.h"
@@ -189,7 +190,10 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
     // Notify if the new main tank is a real player
     if (GET_PLAYERBOT_AI(newMainTank) && GET_PLAYERBOT_AI(newMainTank)->IsRealPlayer())
     {
-        const std::string text = newMainTank->GetName() + ", please taunt Razorscale now!";
+        const std::string playerName = newMainTank->GetName();
+        const std::string text = playerName + " please taunt Razorscale now!";
+        
+        // const std::string text = newMainTank->GetName() + ", please taunt Razorscale now!";
         bot->Say(text, LANG_UNIVERSAL);
     }
 

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -202,9 +202,8 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
     // Otherwise, we have a real player
     const std::string playerName = newMainTank->GetName();
     const std::string text = playerName + " please taunt Razorscale now!";
-    
-    bot->Say("Test message from Razorscale debug!", LANG_UNIVERSAL);
-    bot->Say(text, LANG_UNIVERSAL);
+
+    bot->Yell(text, LANG_UNIVERSAL);
 
     _lastRoleSwapTime = std::time(nullptr);
 }

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -190,7 +190,7 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
     if (GET_PLAYERBOT_AI(newMainTank) && GET_PLAYERBOT_AI(newMainTank)->IsRealPlayer())
     {
         const std::string text = newMainTank->GetName() + ", please taunt Razorscale now!";
-        botAI->Say(text);
+        bot->Say(text, LANG_UNIVERSAL);
     }
 
     _lastRoleSwapTime = std::time(nullptr);

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -188,14 +188,23 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
     group->SetGroupMemberFlag(newMainTank->GetGUID(), true, MEMBER_FLAG_MAINTANK);
 
     // Notify if the new main tank is a real player
-    if (GET_PLAYERBOT_AI(newMainTank) && GET_PLAYERBOT_AI(newMainTank)->IsRealPlayer())
+    // If newMainTank is a real player, GET_PLAYERBOT_AI(...) should be null
+    PlayerbotAI* newMainTankAI = GET_PLAYERBOT_AI(newMainTank);
+    
+    // If this is a normal bot, newMainTankAI won't be nullptr, but it won't be a real player either
+    bool isRealPlayer = (newMainTankAI == nullptr);
+    
+    if (!isRealPlayer)
     {
-        const std::string playerName = newMainTank->GetName();
-        const std::string text = playerName + " please taunt Razorscale now!";
-        
-        // const std::string text = newMainTank->GetName() + ", please taunt Razorscale now!";
-        bot->Say(text, LANG_UNIVERSAL);
+        return;
     }
+    
+    // Otherwise, we have a real player
+    const std::string playerName = newMainTank->GetName();
+    const std::string text = playerName + " please taunt Razorscale now!";
+    
+    bot->Say("Test message from Razorscale debug!", LANG_UNIVERSAL);
+    bot->Say(text, LANG_UNIVERSAL);
 
     _lastRoleSwapTime = std::time(nullptr);
 }

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -133,24 +133,8 @@ bool RazorscaleBossHelper::AreRolesAssigned() const
 
 bool RazorscaleBossHelper::CanSwapRoles() const
 {
-    // Identify the GUID of the current bot
-    ObjectGuid botGuid = bot->GetGUID();
-    if (!botGuid)
-        return false;
-
-    // If no entry exists yet for this bot, initialize it to 0
-    auto it = _lastRoleSwapTime.find(botGuid);
-    if (it == _lastRoleSwapTime.end())
-    {
-        _lastRoleSwapTime[botGuid] = 0;
-        it = _lastRoleSwapTime.find(botGuid);
-    }
-
-    // Compare the current time against the stored time
     std::time_t currentTime = std::time(nullptr);
-    std::time_t lastSwapTime = it->second;
-
-    return (currentTime - lastSwapTime) >= _roleSwapCooldown;
+    return (currentTime - _lastRoleSwapTime) >= _roleSwapCooldown;
 }
 
 void RazorscaleBossHelper::AssignRolesBasedOnHealth()

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.cpp
@@ -205,5 +205,9 @@ void RazorscaleBossHelper::AssignRolesBasedOnHealth()
 
     bot->Yell(text, LANG_UNIVERSAL);
 
-    _lastRoleSwapTime = std::time(nullptr);
+    ObjectGuid botGuid = bot->GetGUID();
+    if (!botGuid)
+        return;
+    
+    _lastRoleSwapTime[botGuid] = std::time(nullptr);
 }

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.h
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.h
@@ -72,7 +72,7 @@ public:
     };
 
     explicit RazorscaleBossHelper(PlayerbotAI* botAI) 
-        : AiObject(botAI), _boss(nullptr), _lastRoleSwapTime(0), _roleSwapCooldown(10) {}
+        : AiObject(botAI), _boss(nullptr) {}
 
     bool UpdateBossAI();
     Unit* GetBoss() const;
@@ -93,8 +93,12 @@ public:
 
 private:
     Unit* _boss;
-    std::time_t _lastRoleSwapTime;
-    const std::time_t _roleSwapCooldown;
+
+    // A map to track the last role swap *per bot* by their GUID
+    static std::unordered_map<ObjectGuid, std::time_t> _lastRoleSwapTime;
+    
+    // The cooldown that applies to every bot
+    static const std::time_t _roleSwapCooldown = 10;
 
     static std::unordered_map<ObjectGuid, time_t> _harpoonCooldowns;
 };

--- a/src/strategy/raids/ulduar/RaidUlduarBossHelper.h
+++ b/src/strategy/raids/ulduar/RaidUlduarBossHelper.h
@@ -2,6 +2,11 @@
 #define _PLAYERBOT_RAIDULDUARBOSSHELPER_H
 
 #include <string>
+#include <unordered_map>
+#include <vector>
+#include <cmath>
+#include <ctime>
+#include <limits>
 
 #include "AiObject.h"
 #include "AiObjectContext.h"
@@ -15,6 +20,84 @@
 #include "SharedDefines.h"
 
 const uint32 ULDUAR_MAP_ID = 603;
+
+class RazorscaleBossHelper : public AiObject
+{
+public:
+    // Enums and constants specific to Razorscale
+    enum RazorscaleUnits : uint32
+    {
+        UNIT_RAZORSCALE          = 33186,
+        UNIT_DARK_RUNE_SENTINEL  = 33846,
+        UNIT_DARK_RUNE_WATCHER   = 33453,
+        UNIT_DARK_RUNE_GUARDIAN  = 33388,
+        UNIT_DEVOURING_FLAME     = 34188,
+    };
+
+    enum RazorscaleGameObjects : uint32
+    {
+        GO_RAZORSCALE_HARPOON_1 = 194519,
+        GO_RAZORSCALE_HARPOON_2 = 194541,
+        GO_RAZORSCALE_HARPOON_3 = 194542,
+        GO_RAZORSCALE_HARPOON_4 = 194543,
+    };
+
+    enum RazorscaleSpells : uint32
+    {
+        SPELL_CHAIN_1           = 49679,
+        SPELL_CHAIN_2           = 49682,
+        SPELL_CHAIN_3           = 49683,
+        SPELL_CHAIN_4           = 49684,
+        SPELL_SENTINEL_WHIRLWIND = 63806,
+        SPELL_STUN_AURA         = 62794,
+        SPELL_FUSEARMOR         = 64771
+    };
+
+    static constexpr uint32 FUSEARMOR_THRESHOLD = 2;
+
+    // Constants for arena parameters
+    static constexpr float RAZORSCALE_FLYING_Z_THRESHOLD = 440.0f;
+    static constexpr float RAZORSCALE_ARENA_CENTER_X = 587.54f;
+    static constexpr float RAZORSCALE_ARENA_CENTER_Y = -175.04f;
+    static constexpr float RAZORSCALE_ARENA_RADIUS = 30.0f;
+
+    // Harpoon cooldown (seconds)
+    static constexpr time_t HARPOON_COOLDOWN_DURATION = 5; 
+
+    // Structure for harpoon data
+    struct HarpoonData
+    {
+        uint32 gameObjectEntry;
+        uint32 chainSpellId;
+    };
+
+    explicit RazorscaleBossHelper(PlayerbotAI* botAI) 
+        : AiObject(botAI), _boss(nullptr), _lastRoleSwapTime(0), _roleSwapCooldown(10) {}
+
+    bool UpdateBossAI();
+    Unit* GetBoss() const;
+
+    bool IsGroundPhase() const;
+    bool IsFlyingPhase() const;
+
+    bool IsHarpoonFired(uint32 chainSpellId) const;
+    static bool IsHarpoonReady(GameObject* harpoonGO);
+    static void SetHarpoonOnCooldown(GameObject* harpoonGO);
+    GameObject* FindNearestHarpoon(float x, float y, float z) const;
+
+    static const std::vector<HarpoonData>& GetHarpoonData();
+
+    void AssignRolesBasedOnHealth();
+    bool AreRolesAssigned() const;
+    bool CanSwapRoles() const;
+
+private:
+    Unit* _boss;
+    std::time_t _lastRoleSwapTime;
+    const std::time_t _roleSwapCooldown;
+
+    static std::unordered_map<ObjectGuid, time_t> _harpoonCooldowns;
+};
 
 // template <class BossAiType>
 // class GenericBossHelper : public AiObject

--- a/src/strategy/raids/ulduar/RaidUlduarStrategy.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarStrategy.cpp
@@ -44,7 +44,7 @@ void RaidUlduarStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode(
         "razorscale fuse armor trigger",
-        NextAction::array(0, new NextAction("razorscale fuse armor action", ACTION_MOVE), nullptr)));
+        NextAction::array(0, new NextAction("razorscale fuse armor action", ACTION_RAID + 2), nullptr)));
 
 }
 

--- a/src/strategy/raids/ulduar/RaidUlduarStrategy.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarStrategy.cpp
@@ -4,7 +4,9 @@
 
 void RaidUlduarStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+    //
     // Flame Leviathan
+    //
     triggers.push_back(new TriggerNode(
         "flame leviathan vehicle near",
         NextAction::array(0, new NextAction("flame leviathan enter vehicle", ACTION_RAID + 2), nullptr)));
@@ -12,7 +14,38 @@ void RaidUlduarStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode(
         "flame leviathan on vehicle",
         NextAction::array(0, new NextAction("flame leviathan vehicle", ACTION_RAID + 1), nullptr)));
+
+    //
+    // Razorscale
+    //
+    triggers.push_back(new TriggerNode(
+        "razorscale avoid devouring flames",
+        NextAction::array(0, new NextAction("razorscale avoid devouring flames", ACTION_RAID + 1), nullptr)));
+
+    triggers.push_back(new TriggerNode(
+        "razorscale avoid sentinel",
+        NextAction::array(0, new NextAction("razorscale avoid sentinel", ACTION_RAID + 2), nullptr)));
     
+    triggers.push_back(new TriggerNode(
+        "razorscale flying alone",
+    NextAction::array(0, new NextAction("razorscale ignore flying alone", ACTION_MOVE + 5), nullptr)));
+
+    triggers.push_back(new TriggerNode(
+        "razorscale avoid whirlwind",
+        NextAction::array(0, new NextAction("razorscale avoid whirlwind", ACTION_RAID + 3), nullptr)));
+
+    triggers.push_back(new TriggerNode(
+        "razorscale grounded",
+        NextAction::array(0, new NextAction("razorscale grounded", ACTION_RAID), nullptr)));
+
+    triggers.push_back(new TriggerNode(
+        "razorscale harpoon trigger",
+        NextAction::array(0, new NextAction("razorscale harpoon action", ACTION_MOVE), nullptr)));
+
+    triggers.push_back(new TriggerNode(
+        "razorscale fuse armor trigger",
+        NextAction::array(0, new NextAction("razorscale fuse armor action", ACTION_MOVE), nullptr)));
+
 }
 
 void RaidUlduarStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)

--- a/src/strategy/raids/ulduar/RaidUlduarTriggerContext.h
+++ b/src/strategy/raids/ulduar/RaidUlduarTriggerContext.h
@@ -17,11 +17,25 @@ public:
     {
         creators["flame leviathan on vehicle"] = &RaidUlduarTriggerContext::flame_leviathan_on_vehicle;
         creators["flame leviathan vehicle near"] = &RaidUlduarTriggerContext::flame_leviathan_vehicle_near;
+        creators["razorscale flying alone"] = &RaidUlduarTriggerContext::razorscale_flying_alone;
+        creators["razorscale avoid devouring flames"] = &RaidUlduarTriggerContext::razorscale_avoid_devouring_flames;
+        creators["razorscale avoid sentinel"] = &RaidUlduarTriggerContext::razorscale_avoid_sentinel;
+        creators["razorscale avoid whirlwind"] = &RaidUlduarTriggerContext::razorscale_avoid_whirlwind;
+        creators["razorscale grounded"] = &RaidUlduarTriggerContext::razorscale_grounded;
+        creators["razorscale harpoon trigger"] = &RaidUlduarTriggerContext::razorscale_harpoon_trigger;
+        creators["razorscale fuse armor trigger"] = &RaidUlduarTriggerContext::razorscale_fuse_armor_trigger;
     }
 
 private:
     static Trigger* flame_leviathan_on_vehicle(PlayerbotAI* ai) { return new FlameLeviathanOnVehicleTrigger(ai); }
     static Trigger* flame_leviathan_vehicle_near(PlayerbotAI* ai) { return new FlameLeviathanVehicleNearTrigger(ai); }
+    static Trigger* razorscale_flying_alone(PlayerbotAI* ai) { return new RazorscaleFlyingAloneTrigger(ai); }
+    static Trigger* razorscale_avoid_devouring_flames(PlayerbotAI* ai) { return new RazorscaleDevouringFlamesTrigger(ai); }
+    static Trigger* razorscale_avoid_sentinel(PlayerbotAI* ai) { return new RazorscaleAvoidSentinelTrigger(ai); }
+    static Trigger* razorscale_avoid_whirlwind(PlayerbotAI* ai) { return new RazorscaleAvoidWhirlwindTrigger(ai); }
+    static Trigger* razorscale_grounded(PlayerbotAI* ai) { return new RazorscaleGroundedTrigger(ai); }
+    static Trigger* razorscale_harpoon_trigger(PlayerbotAI* ai) { return new RazorscaleHarpoonAvailableTrigger(ai); }
+    static Trigger* razorscale_fuse_armor_trigger(PlayerbotAI* ai) { return new RazorscaleFuseArmorTrigger(ai); }
 };
 
 #endif

--- a/src/strategy/raids/ulduar/RaidUlduarTriggers.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarTriggers.cpp
@@ -1,8 +1,11 @@
 #include "RaidUlduarTriggers.h"
 
 #include "EventMap.h"
+#include "GameObject.h"
 #include "Object.h"
+#include "PlayerbotAI.h"
 #include "Playerbots.h"
+#include "RaidUlduarBossHelper.h"
 #include "RaidUlduarScripts.h"
 #include "ScriptedCreature.h"
 #include "SharedDefines.h"
@@ -42,4 +45,188 @@ bool FlameLeviathanVehicleNearTrigger::IsActive()
         return false;
 
     return true;
+}
+
+bool RazorscaleFlyingAloneTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss) 
+    {
+        return false; 
+    }
+    
+    // Check if the boss is flying
+    if (boss->GetPositionZ() < RazorscaleBossHelper::RAZORSCALE_FLYING_Z_THRESHOLD)
+    {
+        return false; 
+    }
+
+    // Get the list of attackers
+    GuidVector attackers = context->GetValue<GuidVector>("attackers")->Get();
+    if (attackers.empty())
+    {
+        return true; // No attackers implies flying alone
+    }
+
+    std::vector<Unit*> dark_rune_adds;
+
+    // Loop through attackers to find dark rune adds
+    for (ObjectGuid const& guid : attackers)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (!unit)
+            continue;
+
+        uint32 entry = unit->GetEntry();
+
+        // Check for valid dark rune entries
+        if (entry == RazorscaleBossHelper::UNIT_DARK_RUNE_WATCHER || 
+            entry == RazorscaleBossHelper::UNIT_DARK_RUNE_GUARDIAN || 
+            entry == RazorscaleBossHelper::UNIT_DARK_RUNE_SENTINEL)
+        {
+            dark_rune_adds.push_back(unit);
+        }
+    }
+
+    // Return whether there are no dark rune adds
+    return dark_rune_adds.empty();
+}
+
+
+bool RazorscaleDevouringFlamesTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss) 
+        return false;
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit && unit->GetEntry() == RazorscaleBossHelper::UNIT_DEVOURING_FLAME)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool RazorscaleAvoidSentinelTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss) 
+        return false;
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit && unit->GetEntry() == RazorscaleBossHelper::UNIT_DARK_RUNE_SENTINEL)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool RazorscaleAvoidWhirlwindTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss) 
+        return false;
+
+    GuidVector npcs = AI_VALUE(GuidVector, "nearest hostile npcs");
+    for (auto& npc : npcs)
+    {
+        Unit* unit = botAI->GetUnit(npc);
+        if (unit && unit->GetEntry() == RazorscaleBossHelper::UNIT_DARK_RUNE_SENTINEL &&
+            (unit->HasAura(RazorscaleBossHelper::SPELL_SENTINEL_WHIRLWIND) || unit->GetCurrentSpell(CURRENT_CHANNELED_SPELL)))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool RazorscaleGroundedTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss) 
+    {
+        return false; 
+    }
+    
+    // Check if the boss is flying
+    if (boss->GetPositionZ() < RazorscaleBossHelper::RAZORSCALE_FLYING_Z_THRESHOLD)
+    {
+        return true; 
+    }
+    return false;
+}
+
+bool RazorscaleHarpoonAvailableTrigger::IsActive()
+{
+    // Get harpoon data from the helper
+    const std::vector<RazorscaleBossHelper::HarpoonData>& harpoonData = RazorscaleBossHelper::GetHarpoonData();
+
+    // Get the boss entity
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss || !boss->IsAlive())
+    {
+        return false;
+    }
+
+    // Update the boss AI context in the helper
+    RazorscaleBossHelper razorscaleHelper(botAI);
+
+    if (!razorscaleHelper.UpdateBossAI())
+    {
+        return false;
+    }
+
+    // Check each harpoon entry
+    for (const auto& harpoon : harpoonData)
+    {
+        // Skip harpoons whose chain spell is already active on the boss
+        if (razorscaleHelper.IsHarpoonFired(harpoon.chainSpellId))
+        {
+            continue;
+        }
+
+        // Find the nearest harpoon GameObject within 200 yards
+        if (GameObject* harpoonGO = bot->FindNearestGameObject(harpoon.gameObjectEntry, 200.0f))
+        {
+            if (RazorscaleBossHelper::IsHarpoonReady(harpoonGO))
+            {
+                return true; // At least one harpoon is available and ready to be fired
+            }
+        }
+    }
+
+    // No harpoons are available or need to be fired
+    return false;
+}
+
+bool RazorscaleFuseArmorTrigger::IsActive()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    // Iterate through group members to find the main tank with Fuse Armor
+    for (GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+    {
+        Player* member = gref->GetSource();
+        if (!member || !botAI->IsMainTank(member))
+            continue;
+
+        Aura* fuseArmor = member->GetAura(RazorscaleBossHelper::SPELL_FUSEARMOR);
+        if (fuseArmor && fuseArmor->GetStackAmount() >= RazorscaleBossHelper::FUSEARMOR_THRESHOLD)
+            return true;
+    }
+
+    return false;
 }

--- a/src/strategy/raids/ulduar/RaidUlduarTriggers.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarTriggers.cpp
@@ -212,6 +212,17 @@ bool RazorscaleHarpoonAvailableTrigger::IsActive()
 
 bool RazorscaleFuseArmorTrigger::IsActive()
 {
+    // Get the boss entity
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorscale");
+    if (!boss || !boss->IsAlive())
+    {
+        return false;
+    }
+
+    // Only proceed if this bot can actually tank
+    if (!botAI->IsTank(bot))
+        return false;
+
     Group* group = bot->GetGroup();
     if (!group)
         return false;

--- a/src/strategy/raids/ulduar/RaidUlduarTriggers.h
+++ b/src/strategy/raids/ulduar/RaidUlduarTriggers.h
@@ -7,7 +7,9 @@
 #include "RaidUlduarBossHelper.h"
 #include "Trigger.h"
 
-
+//
+// Flame Levi
+//
 class FlameLeviathanOnVehicleTrigger : public Trigger
 {
 public:
@@ -19,6 +21,58 @@ class FlameLeviathanVehicleNearTrigger : public Trigger
 {
 public:
     FlameLeviathanVehicleNearTrigger(PlayerbotAI* ai) : Trigger(ai, "flame leviathan vehicle near") {}
+    bool IsActive() override;
+};
+
+//
+// Razorscale
+//
+class RazorscaleFlyingAloneTrigger : public Trigger
+{
+public:
+    RazorscaleFlyingAloneTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale flying alone") {}
+    bool IsActive() override;
+};
+
+class RazorscaleDevouringFlamesTrigger : public Trigger
+{
+public:
+    RazorscaleDevouringFlamesTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale avoid devouring flames") {}
+    bool IsActive() override;
+};
+
+class RazorscaleAvoidSentinelTrigger : public Trigger
+{
+public:
+    RazorscaleAvoidSentinelTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale avoid sentinel") {}
+    bool IsActive() override;
+};
+
+class RazorscaleAvoidWhirlwindTrigger : public Trigger
+{
+public:
+    RazorscaleAvoidWhirlwindTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale avoid whirlwind") {}
+    bool IsActive() override;
+};
+
+class RazorscaleGroundedTrigger : public Trigger
+{
+public:
+    RazorscaleGroundedTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale grounded") {}
+    bool IsActive() override;
+};
+
+class RazorscaleHarpoonAvailableTrigger : public Trigger
+{
+public:
+    RazorscaleHarpoonAvailableTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale harpoon trigger") {}
+    bool IsActive() override;
+};
+
+class RazorscaleFuseArmorTrigger : public Trigger
+{
+public:
+    RazorscaleFuseArmorTrigger(PlayerbotAI* ai) : Trigger(ai, "razorscale fuse armor trigger") {}
     bool IsActive() override;
 };
 


### PR DESCRIPTION
My first attempt at making a boss strategy, looking for feedback.

Triggers and associated actions:

1. Avoid Devouring Flame - All bots avoid it. Main tank (during boss air phase) moves a little over twice as far so melee have some space to attack adds.

2. Avoid Sentinel/Whirlwind - Ranged keep away from them all the times, melee only when they are casting Whirlwind. Main tank marks Sentinel with lowest HP with Skull RTI so they get nuked.

3. Ignore Razorscale when flying and alone - Place Moon RTI on Razorscale so the bots generally ignore her. Moon removed when she comes below Z threshold. This prevents the bots grouping directly under her location, at least at the start of the encounter, they still seem to do it when she transitions back to air. I'm almost certain there's a better way to do this. Bots will also move inside the arena, radius just covers the harpoons.

4. Harpoon available for use - Closest ranged DPS will move to and use any available harpoon. I think we'd check if any adds are alive and >50% before doing the last one, but it's not much of an issue as they usually are.

5. Boss grounded - Ranged bots MoveInside a large area behind the boss, they are able to out range the knock back so it's good to allow that. Melee do their thing behind boss naturally. Once boss is below 50% and permanently grounded the ranged bots will group closer to the centre of the arena.

5. Fused Armor - Bots set new main tank group flag when they get 2 stacks of fuse armor. The tank with the most HP that is not currently affected by Fuse Armor is chosen as the new main tank. This worked exactly as I hoped. Bots respect Main tank status so a bot freshly assigned as main tank will taunt and establish threat immediately and the old tank will let their threat drop so safe levels. Non-main tanks move near the main tank so they are ready.
