### PR TITLE
DPS Warrior action priorities

### DIFF
--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -44,40 +44,42 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     GenericWarriorStrategy::InitTriggers(triggers);
 
     triggers.push_back(new TriggerNode("enemy out of melee",
-                                       NextAction::array(0, new NextAction("charge", ACTION_MOVE + 9), nullptr)));
+                                       NextAction::array(0, new NextAction("charge", ACTION_MOVE + 10), nullptr)));
     triggers.push_back(new TriggerNode(
-        "battle stance", NextAction::array(0, new NextAction("battle stance", ACTION_HIGH + 9), nullptr)));
+        "battle stance", NextAction::array(0, new NextAction("battle stance", ACTION_HIGH + 10), nullptr)));
     triggers.push_back(new TriggerNode("battle shout",
-                                       NextAction::array(0, new NextAction("battle shout", ACTION_HIGH + 8), nullptr)));
+                                       NextAction::array(0, new NextAction("battle shout", ACTION_HIGH + 9), nullptr)));
     triggers.push_back(new TriggerNode(
-        "mortal strike", NextAction::array(0, new NextAction("mortal strike", ACTION_HIGH + 1), nullptr)));
+        "mortal strike", NextAction::array(0, new NextAction("mortal strike", ACTION_HIGH + 3), nullptr)));
     triggers.push_back(new TriggerNode("target critical health",
-                                       NextAction::array(0, new NextAction("execute", ACTION_HIGH + 4), nullptr)));
+                                       NextAction::array(0, new NextAction("execute", ACTION_HIGH + 5), nullptr)));
     triggers.push_back(
-        new TriggerNode("sudden death", NextAction::array(0, new NextAction("execute", ACTION_HIGH + 4), nullptr)));
+        new TriggerNode("sudden death", NextAction::array(0, new NextAction("execute", ACTION_HIGH + 5), nullptr)));
     triggers.push_back(
         new TriggerNode("hamstring", NextAction::array(0, new NextAction("piercing howl", ACTION_HIGH), nullptr)));
     triggers.push_back(
-        new TriggerNode("overpower", NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 3), nullptr)));
+        new TriggerNode("overpower", NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
     triggers.push_back(new TriggerNode("taste for blood",
-                                       NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 3), nullptr)));
+                                       NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
     triggers.push_back(new TriggerNode(
         "victory rush", NextAction::array(0, new NextAction("victory rush", ACTION_INTERRUPT), nullptr)));
-    triggers.push_back(new TriggerNode(
-        "high rage available", NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH), nullptr)));
-    triggers.push_back(new TriggerNode("medium rage available", 
-        NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
-        new NextAction("thunder clap", ACTION_HIGH),
-        nullptr)));
+    triggers.push_back(new TriggerNode("high rage available", 
+            NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH),
+            NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
+            nullptr)));
+    // triggers.push_back(new TriggerNode("medium rage available", 
+    //    NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
+    //    new NextAction("thunder clap", ACTION_HIGH),
+    //    nullptr)));
     triggers.push_back(
         new TriggerNode("bloodrage", NextAction::array(0, new NextAction("bloodrage", ACTION_HIGH + 2), nullptr)));
     triggers.push_back(
         new TriggerNode("death wish", NextAction::array(0, new NextAction("death wish", ACTION_HIGH + 2), nullptr)));
-    triggers.push_back(new TriggerNode("rend", NextAction::array(0, new NextAction("rend", ACTION_HIGH + 5), nullptr)));
+    triggers.push_back(new TriggerNode("rend", NextAction::array(0, new NextAction("rend", ACTION_HIGH + 8), nullptr)));
     triggers.push_back(new TriggerNode(
-        "rend on attacker", NextAction::array(0, new NextAction("rend on attacker", ACTION_HIGH + 5), nullptr)));
+        "rend on attacker", NextAction::array(0, new NextAction("rend on attacker", ACTION_HIGH + 8), nullptr)));
     triggers.push_back(new TriggerNode(
         "critical health", NextAction::array(0, new NextAction("intimidating shout", ACTION_EMERGENCY), nullptr)));
-    triggers.push_back(new TriggerNode("medium aoe",
-                                       NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
+    // triggers.push_back(new TriggerNode("medium aoe",
+    //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
 }

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -68,9 +68,9 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             new NextAction("slam", ACTION_HIGH + 1),
             nullptr)));
     // triggers.push_back(new TriggerNode("medium rage available", 
-    //    NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
-    //    new NextAction("thunder clap", ACTION_HIGH),
-    //    nullptr)));
+    //      NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
+    //      new NextAction("thunder clap", ACTION_HIGH),
+    //      nullptr)));
     triggers.push_back(
         new TriggerNode("bloodrage", NextAction::array(0, new NextAction("bloodrage", ACTION_HIGH + 2), nullptr)));
     triggers.push_back(

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -44,25 +44,41 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     GenericWarriorStrategy::InitTriggers(triggers);
 
     triggers.push_back(new TriggerNode("enemy out of melee",
-                                       NextAction::array(0, new NextAction("charge", ACTION_MOVE + 10), nullptr)));
-    triggers.push_back(new TriggerNode(
-        "battle stance", NextAction::array(0, new NextAction("battle stance", ACTION_HIGH + 10), nullptr)));
+        NextAction::array(0, new NextAction("charge", ACTION_MOVE + 10), nullptr)));
+    
+    triggers.push_back(new TriggerNode("battle stance",
+        NextAction::array(0, new NextAction("battle stance", ACTION_HIGH + 10), nullptr)));
+    
     triggers.push_back(new TriggerNode("battle shout",
-                                       NextAction::array(0, new NextAction("battle shout", ACTION_HIGH + 9), nullptr)));
-    triggers.push_back(new TriggerNode(
-        "mortal strike", NextAction::array(0, new NextAction("mortal strike", ACTION_HIGH + 3), nullptr)));
+        NextAction::array(0, new NextAction("battle shout", ACTION_HIGH + 9), nullptr)));
+    
+    triggers.push_back(new TriggerNode("rend",
+        NextAction::array(0, new NextAction("rend", ACTION_HIGH + 8), nullptr)));
+    
+    triggers.push_back(new TriggerNode("rend on attacker",
+        NextAction::array(0, new NextAction("rend on attacker", ACTION_HIGH + 8), nullptr)));
+    
+    triggers.push_back(new TriggerNode("mortal strike",
+        NextAction::array(0, new NextAction("mortal strike", ACTION_HIGH + 3), nullptr)));
+    
     triggers.push_back(new TriggerNode("target critical health",
-                                       NextAction::array(0, new NextAction("execute", ACTION_HIGH + 5), nullptr)));
-    triggers.push_back(
-        new TriggerNode("sudden death", NextAction::array(0, new NextAction("execute", ACTION_HIGH + 5), nullptr)));
-    triggers.push_back(
-        new TriggerNode("hamstring", NextAction::array(0, new NextAction("piercing howl", ACTION_HIGH), nullptr)));
-    triggers.push_back(
-        new TriggerNode("overpower", NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
+        NextAction::array(0, new NextAction("execute", ACTION_HIGH + 5), nullptr)));
+    
+    triggers.push_back(new TriggerNode("sudden death",
+        NextAction::array(0, new NextAction("execute", ACTION_HIGH + 5), nullptr)));
+    
+    triggers.push_back(new TriggerNode("hamstring",
+        NextAction::array(0, new NextAction("piercing howl", ACTION_HIGH), nullptr)));
+    
+    triggers.push_back(new TriggerNode("overpower",
+        NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
+    
     triggers.push_back(new TriggerNode("taste for blood",
-                                       NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
-    triggers.push_back(new TriggerNode(
-        "victory rush", NextAction::array(0, new NextAction("victory rush", ACTION_INTERRUPT), nullptr)));
+        NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
+    
+    triggers.push_back(new TriggerNode("victory rush",
+        NextAction::array(0, new NextAction("victory rush", ACTION_INTERRUPT), nullptr)));
+    
     triggers.push_back(new TriggerNode("high rage available",
         NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH),
                              new NextAction("slam", ACTION_HIGH + 1),
@@ -73,17 +89,19 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     //      nullptr)));
     triggers.push_back(
         new TriggerNode("bloodrage", NextAction::array(0, new NextAction("bloodrage", ACTION_HIGH + 2), nullptr)));
+    
     triggers.push_back(
         new TriggerNode("death wish", NextAction::array(0, new NextAction("death wish", ACTION_HIGH + 2), nullptr)));
-    triggers.push_back(new TriggerNode("rend", NextAction::array(0, new NextAction("rend", ACTION_HIGH + 8), nullptr)));
-    triggers.push_back(new TriggerNode(
-        "rend on attacker", NextAction::array(0, new NextAction("rend on attacker", ACTION_HIGH + 8), nullptr)));
+
     triggers.push_back(new TriggerNode(
         "critical health", NextAction::array(0, new NextAction("intimidating shout", ACTION_EMERGENCY), nullptr)));
+    
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
+    /*
     triggers.push_back(new TriggerNode("medium aoe", 
         NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
                              new NextAction("bladestorm", ACTION_HIGH + 6),
                                 nullptr)));
+    */
 }

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -64,7 +64,7 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode(
         "victory rush", NextAction::array(0, new NextAction("victory rush", ACTION_INTERRUPT), nullptr)));
     triggers.push_back(new TriggerNode(
-        "high rage available", NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH + 10), nullptr)));
+        "high rage available", NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH), nullptr)));
     triggers.push_back(new TriggerNode("medium rage available", 
         NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
         new NextAction("thunder clap", ACTION_HIGH),

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -66,7 +66,7 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("high rage available", 
             NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH),
             NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
-            nullptr)));
+            nullptr))));
     // triggers.push_back(new TriggerNode("medium rage available", 
     //    NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
     //    new NextAction("thunder clap", ACTION_HIGH),

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -63,10 +63,10 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
                                        NextAction::array(0, new NextAction("overpower", ACTION_HIGH + 4), nullptr)));
     triggers.push_back(new TriggerNode(
         "victory rush", NextAction::array(0, new NextAction("victory rush", ACTION_INTERRUPT), nullptr)));
-    triggers.push_back(new TriggerNode("high rage available", 
-            NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH),
-            new NextAction("slam", ACTION_HIGH + 1),
-            nullptr)));
+    triggers.push_back(new TriggerNode("high rage available",
+        NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH),
+                             new NextAction("slam", ACTION_HIGH + 1),
+                                nullptr)));
     // triggers.push_back(new TriggerNode("medium rage available", 
     //      NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
     //      new NextAction("thunder clap", ACTION_HIGH),
@@ -82,4 +82,8 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         "critical health", NextAction::array(0, new NextAction("intimidating shout", ACTION_EMERGENCY), nullptr)));
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
+    triggers.push_back(new TriggerNode("medium aoe", 
+        NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
+                             new NextAction("bladestorm", ACTION_HIGH + 6),
+                                nullptr)));
 }

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -65,8 +65,8 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         "victory rush", NextAction::array(0, new NextAction("victory rush", ACTION_INTERRUPT), nullptr)));
     triggers.push_back(new TriggerNode("high rage available", 
             NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH),
-            NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
-            nullptr))));
+            new NextAction("slam", ACTION_HIGH + 1),
+            nullptr)));
     // triggers.push_back(new TriggerNode("medium rage available", 
     //    NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1),
     //    new NextAction("thunder clap", ACTION_HIGH),

--- a/src/strategy/warrior/FuryWarriorStrategy.cpp
+++ b/src/strategy/warrior/FuryWarriorStrategy.cpp
@@ -69,11 +69,13 @@ void FuryWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("bloodthirst", NextAction::array(0, new NextAction("bloodthirst", ACTION_HIGH + 7), nullptr)));
     triggers.push_back(
+        new TriggerNode("whirlwind", NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 6), nullptr)));
+    triggers.push_back(
         new TriggerNode("instant slam", NextAction::array(0, new NextAction("slam", ACTION_HIGH + 5), nullptr)));
     triggers.push_back(
         new TriggerNode("bloodrage", NextAction::array(0, new NextAction("bloodrage", ACTION_HIGH + 2), nullptr)));
     triggers.push_back(new TriggerNode("medium rage available",
-                                       NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH + 1), NULL)));
+                                       NextAction::array(0, new NextAction("heroic strike", ACTION_DEFAULT + 0.1f), NULL)));
     // triggers.push_back(new TriggerNode("berserker rage", NextAction::array(0, new NextAction("berserker rage",
     // ACTION_HIGH + 2), nullptr))); triggers.push_back(new TriggerNode("light aoe", NextAction::array(0,
     //     new NextAction("whirlwind", ACTION_HIGH + 2),

--- a/src/strategy/warrior/GenericWarriorStrategy.cpp
+++ b/src/strategy/warrior/GenericWarriorStrategy.cpp
@@ -50,8 +50,8 @@ void WarrirorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode(
         "light aoe", NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 5),
                                        new NextAction("shockwave", ACTION_HIGH + 4),
-                                       new NextAction("sweeping strikes", ACTION_HIGH + 3),
-                                       new NextAction("bladestorm", ACTION_HIGH + 3),
+                                       new NextAction("sweeping strikes", ACTION_HIGH + 7),
+                                       new NextAction("bladestorm", ACTION_HIGH + 6),
                                        // new NextAction("whirlwind", ACTION_HIGH + 2),
                                        new NextAction("demoralizing shout without life time check", ACTION_HIGH + 1),
                                        new NextAction("cleave", ACTION_HIGH), nullptr)));

--- a/src/strategy/warrior/GenericWarriorStrategy.cpp
+++ b/src/strategy/warrior/GenericWarriorStrategy.cpp
@@ -48,10 +48,10 @@ void WarrirorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     // clap on snare target", ACTION_HIGH + 3), nullptr))); triggers.push_back(new TriggerNode("thunder clap",
     // NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 10), nullptr)));
     triggers.push_back(new TriggerNode(
-        "light aoe", NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 5),
-                                       new NextAction("shockwave", ACTION_HIGH + 4),
-                                       new NextAction("sweeping strikes", ACTION_HIGH + 7),
+        "light aoe", NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
                                        new NextAction("bladestorm", ACTION_HIGH + 6),
+                                       new NextAction("thunder clap", ACTION_HIGH + 5),
+                                       new NextAction("shockwave", ACTION_HIGH + 4),
                                        // new NextAction("whirlwind", ACTION_HIGH + 2),
                                        new NextAction("demoralizing shout without life time check", ACTION_HIGH + 1),
                                        new NextAction("cleave", ACTION_HIGH), nullptr)));

--- a/src/strategy/warrior/GenericWarriorStrategy.cpp
+++ b/src/strategy/warrior/GenericWarriorStrategy.cpp
@@ -48,6 +48,10 @@ void WarrirorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     // clap on snare target", ACTION_HIGH + 3), nullptr))); triggers.push_back(new TriggerNode("thunder clap",
     // NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 10), nullptr)));
     triggers.push_back(new TriggerNode(
+        "medium aoe", NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
+                                           new NextAction("bladestorm", ACTION_HIGH + 6),
+                                            nullptr)));
+    triggers.push_back(new TriggerNode(
         "light aoe", NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
                                        new NextAction("bladestorm", ACTION_HIGH + 6),
                                        new NextAction("thunder clap", ACTION_HIGH + 5),
@@ -60,4 +64,5 @@ void WarrirorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
                         NextAction::array(0, new NextAction("shockwave on snare target", ACTION_HIGH + 5), nullptr)));
     // triggers.push_back(new TriggerNode("high rage available", NextAction::array(0, new NextAction("whirlwind",
     // ACTION_HIGH + 10), nullptr)));
+
 }

--- a/src/strategy/warrior/GenericWarriorStrategy.cpp
+++ b/src/strategy/warrior/GenericWarriorStrategy.cpp
@@ -47,10 +47,11 @@ void WarrirorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     // triggers.push_back(new TriggerNode("thunder clap on snare target", NextAction::array(0, new NextAction("thunder
     // clap on snare target", ACTION_HIGH + 3), nullptr))); triggers.push_back(new TriggerNode("thunder clap",
     // NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 10), nullptr)));
-    triggers.push_back(new TriggerNode(
+    /* triggers.push_back(new TriggerNode(
         "medium aoe", NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
                                            new NextAction("bladestorm", ACTION_HIGH + 6),
                                             nullptr)));
+    */
     triggers.push_back(new TriggerNode(
         "light aoe", NextAction::array(0, new NextAction("sweeping strikes", ACTION_HIGH + 7),
                                        new NextAction("bladestorm", ACTION_HIGH + 6),

--- a/src/strategy/warrior/TankWarriorStrategy.cpp
+++ b/src/strategy/warrior/TankWarriorStrategy.cpp
@@ -89,7 +89,9 @@ void TankWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("sunder armor", NextAction::array(0, new NextAction("devastate", ACTION_HIGH + 2), nullptr)));
     triggers.push_back(new TriggerNode("medium rage available",
-                                       NextAction::array(0, new NextAction("shield slam", ACTION_HIGH + 1), nullptr)));
+        NextAction::array(0, new NextAction("shield slam", ACTION_HIGH + 2),
+                             new NextAction("devastate", ACTION_HIGH + 1),
+                             nullptr)));
     triggers.push_back(new TriggerNode(
         "shield block", NextAction::array(0, new NextAction("shield block", ACTION_INTERRUPT + 1), nullptr)));
     triggers.push_back(
@@ -129,7 +131,7 @@ void TankWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("protect party member",
                                        NextAction::array(0, new NextAction("intervene", ACTION_EMERGENCY), nullptr)));
     triggers.push_back(new TriggerNode(
-        "high rage available", NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH + 1), nullptr)));
+        "high rage available", NextAction::array(0, new NextAction("heroic strike", ACTION_HIGH), nullptr)));
     triggers.push_back(new TriggerNode("medium rage available",
                                        NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 1), nullptr)));
 }

--- a/src/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/src/strategy/warrior/WarriorAiObjectContext.cpp
@@ -78,6 +78,7 @@ public:
         creators["thunder clap on snare target"] = &WarriorTriggerFactoryInternal::thunder_clap_on_snare_target;
         creators["thunder clap"] = &WarriorTriggerFactoryInternal::thunder_clap;
         creators["bloodthirst"] = &WarriorTriggerFactoryInternal::bloodthirst;
+        creators["whirlwind"] = &WarriorTriggerFactoryInternal::whirlwind;
         creators["berserker rage"] = &WarriorTriggerFactoryInternal::berserker_rage;
         creators["pummel on enemy healer"] = &WarriorTriggerFactoryInternal::pummel_on_enemy_healer;
         creators["pummel"] = &WarriorTriggerFactoryInternal::pummel;
@@ -157,6 +158,7 @@ private:
     }
     static Trigger* berserker_rage(PlayerbotAI* botAI) { return new BerserkerRageBuffTrigger(botAI); }
     static Trigger* bloodthirst(PlayerbotAI* botAI) { return new BloodthirstBuffTrigger(botAI); }
+    static Trigger* whirlwind(PlayerbotAI* botAI) { return new WhirlwindTrigger(botAI); }
     static Trigger* thunder_clap_on_snare_target(PlayerbotAI* botAI) { return new ThunderClapSnareTrigger(botAI); }
     static Trigger* thunder_clap(PlayerbotAI* botAI) { return new ThunderClapTrigger(botAI); }
     static Trigger* mortal_strike(PlayerbotAI* botAI) { return new MortalStrikeDebuffTrigger(botAI); }

--- a/src/strategy/warrior/WarriorTriggers.h
+++ b/src/strategy/warrior/WarriorTriggers.h
@@ -45,6 +45,7 @@ DEBUFF_TRIGGER(ShockwaveTrigger, "shockwave");
 BOOST_TRIGGER(DeathWishTrigger, "death wish");
 BOOST_TRIGGER(RecklessnessTrigger, "recklessness");
 BUFF_TRIGGER(BloodthirstBuffTrigger, "bloodthirst");
+BUFF_TRIGGER(WhirlwindTrigger, "whirlwind");
 BUFF_TRIGGER(BerserkerRageBuffTrigger, "berserker rage");
 INTERRUPT_HEALER_TRIGGER(ShieldBashInterruptEnemyHealerSpellTrigger, "shield bash");
 INTERRUPT_TRIGGER(ShieldBashInterruptSpellTrigger, "shield bash");


### PR DESCRIPTION
De-prioritised Heroic Strike for Arms and Fury: 
Bots treat heroic strike like it is on the GCD so they don't use it simultaneously with other abilities. Bots would get High Rage and then only cast heroic strike. Using Heroic Strike alone is not enough to stay below the High Rage threshold and because the priority of Heroic Strike was so high (and it has no cooldown) other abilities would not activate. Heroic strike is now one of lowest priority actions and will only be used if the bots other abilities aren't available.

Arms AOE priority:
Sweeping Strikes > Bladestorm > Thunder Clap > Cleave.

Arms non-AOE priority:
Rend > Execute > Overpower > Mortal Strike > Slam > Heroic Strike

Fury:
Adjusted Whirlwind so it is used more frequently in single target situations, Bloodthirst > Whirlwind > Slam > Heroic Strike

Note:
After compiling and restarting the server I did find it was necessary to re-apply talents (talents spec arms pve) and reset botAI to get the new strategies to enable correctly.