### PR TITLE
Improve ICC spread and fix Valithria trigger

### DIFF
--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -2144,8 +2144,13 @@ Position MovementAction::BestPositionForRangedToFlee(Position pos, float radius)
     return Position();
 }
 
-bool MovementAction::FleePosition(Position pos, float radius)
+bool MovementAction::FleePosition(Position pos, float radius, uint32 minInterval)
 {
+    std::list<FleeInfo>& infoList = AI_VALUE(std::list<FleeInfo>&, "recently flee info");
+
+    if (!infoList.empty() && infoList.back().timestamp + minInterval > getMSTime())
+        return false;
+
     Position bestPos;
     if (botAI->IsMelee(bot))
     {
@@ -2160,7 +2165,6 @@ bool MovementAction::FleePosition(Position pos, float radius)
         if (MoveTo(bot->GetMapId(), bestPos.GetPositionX(), bestPos.GetPositionY(), bestPos.GetPositionZ(), false,
                    false, true, false, MovementPriority::MOVEMENT_COMBAT))
         {
-            std::list<FleeInfo>& infoList = AI_VALUE(std::list<FleeInfo>&, "recently flee info");
             uint32 curTS = getMSTime();
             while (!infoList.empty())
             {

--- a/src/strategy/actions/MovementActions.h
+++ b/src/strategy/actions/MovementActions.h
@@ -58,7 +58,7 @@ protected:
     void CreateWp(Player* wpOwner, float x, float y, float z, float o, uint32 entry, bool important = false);
     Position BestPositionForMeleeToFlee(Position pos, float radius);
     Position BestPositionForRangedToFlee(Position pos, float radius);
-    bool FleePosition(Position pos, float radius);
+    bool FleePosition(Position pos, float radius, uint32 minInterval = 1000);
     bool CheckLastFlee(float curAngle, std::list<FleeInfo>& infoList);
 
 protected:

--- a/src/strategy/raids/icecrown/RaidIccActions.cpp
+++ b/src/strategy/raids/icecrown/RaidIccActions.cpp
@@ -138,7 +138,8 @@ bool IccRangedPositionLadyDeathwhisperAction::Execute(Event event)
             if (dist < radius)
             {
                 float moveDistance = std::min(moveIncrement, radius - dist + 1.0f);
-                return MoveAway(unit, moveDistance);
+                return FleePosition(unit->GetPosition(), moveDistance);
+                // return MoveAway(unit, moveDistance);
             }
         }
     }
@@ -274,9 +275,10 @@ bool IccRottingFrostGiantTankPositionAction::Execute(Event event)
         }
 
         Unit* unit = botAI->GetUnit(member);
-        if ((botAI->IsHeal(bot) || botAI->IsDps(bot)) && bot->GetExactDist2d(unit) < radius)
+        if (unit && (botAI->IsHeal(bot) || botAI->IsDps(bot)) && bot->GetExactDist2d(unit) < radius)
         {
-            return MoveAway(unit, radius + distanceExtra - bot->GetExactDist2d(unit));
+            return FleePosition(unit->GetPosition(), radius + distanceExtra - bot->GetExactDist2d(unit));
+            // return MoveAway(unit, radius + distanceExtra - bot->GetExactDist2d(unit));
         }
     }
     return Attack(boss);
@@ -486,7 +488,8 @@ bool IccDbsTankPositionAction::Execute(Event event)
             if (dist < radius)
             {
                 float moveDistance = std::min(moveIncrement, radius - dist + 1.0f);
-                return MoveAway(unit, moveDistance);
+                return FleePosition(unit->GetPosition(), moveDistance);
+                // return MoveAway(unit, moveDistance);
             }
         }
     }
@@ -608,7 +611,8 @@ bool IccFestergutTankPositionAction::Execute(Event event)
             // Move away from closest player, but maintain roughly max range from boss
             float distToCenter = bot->GetExactDist2d(ICC_FESTERGUT_TANK_POSITION);
             float moveDistance = (distToCenter > 25.0f) ? 2.0f : 3.0f; // Move less if already far from center
-            return MoveAway(closestPlayer, moveDistance);
+            return FleePosition(closestPlayer->GetPosition(), moveDistance);
+            // return MoveAway(closestPlayer, moveDistance);
         }
     }
     return false;
@@ -841,7 +845,8 @@ bool IccRotfaceGroupPositionAction::Execute(Event event)
             {
                 float distToCenter = bot->GetExactDist2d(ICC_ROTFACE_TANK_POSITION);
                 float moveDistance = (distToCenter > 25.0f) ? 2.0f : 3.0f;
-                return MoveAway(closestMember, moveDistance);
+                // return MoveAway(closestMember, moveDistance);
+                return FleePosition(closestMember->GetPosition(), moveDistance);
             }
             
             return false;
@@ -1302,7 +1307,8 @@ bool AvoidMalleableGooAction::Execute(Event event)
                     // Only move if we have line of sight
                     if (bot->IsWithinLOS(newX, newY, bot->GetPositionZ()))
                     {
-                        return MoveAway(unit, moveDistance);
+                        return FleePosition(unit->GetPosition(), moveDistance);
+                        // return MoveAway(unit, moveDistance);
                     }
                 }
             }
@@ -1505,7 +1511,8 @@ bool IccBpcEmpoweredVortexAction::Execute(Event event)
             // Only move if we have line of sight
             if (bot->IsWithinLOS(newX, newY, bot->GetPositionZ()))
             {
-                return MoveAway(unit, moveDistance);
+                return FleePosition(unit->GetPosition(), moveDistance);
+                // return MoveAway(unit, moveDistance);
             }
         }
     }
@@ -1547,7 +1554,8 @@ bool IccBqlTankPositionAction::Execute(Event event)
             if (dist < radius)
             {
                 float moveDistance = std::min(moveIncrement, radius - dist + 1.0f);
-                return MoveAway(unit, moveDistance);
+                return FleePosition(unit->GetPosition(), moveDistance);
+                // return MoveAway(unit, moveDistance);
             }
         }
     }
@@ -1564,7 +1572,8 @@ bool IccBqlTankPositionAction::Execute(Event event)
             if (dist < radius)
             {
                 float moveDistance = std::min(moveIncrement, radius - dist + 1.0f);
-                return MoveAway(unit, moveDistance);
+                return FleePosition(unit->GetPosition(), moveDistance);
+                // return MoveAway(unit, moveDistance);
             }
         }
     }

--- a/src/strategy/raids/icecrown/RaidIccTriggers.cpp
+++ b/src/strategy/raids/icecrown/RaidIccTriggers.cpp
@@ -551,10 +551,10 @@ bool IccValithriaPortalTrigger::IsActive()
 
 bool IccValithriaHealTrigger::IsActive()
 {
-    // Unit* boss = AI_VALUE2(Unit*, "find target", "valithria dreamwalker");
-    // if (!boss) 
-    //     return false;
-
+    Unit* boss = bot->FindNearestCreature(36789, 100.0f);
+    if (!boss) 
+        return false;
+    
     // Only healers should use healing
     if (!botAI->IsHeal(bot) || bot->HasAura(70766))
         return false;

--- a/src/strategy/raids/icecrown/RaidIccTriggers.cpp
+++ b/src/strategy/raids/icecrown/RaidIccTriggers.cpp
@@ -551,9 +551,9 @@ bool IccValithriaPortalTrigger::IsActive()
 
 bool IccValithriaHealTrigger::IsActive()
 {
-    Unit* boss = AI_VALUE2(Unit*, "find target", "valithria dreamwalker");
-    if (!boss) 
-        return false;
+    // Unit* boss = AI_VALUE2(Unit*, "find target", "valithria dreamwalker");
+    // if (!boss) 
+    //     return false;
 
     // Only healers should use healing
     if (!botAI->IsHeal(bot) || bot->HasAura(70766))


### PR DESCRIPTION
Hello @Noscopezz! First of all thank you for your fancy ICC strategy.

This PR makes some improvements to spread. It reduces the movement time required for spread and the number of lost spells for ranged caster, although it's still not perfect. I tested it in every situation I could think of and it works fine.

Another fix is ​​for Valithria trigger. It cannot be triggered now as `find target` is only effective for the hostile target.