### PR TITLE
Add undead-rogue to rndbots

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -78,6 +78,7 @@ RandomPlayerbotFactory::RandomPlayerbotFactory(uint32 accountId) : accountId(acc
     availableRaces[CLASS_ROGUE].push_back(RACE_NIGHTELF);
     availableRaces[CLASS_ROGUE].push_back(RACE_GNOME);
     availableRaces[CLASS_ROGUE].push_back(RACE_ORC);
+    availableRaces[CLASS_ROGUE].push_back(RACE_UNDEAD_PLAYER);
     availableRaces[CLASS_ROGUE].push_back(RACE_TROLL);
     if (expansion >= EXPANSION_THE_BURNING_CRUSADE)
     {


### PR DESCRIPTION
Default race-class combination undead-rogue absent from rndbot creation pool in RandomPlayerbotFactory.cpp.

Added undead-rogue to rndbot combinations.