### PR TITLE
Put IsValidAttackTarget check on both bots and their pets

### DIFF
--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -75,6 +75,14 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
         return false;
     }
 
+    if (!bot->IsValidAttackTarget(target))
+    {
+        if (verbose)
+            botAI->TellError("I cannot attack an invalid target");
+
+        return false;
+    }
+
     std::ostringstream msg;
     msg << target->GetName();
 
@@ -106,7 +114,7 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
     }
 
     if (sPlayerbotAIConfig->IsInPvpProhibitedZone(bot->GetZoneId())
-        && (target->IsPlayer() || target->IsPet() || !bot->IsValidAttackTarget(target)))
+        && (target->IsPlayer() || target->IsPet()))
     {
         if (verbose)
             botAI->TellError("I cannot attack others in PvP prohibited zones");

--- a/src/strategy/actions/GenericActions.cpp
+++ b/src/strategy/actions/GenericActions.cpp
@@ -67,11 +67,18 @@ bool PetAttackAction::Execute(Event event)
     {
         return false;
     }
+
     Unit* target = AI_VALUE(Unit*, "current target");
     if (!target)
     {
         return false;
     }
+
+    if (!bot->IsValidAttackTarget(target))
+    {
+        return false;
+    }
+
     pet->SetReactState(REACT_PASSIVE);
     pet->ClearUnitState(UNIT_STATE_FOLLOW);
     pet->AttackStop();


### PR DESCRIPTION
Mostly immersion improvement: It occasionally happens that bots and/or their pets attack invalid targets. One example is in Sholazar Basin, where they attack Frenzyheart Ravagers, which will never end as they cannot lose health or fight back. This is just one example.

The added checks are checks also done for normal players, so they should not interfere with any gameplay (I could not observe anything out of the ordinary during testing). This also benefits performance, slightly.

Note: There might still be edge cases where either the bot or the pet still (able to) attacks something they shouldn't, but this at least drastically reduces such instances.