### PR TITLE
Fix rpg move far

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -3130,7 +3130,7 @@ void PlayerbotFactory::InitReagents()
                 items.push_back({17030, 40});  // Ankh
             break;
         case CLASS_WARLOCK:
-            items.push_back({6265, 10});  // shard
+            items.push_back({6265, 20});  // shard
             break;
         case CLASS_PRIEST:
             if (level >= 48 && level < 60)

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -197,7 +197,11 @@ WorldPosition NewRpgStatusUpdateAction::SelectRandomInnKeeperPos()
     {
         if (bot->GetMapId() != loc.GetMapId())
             continue;
-
+        
+        if (bot->GetMap()->GetZoneId(bot->GetPhaseMask(), loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ()) !=
+            bot->GetZoneId())
+            continue;
+            
         float range = bot->GetLevel() <= 5 ? 500.0f : 2500.0f;
         if (bot->GetExactDist(loc) < range)
         {

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -246,13 +246,13 @@ bool NewRpgGoFarAwayPosAction::MoveFarTo(WorldPosition dest)
         float dis = rand_norm() * pathFinderDis;
         float dx = x + cos(angle) * dis;
         float dy = y + sin(angle) * dis;
-        float dz = z + 5.0f;
+        float dz = z + 0.5f;
         bot->UpdateAllowedPositionZ(dx, dy, dz);
         PathGenerator path(bot);
         path.CalculatePath(dx, dy, dz);
         PathType type = path.GetPathType();
 
-        bool canReach = type == PATHFIND_INCOMPLETE || type == PATHFIND_NORMAL;
+        bool canReach = type == PATHFIND_NORMAL;
 
         if (canReach && fabs(delta) <= minDelta)
         {


### PR DESCRIPTION
Fixed the issue where rpg move far sometimes caused the bot to move to an invalid position