### PR TITLE
Fix bots attacking others despite being in a prohibited zone - Issue 227: Improved check

### DIFF
--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -105,7 +105,8 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         return false;
     }
 
-    if (!bot->IsValidAttackTarget(target) && sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId()))
+    if (sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId())
+        && (target->IsPlayer() || target->IsPet() || !bot->IsValidAttackTarget(target)))
     {
         if (verbose)
             botAI->TellError("I cannot attack others in PvP prohibited zones");


### PR DESCRIPTION
to work in custom defines zones as well.

Regarding https://github.com/liyunfan1223/mod-playerbots/pull/793