### PR TITLE
Feature: Have bots auto join/start all supported BG's (if enabled) 

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -743,7 +743,7 @@ AiPlayerbot.RandomBotAutoJoinBG = 0
 
 # Arena Considerations:
 # - Rated Arena brackets default to level 80-84 (bracket 14).
-# - Custom code changes may be required for lower-level arena brackets to function properly.
+# - Custom code changes are required for lower-level arena brackets to function properly.
 
 # Battleground bracket ranges:
 AiPlayerbot.RandomBotAutoJoinICBrackets = 0,1

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -731,7 +731,8 @@ AiPlayerbot.RandomBotAutoJoinBG = 0
 # Brackets for warsong 0:10-19, 1:20-29, 2:30-39, 3:40-49 etc. Default: 7 (level 80)
 # Brackets for rated arena: 0:10-14, 1:15-19 etc. Default: 14 (80-84)
 # For lower level ranges to work in Rated Arena, custom code changes need to be made.
-# Count = amount of games Bots auto fill. (Count 1 for WSG = 20 bots).
+# Count = amount of BATTLEGROUNDS Bots auto fill. This is PER BRACKET, so it can ramp up quickly. (i.e. Count 1 for WSG = 20 bots)
+# Ensure you have enough eligible bots.
 AiPlayerbot.randomBotAutoJoinICBrackets = 0,1
 AiPlayerbot.randomBotAutoJoinEYBrackets = 0,1,2
 AiPlayerbot.randomBotAutoJoinAVBrackets = 0,1,2,3

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -726,25 +726,40 @@ AiPlayerbot.RandomBotJoinBG = 1
 # Enable Auto join BG - bots randomly join WSG and 2v2 Arena if server is not lagging
 AiPlayerbot.RandomBotAutoJoinBG = 0
 
-# Required for RandomBotAutoJoinBG
-# Currently you can select 1 bracket (level range) for bots to auto join.
-# Brackets for warsong 0:10-19, 1:20-29, 2:30-39, 3:40-49 etc. Default: 7 (level 80)
-# Brackets for rated arena: 0:10-14, 1:15-19 etc. Default: 14 (80-84)
-# For lower level ranges to work in Rated Arena, custom code changes need to be made.
-# Count = amount of BATTLEGROUNDS Bots auto fill. This is PER BRACKET, so it can ramp up quickly. (i.e. Count 1 for WSG = 20 bots)
-# Ensure you have enough eligible bots.
+# Required Configuration for RandomBotAutoJoinBG
+# This section controls the level brackets and bot participation in battlegrounds and arenas.
+
+# Brackets:
+# - Specify the level ranges for bots to auto-join:
+#   - Warsong Gulch (WS): 0 = 10-19, 1 = 20-29, 2 = 30-39, ..., 7 = 80 (default: 7)
+#   - Rated Arena: 0 = 10-14, 1 = 15-19, ..., 14 = 80-84 (default: 14)
+# - Multiple brackets can be specified as a comma-separated list (e.g., "0,2,5").
+
+# Counts:
+# - Specify the number of Battlegrounds to auto-fill per bracket.
+# - For battlegrounds, Count is the number of bots per bracket. For example:
+#   - Warsong Gulch Count = 1 adds 20 bots (10 per team).
+# - Ensure there are enough eligible bots to meet the specified counts.
+
+# Arena Considerations:
+# - Rated Arena brackets default to level 80-84 (bracket 14).
+# - Custom code changes may be required for lower-level arena brackets to function properly.
+
+# Battleground bracket ranges:
 AiPlayerbot.RandomBotAutoJoinICBrackets = 0,1
 AiPlayerbot.RandomBotAutoJoinEYBrackets = 0,1,2
 AiPlayerbot.RandomBotAutoJoinAVBrackets = 0,1,2,3
 AiPlayerbot.RandomBotAutoJoinABBrackets = 0,1,2,3,4,5,6
 AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6,7
 
+# Battlegrounds count (per bracket!):
 AiPlayerbot.RandomBotAutoJoinBGICCount = 0
 AiPlayerbot.RandomBotAutoJoinBGEYCount = 0
 AiPlayerbot.RandomBotAutoJoinBGAVCount = 0
 AiPlayerbot.RandomBotAutoJoinBGABCount = 0
 AiPlayerbot.RandomBotAutoJoinBGWSCount = 0
 
+# Arena configuration:
 AiPlayerbot.RandomBotAutoJoinArenaBracket = 14
 
 AiPlayerbot.RandomBotAutoJoinBGRatedArena2v2Count = 0

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -732,8 +732,20 @@ AiPlayerbot.RandomBotAutoJoinBG = 0
 # Brackets for rated arena: 0:10-14, 1:15-19 etc. Default: 14 (80-84)
 # For lower level ranges to work in Rated Arena, custom code changes need to be made.
 # Count = amount of games Bots auto fill. (Count 1 for WSG = 20 bots).
-AiPlayerbot.RandomBotAutoJoinWarsongBracket = 7
+AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1
+AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2
+AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3
+AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6
+AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6,7
+
+AiPlayerbot.RandomBotAutoJoinBGICCount = 0
+AiPlayerbot.RandomBotAutoJoinBGEYCount = 0
+AiPlayerbot.RandomBotAutoJoinBGAVCount = 0
+AiPlayerbot.RandomBotAutoJoinBGABCount = 0
+AiPlayerbot.RandomBotAutoJoinBGWSCount = 0
+
 AiPlayerbot.RandomBotAutoJoinArenaBracket = 14
+
 AiPlayerbot.RandomBotAutoJoinBGWarsongCount = 0
 AiPlayerbot.RandomBotAutoJoinBGRatedArena2v2Count = 0
 AiPlayerbot.RandomBotAutoJoinBGRatedArena3v3Count = 0

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -733,10 +733,10 @@ AiPlayerbot.RandomBotAutoJoinBG = 0
 # For lower level ranges to work in Rated Arena, custom code changes need to be made.
 # Count = amount of BATTLEGROUNDS Bots auto fill. This is PER BRACKET, so it can ramp up quickly. (i.e. Count 1 for WSG = 20 bots)
 # Ensure you have enough eligible bots.
-AiPlayerbot.randomBotAutoJoinICBrackets = 0,1
-AiPlayerbot.randomBotAutoJoinEYBrackets = 0,1,2
-AiPlayerbot.randomBotAutoJoinAVBrackets = 0,1,2,3
-AiPlayerbot.randomBotAutoJoinABBrackets = 0,1,2,3,4,5,6
+AiPlayerbot.RandomBotAutoJoinICBrackets = 0,1
+AiPlayerbot.RandomBotAutoJoinEYBrackets = 0,1,2
+AiPlayerbot.RandomBotAutoJoinAVBrackets = 0,1,2,3
+AiPlayerbot.RandomBotAutoJoinABBrackets = 0,1,2,3,4,5,6
 AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6,7
 
 AiPlayerbot.RandomBotAutoJoinBGICCount = 0

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -732,10 +732,10 @@ AiPlayerbot.RandomBotAutoJoinBG = 0
 # Brackets for rated arena: 0:10-14, 1:15-19 etc. Default: 14 (80-84)
 # For lower level ranges to work in Rated Arena, custom code changes need to be made.
 # Count = amount of games Bots auto fill. (Count 1 for WSG = 20 bots).
-AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1
-AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2
-AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3
-AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6
+AiPlayerbot.randomBotAutoJoinICBrackets = 0,1
+AiPlayerbot.randomBotAutoJoinEYBrackets = 0,1,2
+AiPlayerbot.randomBotAutoJoinAVBrackets = 0,1,2,3
+AiPlayerbot.randomBotAutoJoinABBrackets = 0,1,2,3,4,5,6
 AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6,7
 
 AiPlayerbot.RandomBotAutoJoinBGICCount = 0

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -746,7 +746,6 @@ AiPlayerbot.RandomBotAutoJoinBGWSCount = 0
 
 AiPlayerbot.RandomBotAutoJoinArenaBracket = 14
 
-AiPlayerbot.RandomBotAutoJoinBGWarsongCount = 0
 AiPlayerbot.RandomBotAutoJoinBGRatedArena2v2Count = 0
 AiPlayerbot.RandomBotAutoJoinBGRatedArena3v3Count = 0
 AiPlayerbot.RandomBotAutoJoinBGRatedArena5v5Count = 0

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -723,41 +723,52 @@ AiPlayerbot.AutoTeleportForLevel = 1
 # Enable BG/Arena for random Bots
 AiPlayerbot.RandomBotJoinBG = 1
 
-# Enable Auto join BG - bots randomly join WSG and 2v2 Arena if server is not lagging
+# Enable Auto join BG - have bots start BG's and Arenas on their own
 AiPlayerbot.RandomBotAutoJoinBG = 0
 
 # Required Configuration for RandomBotAutoJoinBG
-# This section controls the level brackets and bot participation in battlegrounds and arenas.
-
+#
+# Known issue: When enabling a lot of brackats in combination with multiple instances,
+#              can lead to more instances created by bots than intended (over-queuing).
+#
+# This section controls the level brackets and 
+# automatic bot participation in battlegrounds and arenas.
+#
 # Brackets:
 # - Specify the level ranges for bots to auto-join:
 #   - Warsong Gulch (WS): 0 = 10-19, 1 = 20-29, 2 = 30-39, ..., 7 = 80 (default: 7)
 #   - Rated Arena: 0 = 10-14, 1 = 15-19, ..., 14 = 80-84 (default: 14)
 # - Multiple brackets can be specified as a comma-separated list (e.g., "0,2,5").
-
+#
 # Counts:
 # - Specify the number of Battlegrounds to auto-fill per bracket.
 # - For battlegrounds, Count is the number of bots per bracket. For example:
 #   - Warsong Gulch Count = 1 adds 20 bots (10 per team).
 # - Ensure there are enough eligible bots to meet the specified counts.
-
+#
 # Arena Considerations:
 # - Rated Arena brackets default to level 80-84 (bracket 14).
 # - Custom code changes are required for lower-level arena brackets to function properly.
+#
+# Battleground bracket range possibilities:
+# AiPlayerbot.RandomBotAutoJoinICBrackets = 0,1
+# AiPlayerbot.RandomBotAutoJoinEYBrackets = 0,1,2
+# AiPlayerbot.RandomBotAutoJoinAVBrackets = 0,1,2,3
+# AiPlayerbot.RandomBotAutoJoinABBrackets = 0,1,2,3,4,5,6
+# AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6,7
 
-# Battleground bracket ranges:
-AiPlayerbot.RandomBotAutoJoinICBrackets = 0,1
-AiPlayerbot.RandomBotAutoJoinEYBrackets = 0,1,2
-AiPlayerbot.RandomBotAutoJoinAVBrackets = 0,1,2,3
-AiPlayerbot.RandomBotAutoJoinABBrackets = 0,1,2,3,4,5,6
-AiPlayerbot.RandomBotAutoJoinWSBrackets = 0,1,2,3,4,5,6,7
+AiPlayerbot.RandomBotAutoJoinICBrackets = 1
+AiPlayerbot.RandomBotAutoJoinEYBrackets = 2
+AiPlayerbot.RandomBotAutoJoinAVBrackets = 3
+AiPlayerbot.RandomBotAutoJoinABBrackets = 6
+AiPlayerbot.RandomBotAutoJoinWSBrackets = 7
 
 # Battlegrounds count (per bracket!):
 AiPlayerbot.RandomBotAutoJoinBGICCount = 0
-AiPlayerbot.RandomBotAutoJoinBGEYCount = 0
+AiPlayerbot.RandomBotAutoJoinBGEYCount = 1
 AiPlayerbot.RandomBotAutoJoinBGAVCount = 0
-AiPlayerbot.RandomBotAutoJoinBGABCount = 0
-AiPlayerbot.RandomBotAutoJoinBGWSCount = 0
+AiPlayerbot.RandomBotAutoJoinBGABCount = 1
+AiPlayerbot.RandomBotAutoJoinBGWSCount = 1
 
 # Arena configuration:
 AiPlayerbot.RandomBotAutoJoinArenaBracket = 14

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -278,9 +278,21 @@ bool PlayerbotAIConfig::Initialize()
 
     randomBotJoinBG = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotJoinBG", true);
     randomBotAutoJoinBG = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotAutoJoinBG", false);
-    randomBotAutoJoinWarsongBracket = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinWarsongBracket", 14);
+
     randomBotAutoJoinArenaBracket = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinArenaBracket", 7);
-    randomBotAutoJoinBGWarsongCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGWarsongCount", 0);
+
+    randomBotAutoJoinICBrackets = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotAutoJoinICBrackets", "0,1");
+    randomBotAutoJoinEYBrackets = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotAutoJoinEYBrackets", "0,1,2");
+    randomBotAutoJoinAVBrackets = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotAutoJoinAVBrackets", "0,1,2,3");
+    randomBotAutoJoinABBrackets = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotAutoJoinABBrackets", "0,1,2,3,4,5,6");
+    randomBotAutoJoinWSBrackets = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotAutoJoinWSBrackets", "0,1,2,3,4,5,6,7");
+
+    randomBotAutoJoinBGICCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGICCount", 0);
+    randomBotAutoJoinBGEYCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGEYCount", 0);
+    randomBotAutoJoinBGAVCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGAVCount", 0);
+    randomBotAutoJoinBGABCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGABCount", 0);
+    randomBotAutoJoinBGWSCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGWSCount", 0);
+
     randomBotAutoJoinBGRatedArena2v2Count =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAutoJoinBGRatedArena2v2Count", 0);
     randomBotAutoJoinBGRatedArena3v3Count =

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -173,12 +173,25 @@ public:
 
     bool randomBotJoinBG;
     bool randomBotAutoJoinBG;
-    uint32 randomBotAutoJoinWarsongBracket;
+
+    std::string randomBotAutoJoinICBrackets;
+    std::string randomBotAutoJoinEYBrackets;
+    std::string randomBotAutoJoinAVBrackets;
+    std::string randomBotAutoJoinABBrackets;
+    std::string randomBotAutoJoinWSBrackets;
+
+    uint32 randomBotAutoJoinBGICCount;
+    uint32 randomBotAutoJoinBGEYCount;
+    uint32 randomBotAutoJoinBGAVCount;
+    uint32 randomBotAutoJoinBGABCount;
+    uint32 randomBotAutoJoinBGWSCount;
+
     uint32 randomBotAutoJoinArenaBracket;
-    uint32 randomBotAutoJoinBGWarsongCount;
+
     uint32 randomBotAutoJoinBGRatedArena2v2Count;
     uint32 randomBotAutoJoinBGRatedArena3v3Count;
     uint32 randomBotAutoJoinBGRatedArena5v5Count;
+
     bool randomBotLoginAtStartup;
     uint32 randomBotTeleLowerLevel, randomBotTeleHigherLevel;
     bool logInGroupOnly, logValuesPerTick;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -862,7 +862,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
         auto updateRatedArenaInstanceCount = [&](uint32 queueType, uint32 bracket, uint32 minCount) {
             if (BattlegroundData[queueType][bracket].activeRatedArenaQueue < minCount &&
                 BattlegroundData[queueType][bracket].ratedArenaInstanceCount < minCount)
-                BattlegroundData[queueType][bracket].ratedArenaInstanceCount++;
+                BattlegroundData[queueType][bracket].activeRatedArenaQueue++;
         };
 
         auto updateBGInstanceCount = [&](uint32 queueType, std::vector<uint32> brackets, uint32 minCount) {
@@ -870,7 +870,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
             {
                 if (BattlegroundData[queueType][bracket].activeBgQueue < minCount &&
                     BattlegroundData[queueType][bracket].bgInstanceCount < minCount)   
-                    BattlegroundData[queueType][bracket].bgInstanceCount++;
+                    BattlegroundData[queueType][bracket].activeBgQueue++;
             }
         };
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -641,7 +641,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
     if (!BgCheckTimer)
         BgCheckTimer = time(nullptr);
 
-    if (time(nullptr) < BgCheckTimer + 30)
+    if (time(nullptr) < BgCheckTimer)
         return;
 
     BgCheckTimer = time(nullptr);

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -638,13 +638,18 @@ std::vector<uint32> parseBrackets(const std::string& str)
 
 void RandomPlayerbotMgr::CheckBgQueue()
 {
-    if (!BgCheckTimer)
+    if (!BgCheckTimer) {
         BgCheckTimer = time(nullptr);
+        return; // Exit immediately after initializing the timer
+    }
 
-    if (time(nullptr) < BgCheckTimer)
-        return;
+    if (time(nullptr) < BgCheckTimer) {
+        return; // No need to proceed if the current time is less than the timer
+    }
 
+    // Update the timer to the current time
     BgCheckTimer = time(nullptr);
+
     LOG_DEBUG("playerbots", "Checking BG Queue...");
 
     BattlegroundData.clear();
@@ -840,7 +845,8 @@ void RandomPlayerbotMgr::CheckBgQueue()
         }
     }
 
-    if (sPlayerbotAIConfig->randomBotAutoJoinBG)
+    // If enabled, wait for all bots to have logged in before queueing for Arena's / BG's
+    if (sPlayerbotAIConfig->randomBotAutoJoinBG && playerBots.size() >= GetMaxAllowedBotCount())
     {
         uint32 randomBotAutoJoinArenaBracket         = sPlayerbotAIConfig->randomBotAutoJoinArenaBracket;
         uint32 randomBotAutoJoinBGRatedArena2v2Count = sPlayerbotAIConfig->randomBotAutoJoinBGRatedArena2v2Count;
@@ -860,7 +866,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
         std::vector<uint32> wsBrackets = parseBrackets(sPlayerbotAIConfig->randomBotAutoJoinWSBrackets);
 
         auto updateRatedArenaInstanceCount = [&](uint32 queueType, uint32 bracket, uint32 minCount) {
-            if (BattlegroundData[queueType][bracket].activeRatedArenaQueue +
+            if (BattlegroundData[queueType][bracket].activeRatedArenaQueue == 0 &&
                 BattlegroundData[queueType][bracket].ratedArenaInstanceCount < minCount)
                 BattlegroundData[queueType][bracket].activeRatedArenaQueue = 1;
         };
@@ -868,7 +874,7 @@ void RandomPlayerbotMgr::CheckBgQueue()
         auto updateBGInstanceCount = [&](uint32 queueType, std::vector<uint32> brackets, uint32 minCount) {
             for (uint32 bracket : brackets)
             {
-                if (BattlegroundData[queueType][bracket].activeBgQueue +
+                if (BattlegroundData[queueType][bracket].activeBgQueue == 0 &&
                     BattlegroundData[queueType][bracket].bgInstanceCount < minCount)   
                     BattlegroundData[queueType][bracket].activeBgQueue = 1;
             }

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -360,7 +360,7 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
 
     if (sPlayerbotAIConfig->randomBotJoinBG /* && !players.empty()*/)
     {
-        if (time(nullptr) > (BgCheckTimer + 30))
+        if (time(nullptr) > (BgCheckTimer + 45))
             sRandomPlayerbotMgr->CheckBgQueue();
     }
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -860,14 +860,16 @@ void RandomPlayerbotMgr::CheckBgQueue()
         std::vector<uint32> wsBrackets = parseBrackets(sPlayerbotAIConfig->randomBotAutoJoinWSBrackets);
 
         auto updateRatedArenaInstanceCount = [&](uint32 queueType, uint32 bracket, uint32 minCount) {
-            if (BattlegroundData[queueType][bracket].ratedArenaInstanceCount < minCount)
+            if (BattlegroundData[queueType][bracket].activeRatedArenaQueue < minCount &&
+                BattlegroundData[queueType][bracket].ratedArenaInstanceCount < minCount)
                 BattlegroundData[queueType][bracket].ratedArenaInstanceCount++;
         };
 
         auto updateBGInstanceCount = [&](uint32 queueType, std::vector<uint32> brackets, uint32 minCount) {
             for (uint32 bracket : brackets)
             {
-                if (BattlegroundData[queueType][bracket].bgInstanceCount < minCount)
+                if (BattlegroundData[queueType][bracket].activeBgQueue < minCount &&
+                    BattlegroundData[queueType][bracket].bgInstanceCount < minCount)   
                     BattlegroundData[queueType][bracket].bgInstanceCount++;
             }
         };

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -859,16 +859,16 @@ void RandomPlayerbotMgr::CheckBgQueue()
         std::vector<uint32> abBrackets = parseBrackets(sPlayerbotAIConfig->randomBotAutoJoinABBrackets);
         std::vector<uint32> wsBrackets = parseBrackets(sPlayerbotAIConfig->randomBotAutoJoinWSBrackets);
 
-        auto updateRatedArenaInstanceCount = [&](uint32 queueType, uint32 bracket, uint32 count) {
-            BattlegroundData[queueType][bracket].ratedArenaInstanceCount =
-                std::max(count, BattlegroundData[queueType][bracket].ratedArenaInstanceCount);
+        auto updateRatedArenaInstanceCount = [&](uint32 queueType, uint32 bracket, uint32 minCount) {
+            if (BattlegroundData[queueType][bracket].ratedArenaInstanceCount < minCount)
+                BattlegroundData[queueType][bracket].ratedArenaInstanceCount++;
         };
 
-        auto updateBGInstanceCount = [&](uint32 queueType, std::vector<uint32> brackets, uint32 count) {
+        auto updateBGInstanceCount = [&](uint32 queueType, std::vector<uint32> brackets, uint32 minCount) {
             for (uint32 bracket : brackets)
             {
-                BattlegroundData[queueType][bracket].bgInstanceCount =
-                    std::max(count, BattlegroundData[queueType][bracket].bgInstanceCount);
+                if (BattlegroundData[queueType][bracket].bgInstanceCount < minCount)
+                    BattlegroundData[queueType][bracket].bgInstanceCount++;
             }
         };
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1076,16 +1076,11 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         return false;
     }
 
-    uint32 isLogginIn = GetEventValue(bot, "login");
-    if (isLogginIn)
-        return false;
-
     uint32 randomTime;
     if (!player)
     {
         AddPlayerBot(botGUID, 0);
         randomTime = urand(1, 2);
-        SetEventValue(bot, "login", 1, randomTime);
 
         uint32 randomBotUpdateInterval = _isBotInitializing ? 1 : sPlayerbotAIConfig->randomBotUpdateInterval;
         randomTime = urand(std::max(5, static_cast<int>(randomBotUpdateInterval * 0.5)),
@@ -1107,8 +1102,6 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
 
         return true;
     }
-
-    SetEventValue(bot, "login", 0, 0);
 
     if (!player->IsInWorld())
         return false;
@@ -2515,7 +2508,6 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
     if (IsRandomBot(player))
     {
         ObjectGuid::LowType guid = player->GetGUID().GetCounter();
-        SetEventValue(guid, "login", 0, 0);
     }
     else
     {

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -860,17 +860,17 @@ void RandomPlayerbotMgr::CheckBgQueue()
         std::vector<uint32> wsBrackets = parseBrackets(sPlayerbotAIConfig->randomBotAutoJoinWSBrackets);
 
         auto updateRatedArenaInstanceCount = [&](uint32 queueType, uint32 bracket, uint32 minCount) {
-            if (BattlegroundData[queueType][bracket].activeRatedArenaQueue < minCount &&
+            if (BattlegroundData[queueType][bracket].activeRatedArenaQueue +
                 BattlegroundData[queueType][bracket].ratedArenaInstanceCount < minCount)
-                BattlegroundData[queueType][bracket].activeRatedArenaQueue++;
+                BattlegroundData[queueType][bracket].activeRatedArenaQueue = 1;
         };
 
         auto updateBGInstanceCount = [&](uint32 queueType, std::vector<uint32> brackets, uint32 minCount) {
             for (uint32 bracket : brackets)
             {
-                if (BattlegroundData[queueType][bracket].activeBgQueue < minCount &&
+                if (BattlegroundData[queueType][bracket].activeBgQueue +
                     BattlegroundData[queueType][bracket].bgInstanceCount < minCount)   
-                    BattlegroundData[queueType][bracket].activeBgQueue++;
+                    BattlegroundData[queueType][bracket].activeBgQueue = 1;
             }
         };
 


### PR DESCRIPTION
Bots can now auto join/start (if enabled) all supported BG's instead of just WSG and more control over the Brackets and instance amount settings.

```
BG:AV 51-60: Player (0:0) Bot (41:40) Total (A:41 H:40), Instances 1
BG:AV 61-70: Player (0:0) Bot (59:54) Total (A:59 H:54), Instances 2
BG:AV 71-79: Player (0:0) Bot (40:40) Total (A:40 H:40), Instances 1
BG:AV 80-85: Player (0:0) Bot (40:40) Total (A:40 H:40), Instances 1
BG:WSG 10-19: Player (0:0) Bot (32:49) Total (A:32 H:49), Instances 5
BG:WSG 20-29: Player (0:0) Bot (50:50) Total (A:50 H:50), Instances 5
BG:WSG 30-39: Player (0:0) Bot (30:30) Total (A:30 H:30), Instances 4
BG:AB 20-29: Player (0:0) Bot (60:60) Total (A:60 H:60), Instances 4
BG:AB 30-39: Player (0:0) Bot (60:60) Total (A:60 H:60), Instances 4
BG:AB 40-49: Player (0:0) Bot (60:60) Total (A:60 H:60), Instances 4
BG:AB 50-59: Player (0:0) Bot (60:60) Total (A:60 H:60), Instances 4
BG:AB 60-69: Player (0:0) Bot (60:51) Total (A:60 H:51), Instances 4
BG:AB 70-79: Player (0:0) Bot (60:60) Total (A:60 H:60), Instances 4
BG:AB 80-85: Player (0:0) Bot (60:60) Total (A:60 H:60), Instances 4
BG:EotS 61-69: Player (0:0) Bot (45:45) Total (A:45 H:45), Instances 3
BG:EotS 70-79: Player (0:0) Bot (44:37) Total (A:44 H:37), Instances 3
BG:EotS 80-85: Player (0:0) Bot (45:45) Total (A:45 H:45), Instances 3
BG:IoC 71-79: Player (0:0) Bot (40:40) Total (A:40 H:40), Instances 1
BG:IoC 80-84: Player (0:0) Bot (40:40) Total (A:40 H:40), Instances 1
```