### PR TITLE
Move backwards when enemy too close

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4115,11 +4115,16 @@ inline bool ZoneHasRealPlayers(Player* bot)
         return false;
     }
     
-    for (auto& player : sRandomPlayerbotMgr->GetPlayers())
+    for (Player* player : sRandomPlayerbotMgr->GetPlayers())
     {
         if (player->GetMapId() != bot->GetMapId())
             continue;
-
+        
+        if (player->IsGameMaster() && !player->IsVisible())
+        {
+            continue;
+        }
+        
         if (player->GetZoneId() == bot->GetZoneId())
         {
             PlayerbotAI* botAI = GET_PLAYERBOT_AI(player);

--- a/src/strategy/actions/FollowActions.cpp
+++ b/src/strategy/actions/FollowActions.cpp
@@ -33,7 +33,7 @@ bool FollowAction::Execute(Event event)
         
         MovementPriority priority = botAI->GetState() == BOT_STATE_COMBAT ? MovementPriority::MOVEMENT_COMBAT : MovementPriority::MOVEMENT_NORMAL;
         moved = MoveTo(loc.GetMapId(), loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), false, false, false,
-                       true, priority);
+                       true, priority, true);
     }
 
     if (Pet* pet = bot->GetPet())

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -177,7 +177,7 @@ bool MovementAction::MoveToLOS(WorldObject* target, bool ranged)
 }
 
 bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, bool react, bool normal_only,
-                            bool exact_waypoint, MovementPriority priority, bool lessDelay)
+                            bool exact_waypoint, MovementPriority priority, bool lessDelay, bool backwards)
 {
     UpdateMovementState();
     if (!IsMovingAllowed(mapId, x, y, z))
@@ -208,8 +208,16 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
         {
             MotionMaster& mm = *vehicleBase->GetMotionMaster();  // need to move vehicle, not bot
             mm.Clear();
-            mm.MovePoint(0, x, y, z, generatePath);
-            float delay = 1000.0f * (distance / vehicleBase->GetSpeed(MOVE_RUN));
+            if (!backwards)
+            {
+                mm.MovePoint(0, x, y, z, generatePath);
+            }
+            else
+            {
+                mm.MovePointBackwards(0, x, y, z, generatePath);
+            }
+            float speed = backwards ? vehicleBase->GetSpeed(MOVE_RUN_BACK) : vehicleBase->GetSpeed(MOVE_RUN);
+            float delay = 1000.0f * (distance / speed);
             if (lessDelay)
             {
                 delay -= botAI->GetReactDelay();
@@ -235,8 +243,15 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             }
             MotionMaster& mm = *bot->GetMotionMaster();
             mm.Clear();
-            mm.MovePoint(0, x, y, z, generatePath);
-            float delay = 1000.0f * MoveDelay(distance);
+            if (!backwards)
+            {
+                mm.MovePoint(0, x, y, z, generatePath);
+            }
+            else
+            {
+                mm.MovePointBackwards(0, x, y, z, generatePath);
+            }
+            float delay = 1000.0f * MoveDelay(distance, backwards);
             if (lessDelay)
             {
                 delay -= botAI->GetReactDelay();
@@ -270,8 +285,15 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             MotionMaster& mm = *bot->GetMotionMaster();
             G3D::Vector3 endP = path.back();
             mm.Clear();
-            mm.MovePoint(0, endP.x, endP.y, endP.z, generatePath);
-            float delay = 1000.0f * MoveDelay(distance);
+            if (!backwards)
+            {
+                mm.MovePoint(0, x, y, z, generatePath);
+            }
+            else
+            {
+                mm.MovePointBackwards(0, x, y, z, generatePath);
+            }
+            float delay = 1000.0f * MoveDelay(distance, backwards);
             if (lessDelay)
             {
                 delay -= botAI->GetReactDelay();
@@ -1265,20 +1287,20 @@ bool MovementAction::ChaseTo(WorldObject* obj, float distance, float angle)
     return true;
 }
 
-float MovementAction::MoveDelay(float distance)
+float MovementAction::MoveDelay(float distance, bool backwards)
 {
     float speed;
     if (bot->isSwimming())
     {
-        speed = bot->GetSpeed(MOVE_SWIM);
+        speed = backwards ? bot->GetSpeed(MOVE_SWIM_BACK) : bot->GetSpeed(MOVE_SWIM);
     }
     else if (bot->IsFlying())
     {
-        speed = bot->GetSpeed(MOVE_FLIGHT);
+        speed = backwards ? bot->GetSpeed(MOVE_FLIGHT_BACK) : bot->GetSpeed(MOVE_FLIGHT);
     }
     else
     {
-        speed = bot->GetSpeed(MOVE_RUN);
+        speed = backwards ? bot->GetSpeed(MOVE_RUN_BACK) :bot->GetSpeed(MOVE_RUN);
     }
     float delay = distance / speed;
     return delay;
@@ -1502,6 +1524,12 @@ void MovementAction::ClearIdleState()
 
 bool MovementAction::MoveAway(Unit* target, float distance)
 {
+    // MotionMaster& mm = *bot->GetMotionMaster();
+    // mm.Clear();
+    // mm.MoveBackwards(target, distance);
+    // botAI->SetNextCheckDelay(3000);
+    // // bot->GetSpeed()
+    // return true;
     if (!target)
     {
         return false;
@@ -1523,7 +1551,7 @@ bool MovementAction::MoveAway(Unit* target, float distance)
             dz = bot->GetPositionZ();
             exact = false;
         }
-        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT))
+        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT, false, true))
         {
             return true;
         }
@@ -1545,7 +1573,7 @@ bool MovementAction::MoveAway(Unit* target, float distance)
             dz = bot->GetPositionZ();
             exact = false;
         }
-        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT))
+        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT, false, true))
         {
             return true;
         }

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -1768,7 +1768,7 @@ const Movement::PointsArray MovementAction::SearchForBestPath(float x, float y, 
 bool FleeAction::Execute(Event event)
 {
     // return Flee(AI_VALUE(Unit*, "current target"));
-    return MoveAway(AI_VALUE(Unit*, "current target"), true);
+    return MoveAway(AI_VALUE(Unit*, "current target"), sPlayerbotAIConfig->fleeDistance, true);
 }
 
 bool FleeAction::isUseful()

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -1522,14 +1522,8 @@ void MovementAction::ClearIdleState()
     context->GetValue<PositionMap&>("position")->Get()["random"].Reset();
 }
 
-bool MovementAction::MoveAway(Unit* target, float distance)
+bool MovementAction::MoveAway(Unit* target, float distance, bool backwards)
 {
-    // MotionMaster& mm = *bot->GetMotionMaster();
-    // mm.Clear();
-    // mm.MoveBackwards(target, distance);
-    // botAI->SetNextCheckDelay(3000);
-    // // bot->GetSpeed()
-    // return true;
     if (!target)
     {
         return false;
@@ -1551,7 +1545,7 @@ bool MovementAction::MoveAway(Unit* target, float distance)
             dz = bot->GetPositionZ();
             exact = false;
         }
-        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT, false, true))
+        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT, false, backwards))
         {
             return true;
         }
@@ -1573,7 +1567,7 @@ bool MovementAction::MoveAway(Unit* target, float distance)
             dz = bot->GetPositionZ();
             exact = false;
         }
-        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT, false, true))
+        if (MoveTo(target->GetMapId(), dx, dy, dz, false, false, true, exact, MovementPriority::MOVEMENT_COMBAT, false, backwards))
         {
             return true;
         }
@@ -1774,7 +1768,7 @@ const Movement::PointsArray MovementAction::SearchForBestPath(float x, float y, 
 bool FleeAction::Execute(Event event)
 {
     // return Flee(AI_VALUE(Unit*, "current target"));
-    return MoveAway(AI_VALUE(Unit*, "current target"));
+    return MoveAway(AI_VALUE(Unit*, "current target"), true);
 }
 
 bool FleeAction::isUseful()

--- a/src/strategy/actions/MovementActions.h
+++ b/src/strategy/actions/MovementActions.h
@@ -32,7 +32,7 @@ protected:
     bool MoveNear(uint32 mapId, float x, float y, float z, float distance = sPlayerbotAIConfig->contactDistance, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     bool MoveToLOS(WorldObject* target, bool ranged = false);
     bool MoveTo(uint32 mapId, float x, float y, float z, bool idle = false, bool react = false,
-                bool normal_only = false, bool exact_waypoint = false, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL, bool lessDelay = false);
+                bool normal_only = false, bool exact_waypoint = false, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL, bool lessDelay = false, bool backwards = false);
     bool MoveTo(WorldObject* target, float distance = 0.0f, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     bool MoveNear(WorldObject* target, float distance = sPlayerbotAIConfig->contactDistance, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     float GetFollowAngle();
@@ -40,7 +40,7 @@ protected:
     bool Follow(Unit* target, float distance, float angle);
     bool ChaseTo(WorldObject* obj, float distance = 0.0f, float angle = 0.0f);
     bool ReachCombatTo(Unit* target, float distance = 0.0f);
-    float MoveDelay(float distance);
+    float MoveDelay(float distance, bool backwards = false);
     void WaitForReach(float distance);
     void SetNextMovementDelay(float delayMillis);
     bool IsMovingAllowed(WorldObject* target);

--- a/src/strategy/actions/MovementActions.h
+++ b/src/strategy/actions/MovementActions.h
@@ -51,7 +51,7 @@ protected:
     bool Flee(Unit* target);
     void ClearIdleState();
     void UpdateMovementState();
-    bool MoveAway(Unit* target, float distance = sPlayerbotAIConfig -> fleeDistance);
+    bool MoveAway(Unit* target, float distance = sPlayerbotAIConfig -> fleeDistance, bool backwards = false);
     bool MoveFromGroup(float distance);
     bool Move(float angle, float distance);
     bool MoveInside(uint32 mapId, float x, float y, float z, float distance = sPlayerbotAIConfig->followDistance, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -44,7 +44,7 @@ bool NewRpgStatusUpdateAction::Execute(Event event)
                 }
             }
             // IDLE -> GO_INNKEEPER
-            else if (bot->GetLevel() >= 6 && roll <= 40)
+            else if (bot->GetLevel() >= 6 && roll <= 45)
             {
                 WorldPosition pos = SelectRandomInnKeeperPos();
                 if (pos != WorldPosition() && bot->GetExactDist(pos) > 50.0f)

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -241,7 +241,7 @@ bool NewRpgGoFarAwayPosAction::MoveFarTo(WorldPosition dest)
     const float z = bot->GetPositionZ();
     float rx, ry, rz;
     bool found = false;
-    int attempt = 10;
+    int attempt = 3;
     while (--attempt)
     {
         float angle = bot->GetAngle(&dest);


### PR DESCRIPTION
When an enemy is too close, ranged bots move backward instead of turning around. This makes the bot move more like a real player.

A more useful future improvement would be to have tank move backwards to avoid leaving its back to the enemy.