### PR TITLE
WSG: Removed mount action in "protect fc" + reduced support bot chance

### DIFF
--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -2234,12 +2234,8 @@ bool BGTactics::Execute(Event event)
 
     if (getName() == "protect fc")
     {
-        if (!bot->IsMounted() && !bot->IsInCombat())
-            if (botAI->DoSpecificAction("check mount state"))
-                return true;
-
         uint32 role = context->GetValue<uint32>("bg role")->Get();
-        bool supporter = role < 5;
+        bool supporter = role < 4;
         if (supporter && protectFC())
             return true;
     }


### PR DESCRIPTION
Forgot to commit these yesterday

Fixed issue where bots were trying to mount while protecting their flag carrier

Reduced chance bots are support role, more attackers