### PR TITLE
Fix playerbots database stacking

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -506,7 +506,6 @@ AiPlayerbot.RandomBotRandomPassword = 0
 AiPlayerbot.RandomBotAccountPrefix = "rndbot"
 
 # Enable/Disable rotation of bots (randomly select a bot from the bots pool to go online and rotate them periodically)
-# Need to reset rndbot after changing the setting (.playerbot rndbot reset)
 # default: 0 (disable, the online bots are fixed)
 AiPlayerbot.EnableRotation = 0
 
@@ -527,12 +526,10 @@ AiPlayerbot.PreQuests = 0
 AiPlayerbot.RandomBotJoinLfg = 1
 
 # Percentage ratio of alliance and horde
-# Need to reset rndbot after changing the setting (.playerbot rndbot reset)
 AiPlayerbot.RandomBotAllianceRatio = 50
 AiPlayerbot.RandomBotHordeRatio = 50
 
 # Disable death knight for bots login
-# Need to reset rndbot after changing the setting (.playerbot rndbot reset)
 AiPlayerbot.DisableDeathKnightLogin = 0
 
 #

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -179,6 +179,7 @@ RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
             BattlegroundData[queueType][bracket] = BattlegroundInfo();
         }
     }
+    PlayerbotsDatabase.Execute("DELETE FROM playerbots_random_bots where event = 'add'");
     BgCheckTimer = 0;
     LfgCheckTimer = 0;
     PlayersCheckTimer = 0;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1098,8 +1098,6 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         return true;
     }
 
-    SetEventValue(bot, "login", 0, 0);
-
     if (!player->IsInWorld())
         return false;
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1066,16 +1066,11 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         return false;
     }
 
-    uint32 isLogginIn = GetEventValue(bot, "login");
-    if (isLogginIn)
-        return false;
-
     uint32 randomTime;
     if (!player)
     {
         AddPlayerBot(botGUID, 0);
         randomTime = urand(1, 2);
-        SetEventValue(bot, "login", 1, randomTime);
 
         uint32 randomBotUpdateInterval = _isBotInitializing ? 1 : sPlayerbotAIConfig->randomBotUpdateInterval;
         randomTime = urand(std::max(5, static_cast<int>(randomBotUpdateInterval * 0.5)),
@@ -2503,7 +2498,6 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
     if (IsRandomBot(player))
     {
         ObjectGuid::LowType guid = player->GetGUID().GetCounter();
-        SetEventValue(guid, "login", 0, 0);
     }
     else
     {


### PR DESCRIPTION
- Fix stacking issue described in https://github.com/liyunfan1223/mod-playerbots/issues/869. Removed all database queries on login value as it is unnecessary.
- Make random bots login configs take effect without manual reset by removing the add value when the server starts,
