### PR TITLE
Tweaked Alterac Valley so bots kill final bosses

### DIFF
--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -2463,11 +2463,19 @@ bool BGTactics::selectObjective(bool reset)
 
             if (bot->GetTeamId() == TEAM_HORDE)
             {
-                bool enemyTowersDown =
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_DUNBALDAR_NORTH).State == POINT_DESTROYED &&
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_DUNBALDAR_SOUTH).State == POINT_DESTROYED &&
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_ICEWING_BUNKER).State == POINT_DESTROYED &&
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_STONEHEART_BUNKER).State == POINT_DESTROYED;
+                int towersDestroyed = 0;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_DUNBALDAR_NORTH).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_DUNBALDAR_SOUTH).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_ICEWING_BUNKER).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_STONEHEART_BUNKER).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+
+                // Now require only 2 to be destroyed
+                bool enemyTowersDown = (towersDestroyed >= 2);
+
                 // End Boss
                 if (enemyTowersDown &&
                     alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FIRSTAID_STATION).OwnerId != TEAM_ALLIANCE &&
@@ -2652,11 +2660,19 @@ bool BGTactics::selectObjective(bool reset)
             }
             else  // TEAM_ALLIANCE
             {
-                bool enemyTowersDown =
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FROSTWOLF_WTOWER).State == POINT_DESTROYED &&
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FROSTWOLF_ETOWER).State == POINT_DESTROYED &&
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_TOWER_POINT).State == POINT_DESTROYED &&
-                    alterValleyBG->GetAVNodeInfo(BG_AV_NODES_ICEBLOOD_TOWER).State == POINT_DESTROYED;
+                int towersDestroyed = 0;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FROSTWOLF_WTOWER).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FROSTWOLF_ETOWER).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_TOWER_POINT).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+                if (alterValleyBG->GetAVNodeInfo(BG_AV_NODES_ICEBLOOD_TOWER).State == POINT_DESTROYED)
+                    ++towersDestroyed;
+
+                // Now require only 2 to be destroyed
+                bool enemyTowersDown = (towersDestroyed >= 2);
+                
                 // End Boss
                 if (enemyTowersDown && alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FROSTWOLF_HUT).OwnerId != TEAM_HORDE &&
                     alterValleyBG->GetAVNodeInfo(BG_AV_NODES_FROSTWOLF_HUT).TotalOwnerId != TEAM_HORDE)

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4316,8 +4316,22 @@ bool BGTactics::protectFC()
         return false;
 
     Unit* teamFC = AI_VALUE(Unit*, "team flag carrier");
-    if (teamFC && bot->IsWithinDistInMap(teamFC, 50.0f))
-        return Follow(teamFC);
+
+    if (!teamFC || teamFC == bot)
+    {
+        return false;
+    }
+
+    if (!bot->IsInCombat() && !bot->IsWithinDistInMap(teamFC, 20.0f))
+    {
+        // Get the flag carrier's position
+        float fcX = teamFC->GetPositionX();
+        float fcY = teamFC->GetPositionY();
+        float fcZ = teamFC->GetPositionZ();
+        uint32 mapId = bot->GetMapId();
+        
+        return MoveNear(mapId, fcX, fcY, fcZ, 5.0f, MovementPriority::MOVEMENT_NORMAL);
+    }
 
     return false;
 }

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -2454,8 +2454,8 @@ bool BGTactics::selectObjective(bool reset)
         {
             BattlegroundAV* alterValleyBG = (BattlegroundAV*)bg;
             uint32 role = context->GetValue<uint32>("bg role")->Get();
-            bool supportDefense = role < 3;  // defensive role and mine capture (mine capture disabled for now)
-            bool advancedAttack = role > 5;  // doesnt wait for point to be fully captured before moving on
+            bool supportDefense = role < 2;  // defensive role and mine capture (mine capture disabled for now)
+            bool advancedAttack = role > 4;  // doesnt wait for point to be fully captured before moving on
 
             // some of the code below is a bit inefficent (lots of rechecking same variables, could be made more
             // efficient with a refactor) but it's been left this way so it can be easily reordered. in future we could

--- a/src/strategy/generic/BattlegroundStrategy.cpp
+++ b/src/strategy/generic/BattlegroundStrategy.cpp
@@ -29,6 +29,8 @@ void WarsongStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode("low mana", NextAction::array(0, new NextAction("bg use buff", 30.0f), nullptr)));
     triggers.push_back(new TriggerNode(
         "enemy flagcarrier near", NextAction::array(0, new NextAction("attack enemy flag carrier", 80.0f), nullptr)));
+    triggers.push_back(new TriggerNode(
+        "team has flag", NextAction::array(0, new NextAction("bg protect fc", 75.0f), nullptr)));
     triggers.push_back(new TriggerNode("player has flag",
                                        NextAction::array(0, new NextAction("bg move to objective", 90.0f), nullptr)));
 }


### PR DESCRIPTION
1. Bots would only engage final boss when 4/4 towers were destroyed and they controlled the graveyard near the boss. Reduced tower requirement to any 2 of the towers. Bot still cap the GY before attempting to kill the boss.

2. Also adjusted the defender/attacker role chances so there are more attackers

I've seen them kill bosses in the last 3 out of 5 games. Stalemates still occur occasionally, but it seems much better than before.