### PR TITLE
Feat: Mount level for bot configurable instead of hardcoded

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -8,6 +8,7 @@
 #	PLAYERBOT SETTINGS
 #		GENERAL
 #		SUMMON OPTIONS
+#       MOUNT
 #		GEAR
 #		LOOTING
 #		TIMERS
@@ -193,6 +194,36 @@ AiPlayerbot.ReviveBotWhenSummoned = 1
 # Enable/Disable bot repair gear when summon (0 = no, 1 = yes)
 # default: 1
 AiPlayerbot.BotRepairWhenSummon = 1
+
+#
+#
+#
+####################################################################################################
+
+####################################################################################################
+# MOUNT
+#
+#
+
+# Defines at what level a bot will naturally use its 60% ground mount
+# note: was level 20 during WotLK, 30 during TBC, 40 during Vanilla
+# default: 20
+AiPlayerbot.UseGroundMountAtMinLevel = 20
+
+# Defines at what level a bot will naturally use its 100% fast ground mount
+# note: was level 40 during WotLK, 60 during Vanilla
+# default: 40
+AiPlayerbot.UseFastGroundMountAtMinLevel = 40
+
+# Defines at what level a bot will naturally use its 150% fly mount
+# note: was level 60 during WotLK, 70 during TBC
+# default: 60
+AiPlayerbot.UseFlyMountAtMinLevel = 60;
+
+# Defines at what level a bot will naturally use its 280% fast fly mount
+# note: was level 70 during WotLK and TBC
+# default: 70
+AiPlayerbot.UseFastFlyMountAtMinLevel = 70;
 
 #
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -312,6 +312,11 @@ bool PlayerbotAIConfig::Initialize()
     commandServerPort = sConfigMgr->GetOption<int32>("AiPlayerbot.CommandServerPort", 8888);
     perfMonEnabled = sConfigMgr->GetOption<bool>("AiPlayerbot.PerfMonEnabled", false);
 
+    useGroundMountAtMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.UseGroundMountAtMinLevel", 20);
+    useFastGroundMountAtMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.UseFastGroundMountAtMinLevel", 40);
+    useFlyMountAtMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.UseFlyMountAtMinLevel", 60);
+    useFastFlyMountAtMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.UseFastFlyMountAtMinLevel", 70);
+
     LOG_INFO("server.loading", "---------------------------------------");
     LOG_INFO("server.loading", "          Loading TalentSpecs          ");
     LOG_INFO("server.loading", "---------------------------------------");

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -326,6 +326,11 @@ public:
     int32 maintenanceCommand;
     int32 autoGearCommand, autoGearCommandAltBots, autoGearQualityLimit, autoGearScoreLimit;
 
+    uint32 useGroundMountAtMinLevel;
+    uint32 useFastGroundMountAtMinLevel;
+    uint32 useFlyMountAtMinLevel;
+    uint32 useFastFlyMountAtMinLevel;
+
     std::string const GetTimestampStr();
     bool hasLog(std::string const fileName)
     {

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2825,10 +2825,10 @@ uint32 PlayerbotFactory::CalcMixedGearScore(uint32 gs, uint32 quality)
 
 void PlayerbotFactory::InitMounts()
 {
-    uint32 firstmount = 20;
-    uint32 secondmount = 40;
-    uint32 thirdmount = 60;
-    uint32 fourthmount = 70;
+    uint32 firstmount = sPlayerbotAIConfig->useGroundMountAtMinLevel;
+    uint32 secondmount = sPlayerbotAIConfig->useFastGroundMountAtMinLevel;
+    uint32 thirdmount = sPlayerbotAIConfig->useFlyMountAtMinLevel;
+    uint32 fourthmount = sPlayerbotAIConfig->useFastFlyMountAtMinLevel;
 
     if (bot->GetLevel() < firstmount)
         return;

--- a/src/strategy/actions/CheckMountStateAction.cpp
+++ b/src/strategy/actions/CheckMountStateAction.cpp
@@ -152,7 +152,7 @@ bool CheckMountStateAction::isUseful()
     if (!GET_PLAYERBOT_AI(bot)->HasStrategy("mount", BOT_STATE_NON_COMBAT) && !bot->IsMounted())
         return false;
 
-    bool firstmount = bot->GetLevel() >= 20;
+    bool firstmount = bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel;
     if (!firstmount)
         return false;
 
@@ -178,7 +178,7 @@ bool CheckMountStateAction::isUseful()
 
 bool CheckMountStateAction::Mount()
 {
-    uint32 secondmount = 40;
+    uint32 secondmount = sPlayerbotAIConfig->useFastGroundMountAtMinLevel;
 
     if (bot->isMoving())
     {


### PR DESCRIPTION
### Feature
The level required for bot using mounts were hardcoded, I put them in conf to easily modify them
In conf I have put the previous hardcoded values as default values
- lvl 20 for slow ground mount
- lvl 40 for fast ground mount
- lvl 60 for slow fly mount
- lvl 70 for fast fly mount

### Testing
**Example in a battleground (bracket 30-39) with the slow ground mount configured at lvl 40 in conf file (instead of 20 by default)**
![image](https://github.com/user-attachments/assets/67cbc81e-68e0-445b-9a9b-63984792c8a6)
They walk instead of using the mount because they are not level 40

**Example in a battleground (bracket 40-49) with the slow ground mount configured at lvl 40 (instead of 20 by default) and fast ground mount at lvl 60 (instead of 40 by default) in conf file**
![image](https://github.com/user-attachments/assets/219dcc8b-5030-4f30-9354-ececa5d7db0f)
They correctly slow mount instead of fast mount cause they are level 40+ but not 60 :)

**Example in a battleground (bracket 60-69), same config again**
![image](https://github.com/user-attachments/assets/f4ff0376-0d68-4b27-b6c8-d716ebdd4ef5)
Now they fast mount instead cause they are level 60+

### Compilation OK
**Successfuly compiled and work on my server (Debian 11)**
- Azerothcore-wotlk (branch Playerbots)
- mod-playerbots
- mod-buff-command
- mod-bg-reward
- mod-server-auto-shutdown
- mod-assistant
- mod-individual-xp
- mod-ah-bot
- mod-autobalance
- mod-solocraft
- mod-ony-naxx-logout-teleport
- mod-individual-progression
- mod-pvp-titles
- Recache

### Other
If you use custom values, you need to execute this commands after changing config
.playerbot rndbot reset
.playerbot rndbot init

(Sorry for my bad english, I'm not native)