### PR TITLE
CheckMountStateAction: Added SPELL_AURA_TRANSFORM and IsInDisallowedMountForm

### DIFF
--- a/src/strategy/actions/CheckMountStateAction.cpp
+++ b/src/strategy/actions/CheckMountStateAction.cpp
@@ -117,6 +117,16 @@ bool CheckMountStateAction::isUseful()
     if (bot->HasAura(23333) || bot->HasAura(23335) || bot->HasAura(34976))
         return false;
 
+    // Allow mounting while transformed if the form allows it
+    if (bot->HasAuraType(SPELL_AURA_TRANSFORM))
+    {
+        // Use the IsInDisallowedMountForm function
+        if (bot->IsInDisallowedMountForm())
+        {
+            return false; // Prevent mounting
+        }
+    }
+
     // Only mount if BG starts in less than 30 sec
     if (bot->InBattleground())
     {


### PR DESCRIPTION
Resolved issue where bots are transformed (e.g Deathbringer's Will trinket) and would stand still attempting to mount, still allows mounting when the transform allows it (e.g Pirate Costume, Transporter Malfunction)