### PR TITLE
Fix LFG leave group and several minor issues

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -392,7 +392,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
         }
     }
 
-    if (!bot->InBattleground() && !bot->inRandomLfgDungeon() && bot->GetGroup())
+    if (!bot->InBattleground() && !bot->inRandomLfgDungeon() && bot->GetGroup() && !bot->GetGroup()->isLFGGroup())
 	{
 		Player* leader = bot->GetGroup()->GetLeader();
 		if (leader && leader != bot) // Checks if the leader is valid and is not the bot itself
@@ -1312,11 +1312,9 @@ void PlayerbotAI::DoNextAction(bool min)
     // if in combat but stick with old data - clear targets
     if (currentEngine == engines[BOT_STATE_NON_COMBAT] && bot->IsInCombat())
     {
-        if (aiObjectContext->GetValue<Unit*>("current target")->Get() != nullptr ||
-            aiObjectContext->GetValue<ObjectGuid>("pull target")->Get() != ObjectGuid::Empty ||
-            aiObjectContext->GetValue<Unit*>("dps target")->Get() != nullptr)
+        if (aiObjectContext->GetValue<Unit*>("current target")->Get() != nullptr)
         {
-            Reset();
+            aiObjectContext->GetValue<Unit*>("current target")->Set(nullptr);
         }
     }
 

--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -48,10 +48,12 @@ bool AttackAnythingAction::isUseful()
     if (!target)
         return false;
 
-    bool rpgGoStatus = botAI->rpgInfo.status == NewRpgStatus::GO_GRIND ||
-                       botAI->rpgInfo.status == NewRpgStatus::GO_INNKEEPER;
+    bool inactiveGrindStatus = botAI->rpgInfo.status == NewRpgStatus::GO_GRIND ||
+                               botAI->rpgInfo.status == NewRpgStatus::NEAR_NPC ||
+                               botAI->rpgInfo.status == NewRpgStatus::REST ||
+                               botAI->rpgInfo.status == NewRpgStatus::GO_INNKEEPER;
 
-    if (rpgGoStatus && bot->GetDistance(target) > 25.0f)
+    if (inactiveGrindStatus && bot->GetDistance(target) > 25.0f)
         return false;
 
     std::string const name = std::string(target->GetName());

--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -8,6 +8,7 @@
 #include "ChooseRpgTargetAction.h"
 #include "Event.h"
 #include "LootObjectStack.h"
+#include "NewRpgStrategy.h"
 #include "Playerbots.h"
 #include "PossibleRpgTargetsValue.h"
 #include "PvpTriggers.h"
@@ -35,17 +36,22 @@ bool AttackAnythingAction::isUseful()
 
     if (!AI_VALUE(bool, "can move around"))
         return false;
-
-    if (context->GetValue<TravelTarget*>("travel target")->Get()->isTraveling() &&
-        ChooseRpgTargetAction::isFollowValid(
-            bot, *context->GetValue<TravelTarget*>("travel target")->Get()->getPosition()))  // Bot is traveling
-        return false;
-    // if (bot->IsInCombat()) {
+    
+        
+    // if (context->GetValue<TravelTarget*>("travel target")->Get()->isTraveling() &&
+    //     ChooseRpgTargetAction::isFollowValid(
+    //         bot, *context->GetValue<TravelTarget*>("travel target")->Get()->getPosition()))  // Bot is traveling
     //     return false;
-    // }
+
     Unit* target = GetTarget();
 
     if (!target)
+        return false;
+
+    bool rpgGoStatus = botAI->rpgInfo.status == NewRpgStatus::GO_GRIND ||
+                       botAI->rpgInfo.status == NewRpgStatus::GO_INNKEEPER;
+
+    if (rpgGoStatus && bot->GetDistance(target) > 25.0f)
         return false;
 
     std::string const name = std::string(target->GetName());
@@ -58,10 +64,6 @@ bool AttackAnythingAction::isUseful()
     {
         return false;  // Target is one of the disallowed types
     }
-
-    // if (!ChooseRpgTargetAction::isFollowValid(bot, target))                               //Do not grind mobs far
-    // away from master.
-    //     return false;
 
     return true;
 }

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -236,11 +236,11 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             if (bot->IsSitState())
                 bot->SetStandState(UNIT_STAND_STATE_STAND);
 
-            if (bot->IsNonMeleeSpellCast(true))
-            {
-                bot->CastStop();
-                botAI->InterruptSpell();
-            }
+            // if (bot->IsNonMeleeSpellCast(true))
+            // {
+            //     bot->CastStop();
+            //     botAI->InterruptSpell();
+            // }
             MotionMaster& mm = *bot->GetMotionMaster();
             mm.Clear();
             if (!backwards)
@@ -277,11 +277,11 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             if (bot->IsSitState())
                 bot->SetStandState(UNIT_STAND_STATE_STAND);
 
-            if (bot->IsNonMeleeSpellCast(true))
-            {
-                bot->CastStop();
-                botAI->InterruptSpell();
-            }
+            // if (bot->IsNonMeleeSpellCast(true))
+            // {
+            //     bot->CastStop();
+            //     botAI->InterruptSpell();
+            // }
             MotionMaster& mm = *bot->GetMotionMaster();
             G3D::Vector3 endP = path.back();
             mm.Clear();

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -44,7 +44,7 @@ bool NewRpgStatusUpdateAction::Execute(Event event)
                 }
             }
             // IDLE -> GO_INNKEEPER
-            else if (bot->GetLevel() >= 6 && roll <= 45)
+            else if (roll <= 45)
             {
                 WorldPosition pos = SelectRandomInnKeeperPos();
                 if (pos != WorldPosition() && bot->GetExactDist(pos) > 50.0f)
@@ -245,7 +245,7 @@ bool NewRpgGoFarAwayPosAction::MoveFarTo(WorldPosition dest)
     while (--attempt)
     {
         float angle = bot->GetAngle(&dest);
-        float delta = (rand_norm() - 0.5) * M_PI * 2;
+        float delta = urand(1, 100) <= 75 ? (rand_norm() - 0.5) * M_PI * 0.5 : (rand_norm() - 0.5) * M_PI * 2;
         angle += delta;
         float dis = rand_norm() * pathFinderDis;
         float dx = x + cos(angle) * dis;

--- a/src/strategy/rpg/NewRpgAction.h
+++ b/src/strategy/rpg/NewRpgAction.h
@@ -23,7 +23,7 @@ public:
 protected:
     // const int32 setGrindInterval = 5 * 60 * 1000;
     // const int32 setNpcInterval = 1 * 60 * 1000;
-    const int32 statusNearNpcDuration = 2 * 60 * 1000;
+    const int32 statusNearNpcDuration = 5 * 60 * 1000;
     const int32 statusNearRandomDuration = 2 * 60 * 1000;
     const int32 statusRestDuration = 30 * 1000;
     WorldPosition SelectRandomGrindPos();

--- a/src/strategy/shaman/ShamanActions.cpp
+++ b/src/strategy/shaman/ShamanActions.cpp
@@ -10,7 +10,7 @@
 
 bool CastTotemAction::isUseful()
 {
-    if (needLifeTime > 0.1f)
+    if (needLifeTime > 0.1f && AI_VALUE(uint8, "attacker count") < 3)
     {
         Unit* target = AI_VALUE(Unit*, "current target");
         if (!target)


### PR DESCRIPTION
Several minor fixes:
1. Fix LFG leave group. https://github.com/liyunfan1223/mod-playerbots/issues/733
2. Fixed an issue where moving immediately after casting a spell would cause the spell to fail.
3. Target death no longer interrupts channel spells, such as blizzard.
4. Shaman always cast totems with 3 or more enemies.