### PR TITLE
Reset added rndbots on server restart to automatically apply configuration changes

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -507,7 +507,6 @@ AiPlayerbot.RandomBotRandomPassword = 0
 AiPlayerbot.RandomBotAccountPrefix = "rndbot"
 
 # Enable/Disable rotation of bots (randomly select a bot from the bots pool to go online and rotate them periodically)
-# Need to reset rndbot after changing the setting (.playerbot rndbot reset)
 # default: 0 (disable, the online bots are fixed)
 AiPlayerbot.EnableRotation = 0
 
@@ -528,12 +527,10 @@ AiPlayerbot.PreQuests = 0
 AiPlayerbot.RandomBotJoinLfg = 1
 
 # Percentage ratio of alliance and horde
-# Need to reset rndbot after changing the setting (.playerbot rndbot reset)
 AiPlayerbot.RandomBotAllianceRatio = 50
 AiPlayerbot.RandomBotHordeRatio = 50
 
 # Disable death knight for bots login
-# Need to reset rndbot after changing the setting (.playerbot rndbot reset)
 AiPlayerbot.DisableDeathKnightLogin = 0
 
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -548,9 +548,12 @@ bool PlayerbotAIConfig::Initialize()
     {
         return true;
     }
-    if (sPlayerbotAIConfig->addClassCommand)
-        sRandomPlayerbotMgr->PrepareAddclassCache();
 
+    if (sPlayerbotAIConfig->enabled)
+    {
+        sRandomPlayerbotMgr->Init();
+    }
+    
     sRandomItemMgr->Init();
     sRandomItemMgr->InitAfterAhBot();
     sPlayerbotTextMgr->LoadBotTexts();
@@ -563,8 +566,6 @@ bool PlayerbotAIConfig::Initialize()
         sTravelMgr->LoadQuestTravelTable();
     }
 
-    if (sPlayerbotAIConfig->randomBotJoinBG)
-        sRandomPlayerbotMgr->LoadBattleMastersCache();
 
     if (sPlayerbotAIConfig->randomBotSuggestDungeons)
     {

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -168,7 +168,6 @@ RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
     if (sPlayerbotAIConfig->enabled || sPlayerbotAIConfig->randomBotAutologin)
     {
         sPlayerbotCommandServer->Start();
-        PrepareTeleportCache();
     }
 
     BattlegroundData.clear(); // Clear here and here only.
@@ -1746,6 +1745,22 @@ void RandomPlayerbotMgr::PrepareAddclassCache()
         }
     }
     LOG_INFO("playerbots", ">> {} characters collected for addclass command.", collected);
+}
+
+void RandomPlayerbotMgr::Init()
+{
+    if (sPlayerbotAIConfig->addClassCommand)
+        sRandomPlayerbotMgr->PrepareAddclassCache();
+    
+    if (sPlayerbotAIConfig->enabled)
+    {
+        sRandomPlayerbotMgr->PrepareTeleportCache();
+    }
+    
+    if (sPlayerbotAIConfig->randomBotJoinBG)
+        sRandomPlayerbotMgr->LoadBattleMastersCache();
+
+    PlayerbotsDatabase.Execute("DELETE FROM playerbots_random_bots WHERE event = 'add'");
 }
 
 void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -170,6 +170,8 @@ public:
     static uint8 GetTeamClassIdx(bool isAlliance, uint8 claz) { return isAlliance * 20 + claz; }
 
     void PrepareAddclassCache();
+    void PrepareTeleportCache();
+    void Init();
     std::map<uint8, std::vector<ObjectGuid>> addclassCache;
     std::map<uint8, std::vector<WorldLocation>> locsPerLevelCache;
     std::map<uint8, std::vector<WorldLocation>> allianceStarterPerLevelCache;
@@ -199,7 +201,6 @@ private:
     void RandomTeleport(Player* bot);
     void RandomTeleport(Player* bot, std::vector<WorldLocation>& locs, bool hearth = false);
     uint32 GetZoneLevel(uint16 mapId, float teleX, float teleY, float teleZ);
-    void PrepareTeleportCache();
     typedef void (RandomPlayerbotMgr::*ConsoleCommandHandler)(Player*);
 
     std::vector<Player*> players;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -49,6 +49,7 @@ std::list<uint32> PlayerbotFactory::classQuestIds;
 std::list<uint32> PlayerbotFactory::specialQuestIds;
 std::vector<uint32> PlayerbotFactory::enchantSpellIdCache;
 std::vector<uint32> PlayerbotFactory::enchantGemIdCache;
+std::unordered_map<uint32, std::vector<uint32>> PlayerbotFactory::trainerIdCache;
 
 PlayerbotFactory::PlayerbotFactory(Player* bot, uint32 level, uint32 itemQuality, uint32 gearScoreLimit)
     : level(level), itemQuality(itemQuality), gearScoreLimit(gearScoreLimit), bot(bot)
@@ -2327,7 +2328,7 @@ void PlayerbotFactory::SetRandomSkill(uint16 id)
 
 void PlayerbotFactory::InitAvailableSpells()
 {
-    if (trainerIdCache.empty())
+    if (trainerIdCache[bot->getClass()].empty())
     {
         CreatureTemplateContainer const* creatureTemplateContainer = sObjectMgr->GetCreatureTemplates();
         for (CreatureTemplateContainer::const_iterator i = creatureTemplateContainer->begin();
@@ -2341,10 +2342,10 @@ void PlayerbotFactory::InitAvailableSpells()
                 continue;
 
             uint32 trainerId = co.Entry;
-            trainerIdCache.push_back(trainerId);
+            trainerIdCache[bot->getClass()].push_back(trainerId);
         }
     }
-    for (uint32 trainerId : trainerIdCache)
+    for (uint32 trainerId : trainerIdCache[bot->getClass()])
     {
         TrainerSpellData const* trainer_spells = sObjectMgr->GetNpcTrainerSpells(trainerId);
         if (!trainer_spells)

--- a/src/factory/PlayerbotFactory.h
+++ b/src/factory/PlayerbotFactory.h
@@ -190,7 +190,7 @@ private:
     uint32 itemQuality;
     uint32 gearScoreLimit;
     static std::list<uint32> specialQuestIds;
-    std::vector<uint32> trainerIdCache;
+    static std::unordered_map<uint32, std::vector<uint32>> trainerIdCache;
     static std::vector<uint32> enchantSpellIdCache;
     static std::vector<uint32> enchantGemIdCache;
 


### PR DESCRIPTION
No longer need to manually execute the reset command after modifying configuration about added rndbots. It should also fix some issues that added rndbots does not match the database status. https://github.com/liyunfan1223/mod-playerbots/issues/449 

And some minor refactorings and optimizations.