### PR TITLE
Warrior strategy update

### DIFF
--- a/src/strategy/rogue/RogueTriggers.cpp
+++ b/src/strategy/rogue/RogueTriggers.cpp
@@ -105,7 +105,8 @@ bool SprintTrigger::IsActive()
 
 bool ExposeArmorTrigger::IsActive()
 {
-    return DebuffTrigger::IsActive() && !botAI->HasAura("sunder armor", bot, false, false, -1, true) &&
+    Unit* target = AI_VALUE(Unit*, "current target"); // Get the bot's current target
+    return DebuffTrigger::IsActive() && !botAI->HasAura("sunder armor", target, false, false, -1, true) &&
            AI_VALUE2(uint8, "combo", "current target") <= 3;
 }
 

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -19,7 +19,6 @@ public:
         creators["heroic strike"] = &heroic_strike;
         creators["enraged regeneration"] = &enraged_regeneration;
         creators["retaliation"] = &retaliation;
-        retaliation
     }
 
 private:

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -18,6 +18,8 @@ public:
         creators["mocking blow"] = &mocking_blow;
         creators["heroic strike"] = &heroic_strike;
         creators["enraged regeneration"] = &enraged_regeneration;
+        creators["retaliation"] = &retaliation;
+        retaliation
     }
 
 private:
@@ -30,6 +32,14 @@ private:
     static ActionNode* enraged_regeneration(PlayerbotAI* botAI)
     {
         return new ActionNode("enraged regeneration",
+                              /*P*/ nullptr,
+                              /*A*/ nullptr,
+                              /*C*/ nullptr);
+    }
+
+    static ActionNode* retaliation(PlayerbotAI* botAI)
+    {
+        return new ActionNode("retaliation",
                               /*P*/ nullptr,
                               /*A*/ nullptr,
                               /*C*/ nullptr);
@@ -107,6 +117,8 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
                              new NextAction("intimidating shout", ACTION_EMERGENCY),
                                 nullptr)));
 
+    triggers.push_back(new TriggerNode("medium health",
+        NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY), nullptr)));
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
     /*

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -127,10 +127,10 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("enraged regeneration", ACTION_EMERGENCY), nullptr)));
 
     triggers.push_back(new TriggerNode("almost full health",
-        NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY), nullptr)));
+        NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY + 1), nullptr)));
 
     triggers.push_back(new TriggerNode("shattering throw",
-        NextAction::array(0, new NextAction("shattering throw", ACTION_INTERRUPT), nullptr)));
+        NextAction::array(0, new NextAction("shattering throw", ACTION_EMERGENCY + 2), nullptr)));
 
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -112,12 +112,14 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode("death wish", NextAction::array(0, new NextAction("death wish", ACTION_HIGH + 2), nullptr)));
 
     triggers.push_back(new TriggerNode("critical health",
-        NextAction::array(0, new NextAction("enraged regeneration", ACTION_EMERGENCY + 1),
-                             new NextAction("intimidating shout", ACTION_EMERGENCY),
-                                nullptr)));
-
+        NextAction::array(0, new NextAction("intimidating shout", ACTION_EMERGENCY), nullptr)));
+    
     triggers.push_back(new TriggerNode("medium health",
+        NextAction::array(0, new NextAction("enraged regeneration", ACTION_EMERGENCY), nullptr)));
+
+    triggers.push_back(new TriggerNode("almost full health",
         NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY), nullptr)));
+
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
     /*

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -120,6 +120,9 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("almost full health",
         NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY), nullptr)));
 
+    triggers.push_back(new TriggerNode("shattering throw",
+        NextAction::array(0, new NextAction("shattering throw", ACTION_INTERRUPT), nullptr)));
+
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
     /*

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -49,7 +49,7 @@ private:
     {
         return new ActionNode("shattering throw",
                               /*P*/ nullptr,
-                              /*A*/ nullptr,
+                              /*A*/ NextAction::array(0, new NextAction("shattering throw"), nullptr),
                               /*C*/ nullptr);
     }
 };

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -19,6 +19,7 @@ public:
         creators["heroic strike"] = &heroic_strike;
         creators["enraged regeneration"] = &enraged_regeneration;
         creators["retaliation"] = &retaliation;
+        creators["shattering throw"] = &shattering_throw;
     }
 
 private:
@@ -39,6 +40,14 @@ private:
     static ActionNode* retaliation(PlayerbotAI* botAI)
     {
         return new ActionNode("retaliation",
+                              /*P*/ nullptr,
+                              /*A*/ nullptr,
+                              /*C*/ nullptr);
+    }
+
+    static ActionNode* shattering_throw(PlayerbotAI* botAI)
+    {
+        return new ActionNode("shattering throw",
                               /*P*/ nullptr,
                               /*A*/ nullptr,
                               /*C*/ nullptr);

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -129,7 +129,7 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("almost full health",
         NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY + 1), nullptr)));
 
-    triggers.push_back(new TriggerNode("shattering throw",
+    triggers.push_back(new TriggerNode("shattering throw trigger",
         NextAction::array(0, new NextAction("shattering throw", ACTION_EMERGENCY + 2), nullptr)));
 
     // triggers.push_back(new TriggerNode("medium aoe",

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -49,7 +49,7 @@ private:
     {
         return new ActionNode("shattering throw",
                               /*P*/ nullptr,
-                              /*A*/ NextAction::array(0, new NextAction("shattering throw"), nullptr),
+                              /*A*/ nullptr,
                               /*C*/ nullptr);
     }
 };
@@ -130,7 +130,7 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("retaliation", ACTION_EMERGENCY + 1), nullptr)));
 
     triggers.push_back(new TriggerNode("shattering throw trigger",
-        NextAction::array(0, new NextAction("shattering throw", ACTION_EMERGENCY + 2), nullptr)));
+        NextAction::array(0, new NextAction("shattering throw", ACTION_INTERRUPT + 1), nullptr)));
 
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));

--- a/src/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/src/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -17,6 +17,7 @@ public:
         creators["piercing howl"] = &piercing_howl;
         creators["mocking blow"] = &mocking_blow;
         creators["heroic strike"] = &heroic_strike;
+        creators["enraged regeneration"] = &enraged_regeneration;
     }
 
 private:
@@ -25,6 +26,14 @@ private:
     ACTION_NODE_A(piercing_howl, "piercing howl", "mocking blow");
     ACTION_NODE_A(mocking_blow, "mocking blow", "hamstring");
     ACTION_NODE_A(heroic_strike, "heroic strike", "melee");
+
+    static ActionNode* enraged_regeneration(PlayerbotAI* botAI)
+    {
+        return new ActionNode("enraged regeneration",
+                              /*P*/ nullptr,
+                              /*A*/ nullptr,
+                              /*C*/ nullptr);
+    }
 };
 
 ArmsWarriorStrategy::ArmsWarriorStrategy(PlayerbotAI* botAI) : GenericWarriorStrategy(botAI)
@@ -93,9 +102,11 @@ void ArmsWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("death wish", NextAction::array(0, new NextAction("death wish", ACTION_HIGH + 2), nullptr)));
 
-    triggers.push_back(new TriggerNode(
-        "critical health", NextAction::array(0, new NextAction("intimidating shout", ACTION_EMERGENCY), nullptr)));
-    
+    triggers.push_back(new TriggerNode("critical health",
+        NextAction::array(0, new NextAction("enraged regeneration", ACTION_EMERGENCY + 1),
+                             new NextAction("intimidating shout", ACTION_EMERGENCY),
+                                nullptr)));
+
     // triggers.push_back(new TriggerNode("medium aoe",
     //                                   NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), nullptr)));
     /*

--- a/src/strategy/warrior/FuryWarriorStrategy.cpp
+++ b/src/strategy/warrior/FuryWarriorStrategy.cpp
@@ -18,6 +18,7 @@ public:
         creators["piercing howl"] = &piercing_howl;
         // creators["bloodthirst"] = &bloodthirst;
         creators["pummel"] = &pummel;
+        creators["enraged regeneration"] = &enraged_regeneration;
     }
 
 private:
@@ -27,6 +28,14 @@ private:
     // ACTION_NODE_A(death_wish, "death wish", "berserker rage");
     // ACTION_NODE_A(bloodthirst, "bloodthirst", "melee");
     ACTION_NODE_A(pummel, "pummel", "intercept");
+
+    static ActionNode* enraged_regeneration(PlayerbotAI* botAI)
+    {
+        return new ActionNode("enraged regeneration",
+                              /*P*/ nullptr,
+                              /*A*/ nullptr,
+                              /*C*/ nullptr);
+    }
 };
 
 FuryWarriorStrategy::FuryWarriorStrategy(PlayerbotAI* botAI) : GenericWarriorStrategy(botAI)
@@ -85,4 +94,6 @@ void FuryWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode("death wish", NextAction::array(0, new NextAction("death wish", ACTION_HIGH), nullptr)));
     triggers.push_back(
         new TriggerNode("recklessness", NextAction::array(0, new NextAction("recklessness", ACTION_HIGH), nullptr)));
+    triggers.push_back(new TriggerNode("critical health",
+        NextAction::array(0, new NextAction("enraged regeneration", ACTION_EMERGENCY), nullptr)));
 }

--- a/src/strategy/warrior/GenericWarriorStrategy.h
+++ b/src/strategy/warrior/GenericWarriorStrategy.h
@@ -20,6 +20,8 @@ public:
         creators["charge"] = &charge;
         creators["mocking blow"] = &mocking_blow;
         creators["overpower"] = &overpower;
+        creators["retaliation"] = &retaliation;
+        creators["shattering throw"] = &shattering_throw;
 
         // temp
         creators["mortal strike"] = &mortal_strike;
@@ -57,6 +59,8 @@ private:
     ACTION_NODE_P(intervene, "intervene", "defensive stance");
     // temp
     ACTION_NODE_P(mortal_strike, "mortal strike", "battle stance");
+    ACTION_NODE_P(retaliation, "retaliation", "battle stance");
+    ACTION_NODE_P(shattering_throw, "shattering throw", "battle stance");
 };
 
 class GenericWarriorStrategy : public CombatStrategy

--- a/src/strategy/warrior/TankWarriorStrategy.cpp
+++ b/src/strategy/warrior/TankWarriorStrategy.cpp
@@ -23,6 +23,7 @@ public:
         creators["taunt"] = &taunt;
         creators["taunt spell"] = &taunt;
         creators["vigilance"] = &vigilance;
+        creators["enraged regeneration"] = &enraged_regeneration;
     }
 
 private:
@@ -46,6 +47,14 @@ private:
     static ActionNode* vigilance(PlayerbotAI* botAI)
     {
         return new ActionNode("vigilance",
+                              /*P*/ nullptr,
+                              /*A*/ nullptr,
+                              /*C*/ nullptr);
+    }
+
+    static ActionNode* enraged_regeneration(PlayerbotAI* botAI)
+    {
+        return new ActionNode("enraged regeneration",
                               /*P*/ nullptr,
                               /*A*/ nullptr,
                               /*C*/ nullptr);
@@ -105,8 +114,10 @@ void TankWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("heroic throw on snare target", ACTION_INTERRUPT), nullptr)));
     triggers.push_back(new TriggerNode(
         "low health", NextAction::array(0, new NextAction("shield wall", ACTION_MEDIUM_HEAL), nullptr)));
-    triggers.push_back(new TriggerNode(
-        "critical health", NextAction::array(0, new NextAction("last stand", ACTION_EMERGENCY + 3), nullptr)));
+    triggers.push_back(new TriggerNode("critical health", 
+        NextAction::array(0, new NextAction("last stand", ACTION_EMERGENCY + 3),
+                             new NextAction("enraged regeneration", ACTION_EMERGENCY + 2),
+                                nullptr)));
     // triggers.push_back(new TriggerNode("medium aoe", NextAction::array(0, new NextAction("battle shout taunt",
     // ACTION_HIGH + 1), nullptr)));
     triggers.push_back(new TriggerNode(

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -203,7 +203,7 @@ bool CastShatteringThrowAction::isPossible()
         return false;
 
     // Spell cooldown check
-    if (bot->HasSpell(64382))
+    if (!bot->HasSpell(64382))
     {
         LOG_INFO("playerbots",
             "CastShatteringThrowAction::isPossible - Spell not known. Bot: {}, Spell ID: {}",

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -142,7 +142,7 @@ bool CastRetaliationAction::isUseful()
     return meleeAttackers >= 2 && !botAI->HasAura("retaliation", bot);
 }
 
-Value<Unit*>* CastShatteringThrowAction::GetTargetValue()
+Unit* CastShatteringThrowAction::GetTarget()
 {
     GuidVector enemies = AI_VALUE(GuidVector, "possible targets");
 
@@ -152,22 +152,20 @@ Value<Unit*>* CastShatteringThrowAction::GetTargetValue()
         if (!enemy || !enemy->IsAlive() || enemy->IsFriendlyTo(bot))
             continue;
 
-        // Check if the enemy is within 25 yards and has the specific auras
         if (bot->IsWithinDistInMap(enemy, 25.0f) &&
             (enemy->HasAura(642) ||   // Divine Shield
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
-            LOG_INFO("playerbots", "Bot Name = {}, CastShatteringThrowAction: Valid target found: Name = {}, GUID = {}", 
+            LOG_INFO("playerbots", "Bot Name = {}, CastShatteringThrowAction::GetTarget: Valid target found: Name = {}, GUID = {}", 
                 bot->GetName(), 
                 enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
                 guid.GetRawValue());
-            return new ManualSetValue<Unit*>(botAI, enemy);
+            return enemy;
         }
     }
 
-    // No valid target
-    return new ManualSetValue<Unit*>(botAI, nullptr);
+    return nullptr; // No valid target
 }
 
 bool CastShatteringThrowAction::isUseful()

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -202,9 +202,26 @@ bool CastShatteringThrowAction::isPossible()
     if (!target)
         return false;
 
-    // Example range check: Shattering Throw is typically 30 yards in WotLK, but
-    // you can adapt to your code's expected range, e.g. 25.0f if you prefer
-    float distance = sServerFacade->GetDistance2d(bot, target);
+    // Spell cooldown check
+    if (bot->HasSpell(64382))
+    {
+        LOG_INFO("playerbots",
+            "CastShatteringThrowAction::isPossible - Spell not known. Bot: {}, Spell ID: {}",
+            bot->GetName(), 64382);
+        return false;
+    }
+
+    // Spell cooldown check
+    if (bot->HasSpellCooldown(64382))
+    {
+        LOG_INFO("playerbots",
+            "CastShatteringThrowAction::isPossible - Spell is on cooldown. Bot: {}, Spell ID: {}",
+            bot->GetName(), 64382);
+        return false;
+    }
+
+    // Range check: Shattering Throw is 30 yards    
+    float distance = bot->GetDistance2d(bot, target);
     if (distance > 30.0f)
     {
         return false;

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -221,7 +221,7 @@ bool CastShatteringThrowAction::isPossible()
     }
 
     // Range check: Shattering Throw is 30 yards    
-    if (!bot->IsWithinDistInMap(target, 30.0f)
+    if (!bot->IsWithinDistInMap(target, 30.0f))
     {
         return false;
     }

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -196,6 +196,7 @@ bool CastShatteringThrowAction::isUseful()
     return false; // No valid targets within range
 }
 
+/*
 bool CastShatteringThrowAction::Execute(Event event)
 {
     LOG_INFO("playerbots", "Bot Name = {}, Executing Shattering Throw function", bot->GetName());
@@ -210,3 +211,4 @@ bool CastShatteringThrowAction::Execute(Event event)
 
     return botAI->CastSpell("shattering throw", target);
 }
+*/

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -157,10 +157,6 @@ Unit* CastShatteringThrowAction::GetTarget()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
-            LOG_INFO("playerbots", "Bot Name = {}, CastShatteringThrowAction::GetTarget: Valid target found: Name = {}, GUID = {}", 
-                bot->GetName(), 
-                enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
-                guid.GetRawValue());
             return enemy;
         }
     }
@@ -170,6 +166,19 @@ Unit* CastShatteringThrowAction::GetTarget()
 
 bool CastShatteringThrowAction::isUseful()
 {
+
+    // Spell cooldown check
+    if (!bot->HasSpell(64382))
+    {
+        return false;
+    }
+
+    // Spell cooldown check
+    if (bot->HasSpellCooldown(64382))
+    {
+        return false;
+    }
+
     GuidVector enemies = AI_VALUE(GuidVector, "possible targets");
 
     for (ObjectGuid const& guid : enemies)
@@ -184,11 +193,6 @@ bool CastShatteringThrowAction::isUseful()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
-            LOG_INFO("playerbots", "Bot Name = {}, ShatteringThrowAction::isUseful: Valid target found: Name = {}, GUID = {}", 
-                bot->GetName(), 
-                enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
-                guid.GetRawValue());
-
             return true;
         }
     }
@@ -201,24 +205,6 @@ bool CastShatteringThrowAction::isPossible()
     Unit* target = GetTarget();
     if (!target)
         return false;
-
-    // Spell cooldown check
-    if (!bot->HasSpell(64382))
-    {
-        LOG_INFO("playerbots",
-            "CastShatteringThrowAction::isPossible - Spell not known. Bot: {}, Spell ID: {}",
-            bot->GetName(), 64382);
-        return false;
-    }
-
-    // Spell cooldown check
-    if (bot->HasSpellCooldown(64382))
-    {
-        LOG_INFO("playerbots",
-            "CastShatteringThrowAction::isPossible - Spell is on cooldown. Bot: {}, Spell ID: {}",
-            bot->GetName(), 64382);
-        return false;
-    }
 
     // Range check: Shattering Throw is 30 yards    
     if (!bot->IsWithinDistInMap(target, 30.0f))
@@ -233,23 +219,14 @@ bool CastShatteringThrowAction::isPossible()
     }
 
     // If the minimal checks above pass, simply return true.
-    LOG_INFO("playerbots",
-        "CastShatteringThrowAction::isPossible - Passed, returning true. Bot: {}, Target: {}",
-        bot->GetName(), target->GetName().empty() ? "Unknown" : target->GetName());
     return true;
 }
 
 bool CastShatteringThrowAction::Execute(Event event)
 {
-    LOG_INFO("playerbots", "Bot Name = {}, Executing Shattering Throw function", bot->GetName());
     Unit* target = GetTarget();
     if (!target)
         return false;
-
-    LOG_INFO("playerbots", "Bot Name = {}, Casting Shattering Throw at target: Name = {}, GUID = {}", 
-             bot->GetName(), 
-             target->GetName().empty() ? "Unknown" : target->GetName(), 
-             target->GetGUID().GetRawValue());
 
     return botAI->CastSpell("shattering throw", target);
 }

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -117,7 +117,9 @@ bool CastRetaliationAction::isUseful()
         if (attacker->GetTypeId() == TYPEID_UNIT)
         {
             Creature* creature = attacker->ToCreature();
-            if (creature && (creature->IsClass(UNIT_CLASS_WARRIOR) || creature->IsClass(UNIT_CLASS_ROGUE)))
+            if (creature && (creature->IsClass(CLASS_WARRIOR)
+                || creature->IsClass(CLASS_ROGUE)
+                || creature->IsClass(CLASS_PALADIN)))
             {
                 ++meleeAttackers;
             }

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -158,6 +158,10 @@ Value<Unit*>* CastShatteringThrowAction::GetTargetValue()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
+            LOG_INFO("playerbots", "Bot Name = {}, ShatteringThrowTrigger: Valid target found: Name = {}, GUID = {}", 
+                bot->GetName(), 
+                enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
+                guid.GetRawValue());
             return new ManualSetValue<Unit*>(botAI, enemy);
         }
     }
@@ -173,5 +177,11 @@ bool CastShatteringThrowAction::Execute(Event event)
     if (!target || target == bot)
         return false;
 
+    LOG_INFO("playerbots", "Bot Name = {}, Casting Shattering Throw at target: Name = {}, GUID = {}", 
+             bot->GetName(), 
+             target->GetName().empty() ? "Unknown" : target->GetName(), 
+             target->GetGUID().GetRawValue());
+
     return botAI->CastSpell("shattering throw", target);
 }
+

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -173,6 +173,7 @@ Value<Unit*>* CastShatteringThrowAction::GetTargetValue()
 
 bool CastShatteringThrowAction::Execute(Event event)
 {
+    LOG_INFO("playerbots", "Bot Name = {}, Executing Shattering Throw function", bot->GetName());
     Unit* target = GetTarget();
     if (!target || target == bot)
         return false;

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -221,8 +221,7 @@ bool CastShatteringThrowAction::isPossible()
     }
 
     // Range check: Shattering Throw is 30 yards    
-    float distance = bot->GetDistance2d(bot, target);
-    if (distance > 30.0f)
+    if (!bot->IsWithinDistInMap(target, 30.0f)
     {
         return false;
     }

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -196,7 +196,33 @@ bool CastShatteringThrowAction::isUseful()
     return false; // No valid targets within range
 }
 
-/*
+bool CastShatteringThrowAction::isPossible()
+{
+    Unit* target = GetTarget();
+    if (!target)
+        return false;
+
+    // Example range check: Shattering Throw is typically 30 yards in WotLK, but
+    // you can adapt to your code's expected range, e.g. 25.0f if you prefer
+    float distance = sServerFacade->GetDistance2d(bot, target);
+    if (distance > 30.0f)
+    {
+        return false;
+    }
+
+    // Check line of sight
+    if (!bot->IsWithinLOSInMap(target))
+    {
+        return false;
+    }
+
+    // If the minimal checks above pass, simply return true.
+    LOG_INFO("playerbots",
+        "CastShatteringThrowAction::isPossible - Passed, returning true. Bot: {}, Target: {}",
+        bot->GetName(), target->GetName().empty() ? "Unknown" : target->GetName());
+    return true;
+}
+
 bool CastShatteringThrowAction::Execute(Event event)
 {
     LOG_INFO("playerbots", "Bot Name = {}, Executing Shattering Throw function", bot->GetName());
@@ -211,4 +237,3 @@ bool CastShatteringThrowAction::Execute(Event event)
 
     return botAI->CastSpell("shattering throw", target);
 }
-*/

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -110,7 +110,7 @@ bool CastRetaliationAction::isUseful()
     for (ObjectGuid const& guid : attackers)
     {
         Unit* attacker = botAI->GetUnit(guid);
-        if (!attacker || !attacker->IsAlive())
+        if (!attacker || !attacker->IsAlive() || attacker->GetVictim() != bot)
             continue;
 
         // Check if the attacker is melee-based using unit_class

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -104,6 +104,18 @@ bool CastVigilanceAction::Execute(Event event)
 
 bool CastRetaliationAction::isUseful()
 {
+    // Spell cooldown check
+    if (!bot->HasSpell(20230))
+    {
+        return false;
+    }
+
+    // Spell cooldown check
+    if (bot->HasSpellCooldown(20230))
+    {
+        return false;
+    }
+
     uint8 meleeAttackers = 0;
     GuidVector attackers = AI_VALUE(GuidVector, "attackers");
 

--- a/src/strategy/warrior/WarriorActions.cpp
+++ b/src/strategy/warrior/WarriorActions.cpp
@@ -158,7 +158,7 @@ Value<Unit*>* CastShatteringThrowAction::GetTargetValue()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
-            LOG_INFO("playerbots", "Bot Name = {}, ShatteringThrowTrigger: Valid target found: Name = {}, GUID = {}", 
+            LOG_INFO("playerbots", "Bot Name = {}, CastShatteringThrowAction: Valid target found: Name = {}, GUID = {}", 
                 bot->GetName(), 
                 enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
                 guid.GetRawValue());

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -60,7 +60,7 @@ SNARE_ACTION(CastThunderClapSnareAction, "thunder clap");
 SNARE_ACTION(CastHamstringAction, "hamstring");
 MELEE_ACTION(CastOverpowerAction, "overpower");
 MELEE_ACTION(CastMockingBlowAction, "mocking blow");
-BUFF_ACTION(CastRetaliationAction, "retaliation");
+// BUFF_ACTION(CastRetaliationAction, "retaliation");
 // arms 3.3.5
 SPELL_ACTION(CastHeroicThrowAction, "heroic throw");
 SNARE_ACTION(CastHeroicThrowSnareAction, "heroic throw");
@@ -142,6 +142,14 @@ public:
 
     Value<Unit*>* GetTargetValue() override;
     bool Execute(Event event) override;
+};
+
+class CastRetaliationAction : public CastBuffSpellAction
+{
+public:
+    CastRetaliationAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "retaliation") {}
+
+    bool isUseful() override;
 };
 
 #endif

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -159,7 +159,8 @@ public:
 
     Unit* GetTarget() override;
     bool isUseful() override;
-    // bool Execute(Event event) override;
+    bool isPossible() override;
+    bool Execute(Event event) override;
 };
 
 #endif

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -158,8 +158,8 @@ public:
     CastShatteringThrowAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "shattering throw") {}
 
     Value<Unit*>* GetTargetValue() override;
+    bool isUseful() override;
     bool Execute(Event event) override;
 };
-
 
 #endif

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -159,7 +159,7 @@ public:
 
     Unit* GetTarget() override;
     bool isUseful() override;
-    bool Execute(Event event) override;
+    // bool Execute(Event event) override;
 };
 
 #endif

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -64,7 +64,7 @@ MELEE_ACTION(CastMockingBlowAction, "mocking blow");
 // arms 3.3.5
 SPELL_ACTION(CastHeroicThrowAction, "heroic throw");
 SNARE_ACTION(CastHeroicThrowSnareAction, "heroic throw");
-DEBUFF_ACTION(CastShatteringThrowAction, "shattering throw");
+// DEBUFF_ACTION(CastShatteringThrowAction, "shattering throw");
 
 // arms talents
 MELEE_ACTION(CastMortalStrikeAction, "mortal strike");
@@ -151,5 +151,15 @@ public:
 
     bool isUseful() override;
 };
+
+class CastShatteringThrowAction : public CastDebuffSpellAction
+{
+public:
+    CastShatteringThrowAction(PlayerbotAI* botAI) : CastDebuffSpellAction(botAI, "shattering throw") {}
+
+    Value<Unit*>* GetTargetValue() override;
+    bool Execute(Event event) override;
+};
+
 
 #endif

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -152,13 +152,10 @@ public:
     bool isUseful() override;
 };
 
-class CastShatteringThrowAction : public CastDebuffSpellAction
+class CastShatteringThrowAction : public CastSpellAction
 {
 public:
-    CastShatteringThrowAction(PlayerbotAI* botAI) : CastDebuffSpellAction(botAI, "shattering throw")
-    {
-        range = 25.0f;
-    }
+    CastShatteringThrowAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "shattering throw") {}
 
     Value<Unit*>* GetTargetValue() override;
     bool Execute(Event event) override;

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -157,7 +157,7 @@ class CastShatteringThrowAction : public CastSpellAction
 public:
     CastShatteringThrowAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "shattering throw") {}
 
-    Value<Unit*>* GetTargetValue() override;
+    Unit* GetTarget() override;
     bool isUseful() override;
     bool Execute(Event event) override;
 };

--- a/src/strategy/warrior/WarriorActions.h
+++ b/src/strategy/warrior/WarriorActions.h
@@ -155,7 +155,10 @@ public:
 class CastShatteringThrowAction : public CastDebuffSpellAction
 {
 public:
-    CastShatteringThrowAction(PlayerbotAI* botAI) : CastDebuffSpellAction(botAI, "shattering throw") {}
+    CastShatteringThrowAction(PlayerbotAI* botAI) : CastDebuffSpellAction(botAI, "shattering throw")
+    {
+        range = 25.0f;
+    }
 
     Value<Unit*>* GetTargetValue() override;
     bool Execute(Event event) override;

--- a/src/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/src/strategy/warrior/WarriorAiObjectContext.cpp
@@ -242,6 +242,7 @@ public:
         creators["heroic throw on snare target"] = &WarriorAiObjectContextInternal::heroic_throw_on_snare_target;
         creators["shattering throw"] = &WarriorAiObjectContextInternal::shattering_throw;
         creators["vigilance"] = &WarriorAiObjectContextInternal::vigilance;
+        creators["enraged regeneration"] = &WarriorAiObjectContextInternal::enraged_regeneration;
     }
 
 private:
@@ -312,6 +313,7 @@ private:
     static Action* heroic_throw(PlayerbotAI* botAI) { return new CastHeroicThrowAction(botAI); }
     static Action* bladestorm(PlayerbotAI* botAI) { return new CastBladestormAction(botAI); }
     static Action* vigilance(PlayerbotAI* botAI) { return new CastVigilanceAction(botAI); }
+    static Action* enraged_regeneration(PlayerbotAI* botAI) { return new CastEnragedRegenerationAction(botAI); }
 };
 
 WarriorAiObjectContext::WarriorAiObjectContext(PlayerbotAI* botAI) : AiObjectContext(botAI)

--- a/src/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/src/strategy/warrior/WarriorAiObjectContext.cpp
@@ -101,6 +101,7 @@ public:
         // creators["slam"] = &WarriorTriggerFactoryInternal::slam;
 
         creators["vigilance"] = &WarriorTriggerFactoryInternal::vigilance;
+        creators["shattering throw"] = &WarriorTriggerFactoryInternal::shattering_throw;
     }
 
 private:
@@ -172,6 +173,7 @@ private:
     // static Trigger* slam(PlayerbotAI* ai) { return new SlamTrigger(ai); }
 
     static Trigger* vigilance(PlayerbotAI* botAI) { return new VigilanceTrigger(botAI); }
+    static Trigger* shattering_throw(PlayerbotAI* botAI) { return new ShatteringThrowTrigger(botAI); }
 };
 
 class WarriorAiObjectContextInternal : public NamedObjectContext<Action>

--- a/src/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/src/strategy/warrior/WarriorAiObjectContext.cpp
@@ -101,7 +101,7 @@ public:
         // creators["slam"] = &WarriorTriggerFactoryInternal::slam;
 
         creators["vigilance"] = &WarriorTriggerFactoryInternal::vigilance;
-        creators["shattering throw"] = &WarriorTriggerFactoryInternal::shattering_throw;
+        creators["shattering throw trigger"] = &WarriorTriggerFactoryInternal::shattering_throw_trigger;
     }
 
 private:
@@ -173,7 +173,7 @@ private:
     // static Trigger* slam(PlayerbotAI* ai) { return new SlamTrigger(ai); }
 
     static Trigger* vigilance(PlayerbotAI* botAI) { return new VigilanceTrigger(botAI); }
-    static Trigger* shattering_throw(PlayerbotAI* botAI) { return new ShatteringThrowTrigger(botAI); }
+    static Trigger* shattering_throw_trigger(PlayerbotAI* botAI) { return new ShatteringThrowTrigger(botAI); }
 };
 
 class WarriorAiObjectContextInternal : public NamedObjectContext<Action>

--- a/src/strategy/warrior/WarriorTriggers.cpp
+++ b/src/strategy/warrior/WarriorTriggers.cpp
@@ -84,3 +84,27 @@ bool VigilanceTrigger::IsActive()
 
     return false; // No need to reassign Vigilance
 }
+
+bool ShatteringThrowTrigger::IsActive()
+{
+    GuidVector enemies = AI_VALUE(GuidVector, "possible targets");
+
+    for (ObjectGuid const& guid : enemies)
+    {
+        Unit* enemy = botAI->GetUnit(guid);
+        if (!enemy || !enemy->IsAlive() || enemy->IsFriendlyTo(bot))
+            continue;
+
+        // Check if the enemy is within 25 yards and has the specific auras
+        if (bot->IsWithinDistInMap(enemy, 25.0f) &&
+            (enemy->HasAura(642) ||   // Divine Shield
+             enemy->HasAura(45438) || // Ice Block
+             enemy->HasAura(41450)))  // Blessing of Protection
+        {
+            return true;
+        }
+    }
+
+    return false; // No valid targets within range
+}
+

--- a/src/strategy/warrior/WarriorTriggers.cpp
+++ b/src/strategy/warrior/WarriorTriggers.cpp
@@ -101,11 +101,6 @@ bool ShatteringThrowTrigger::IsActive()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
-            LOG_INFO("playerbots", "Bot Name = {}, ShatteringThrowTrigger: Valid target found: Name = {}, GUID = {}", 
-                bot->GetName(), 
-                enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
-                guid.GetRawValue());
-
             return true;
         }
     }

--- a/src/strategy/warrior/WarriorTriggers.cpp
+++ b/src/strategy/warrior/WarriorTriggers.cpp
@@ -87,6 +87,18 @@ bool VigilanceTrigger::IsActive()
 
 bool ShatteringThrowTrigger::IsActive()
 {
+    // Spell cooldown check
+    if (!bot->HasSpell(64382))
+    {
+        return false;
+    }
+
+    // Spell cooldown check
+    if (bot->HasSpellCooldown(64382))
+    {
+        return false;
+    }
+
     GuidVector enemies = AI_VALUE(GuidVector, "possible targets");
 
     for (ObjectGuid const& guid : enemies)

--- a/src/strategy/warrior/WarriorTriggers.cpp
+++ b/src/strategy/warrior/WarriorTriggers.cpp
@@ -101,7 +101,11 @@ bool ShatteringThrowTrigger::IsActive()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
-            LOG_INFO("playerbots", "ShatteringThrowTrigger: Valid target found: GUID {}", guid.GetRawValue());
+            LOG_INFO("playerbots", "Bot Name = {}, ShatteringThrowTrigger: Valid target found: Name = {}, GUID = {}", 
+                bot->GetName(), 
+                enemy->GetName().empty() ? "Unknown" : enemy->GetName(), 
+                guid.GetRawValue());
+
             return true;
         }
     }

--- a/src/strategy/warrior/WarriorTriggers.cpp
+++ b/src/strategy/warrior/WarriorTriggers.cpp
@@ -101,6 +101,7 @@ bool ShatteringThrowTrigger::IsActive()
              enemy->HasAura(45438) || // Ice Block
              enemy->HasAura(41450)))  // Blessing of Protection
         {
+            LOG_INFO("playerbots", "ShatteringThrowTrigger: Valid target found: GUID {}", guid.GetRawValue());
             return true;
         }
     }

--- a/src/strategy/warrior/WarriorTriggers.h
+++ b/src/strategy/warrior/WarriorTriggers.h
@@ -72,6 +72,15 @@ public:
     bool IsActive() override; 
 };
 
+class ShatteringThrowTrigger : public Trigger
+{
+public:
+    ShatteringThrowTrigger(PlayerbotAI* botAI) : Trigger(botAI, "shattering throw") {}
+
+    bool IsActive() override;
+};
+
+
 // class SlamTrigger : public HasAuraTrigger
 // {
 // public:

--- a/src/strategy/warrior/WarriorTriggers.h
+++ b/src/strategy/warrior/WarriorTriggers.h
@@ -75,7 +75,7 @@ public:
 class ShatteringThrowTrigger : public Trigger
 {
 public:
-    ShatteringThrowTrigger(PlayerbotAI* botAI) : Trigger(botAI, "shattering throw") {}
+    ShatteringThrowTrigger(PlayerbotAI* botAI) : Trigger(botAI, "shattering throw trigger") {}
 
     bool IsActive() override;
 };


### PR DESCRIPTION
1. Enabled Enraged regeneration for all specs.
2. Fixed issue where Rogues would constantly apply Expose Armor on targets that already had Sunder Armor.
3. Arms warriors use Retaliation when being melee'd by two or more creature.
4. Arms warriors use Shattering Throw on enemies with Divine Shield, Ice Block, or Hand of Protection.