### PR TITLE
Added ability to specify bot target for spell casting

### DIFF
--- a/src/strategy/actions/CastCustomSpellAction.cpp
+++ b/src/strategy/actions/CastCustomSpellAction.cpp
@@ -54,6 +54,33 @@ bool CastCustomSpellAction::Execute(Event event)
         ltrim(text);
     }
 
+    uint32 spell = 0;
+    if (!target)
+    {
+        size_t onPos = FindLastSeparator(text, " on ");
+        if (onPos != std::string::npos)
+        {
+            std::string targetName = text.substr(onPos + 4);
+            ltrim(targetName);
+            if (!targetName.empty())
+            {
+                // check if spell still exists after we remove " on PlayerName" part
+                std::string truncatedText = text.substr(0, onPos);
+                ltrim(truncatedText);
+                spell = AI_VALUE2(uint32, "spell id", truncatedText);
+
+                if (spell)
+                {
+                    if (Player* targetPlayer = ObjectAccessor::FindPlayerByName(targetName))
+                    {
+                        target = targetPlayer;
+                        text = truncatedText;
+                    }
+                }
+            }
+        }
+    }
+
     if (!target)
         if (master && master->GetTarget())
             target = botAI->GetUnit(master->GetTarget());
@@ -81,7 +108,8 @@ bool CastCustomSpellAction::Execute(Event event)
         }
     }
 
-    uint32 spell = AI_VALUE2(uint32, "spell id", text);
+    if (!spell)
+        spell = AI_VALUE2(uint32, "spell id", text);
 
     std::ostringstream msg;
     if (!spell)


### PR DESCRIPTION
1.	Added the ability to explicitly specify a target for spell casting using the " on PlayerName" syntax
2.	The code now parses command like "cast spell_name on PlayerName" where:
	• 	It extracts the player name after " on "
	•	Verifies if the spell exists without the target part
	•	Attempts to find the target player by name
	•	If found, sets that player as the spell target

[Video preview](https://www.youtube.com/live/mEs0fPy-_hU)