### PR TITLE
Resolved issues with herb gathering

### DIFF
--- a/src/LootObjectStack.h
+++ b/src/LootObjectStack.h
@@ -3,84 +3,410 @@
  * and/or modify it under version 2 of the License, or (at your option), any later version.
  */
 
-#ifndef _PLAYERBOT_LOOTOBJECTSTACK_H
-#define _PLAYERBOT_LOOTOBJECTSTACK_H
+#include "LootObjectStack.h"
 
-#include "ObjectGuid.h"
+#include "LootMgr.h"
+#include "Playerbots.h"
+#include "Unit.h"
 
-class AiObjectContext;
-class Player;
-class WorldObject;
+#define MAX_LOOT_OBJECT_COUNT 10
 
-struct ItemTemplate;
+LootTarget::LootTarget(ObjectGuid guid) : guid(guid), asOfTime(time(nullptr)) {}
 
-class LootStrategy
+LootTarget::LootTarget(LootTarget const& other)
 {
-public:
-    LootStrategy() {}
-    virtual ~LootStrategy(){};
-    virtual bool CanLoot(ItemTemplate const* proto, AiObjectContext* context) = 0;
-    virtual std::string const GetName() = 0;
-};
+    guid = other.guid;
+    asOfTime = other.asOfTime;
+}
 
-class LootObject
+LootTarget& LootTarget::operator=(LootTarget const& other)
 {
-public:
-    LootObject() : skillId(0), reqSkillValue(0), reqItem(0) {}
-    LootObject(Player* bot, ObjectGuid guid);
-    LootObject(LootObject const& other);
+    if ((void*)this == (void*)&other)
+        return *this;
 
-    bool IsEmpty() { return !guid; }
-    bool IsLootPossible(Player* bot);
-    void Refresh(Player* bot, ObjectGuid guid);
-    WorldObject* GetWorldObject(Player* bot);
-    ObjectGuid guid;
+    guid = other.guid;
+    asOfTime = other.asOfTime;
 
-    uint32 skillId;
-    uint32 reqSkillValue;
-    uint32 reqItem;
+    return *this;
+}
 
-private:
-    static bool IsNeededForQuest(Player* bot, uint32 itemId);
-};
+bool LootTarget::operator<(LootTarget const& other) const { return guid < other.guid; }
 
-class LootTarget
+void LootTargetList::shrink(time_t fromTime)
 {
-public:
-    LootTarget(ObjectGuid guid);
-    LootTarget(LootTarget const& other);
+    for (std::set<LootTarget>::iterator i = begin(); i != end();)
+    {
+        if (i->asOfTime <= fromTime)
+            erase(i++);
+        else
+            ++i;
+    }
+}
 
-public:
-    LootTarget& operator=(LootTarget const& other);
-    bool operator<(LootTarget const& other) const;
-
-public:
-    ObjectGuid guid;
-    time_t asOfTime;
-};
-
-class LootTargetList : public std::set<LootTarget>
+LootObject::LootObject(Player* bot, ObjectGuid guid) : guid(), skillId(SKILL_NONE), reqSkillValue(0), reqItem(0)
 {
-public:
-    void shrink(time_t fromTime);
-};
+    Refresh(bot, guid);
+}
 
-class LootObjectStack
+void LootObject::Refresh(Player* bot, ObjectGuid lootGUID)
 {
-public:
-    LootObjectStack(Player* bot) : bot(bot) {}
+    skillId = SKILL_NONE;
+    reqSkillValue = 0;
+    reqItem = 0;
+    guid.Clear();
 
-    bool Add(ObjectGuid guid);
-    void Remove(ObjectGuid guid);
-    void Clear();
-    bool CanLoot(float maxDistance);
-    LootObject GetLoot(float maxDistance = 0);
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+    {
+        return;
+    }
+    Creature* creature = botAI->GetCreature(lootGUID);
+    if (creature && creature->getDeathState() == DeathState::Corpse)
+    {
+        if (creature->HasFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE))
+            guid = lootGUID;
 
-private:
-    std::vector<LootObject> OrderByDistance(float maxDistance = 0);
+        if (creature->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE))
+        {
+            skillId = creature->GetCreatureTemplate()->GetRequiredLootSkill();
+            uint32 targetLevel = creature->GetLevel();
+            reqSkillValue = targetLevel < 10 ? 1 : targetLevel < 20 ? (targetLevel - 10) * 10 : targetLevel * 5;
+            if (botAI->HasSkill((SkillType)skillId) && bot->GetSkillValue(skillId) >= reqSkillValue)
+                guid = lootGUID;
+        }
 
-    Player* bot;
-    LootTargetList availableLoot;
-};
+        return;
+    }
 
-#endif
+    GameObject* go = botAI->GetGameObject(lootGUID);
+    if (go && go->isSpawned() && go->GetGoState() == GO_STATE_READY)
+    {
+        bool onlyHasQuestItems = true;
+        bool hasAnyQuestItems = false;
+
+        GameObjectQuestItemList const* items = sObjectMgr->GetGameObjectQuestItemList(go->GetEntry());
+        for (int i = 0; i < MAX_GAMEOBJECT_QUEST_ITEMS; i++)
+        {
+            if (!items || i >= items->size())
+                break;
+
+            uint32 itemId = uint32((*items)[i]);
+            if (!itemId)
+                continue;
+
+            hasAnyQuestItems = true;
+
+            if (IsNeededForQuest(bot, itemId))
+            {
+                this->guid = lootGUID;
+                return;
+            }
+
+            const ItemTemplate* proto = sObjectMgr->GetItemTemplate(itemId);
+            if (!proto)
+                continue;
+
+            if (proto->Class != ITEM_CLASS_QUEST)
+            {
+                onlyHasQuestItems = false;
+            }
+        }
+
+        // Retrieve the correct loot table entry
+        uint32 lootEntry = go->GetGOInfo()->GetLootId();
+        if (lootEntry == 0)
+            return;
+
+        // Check the main loot template
+        if (const LootTemplate* lootTemplate = LootTemplates_Gameobject.GetLootFor(lootEntry))
+        {
+            Loot loot;
+            lootTemplate->Process(loot, LootTemplates_Gameobject, 1, bot);
+
+            for (const LootItem& item : loot.items)
+            {
+                uint32 itemId = item.itemid;
+                if (!itemId)
+                    continue;
+
+                const ItemTemplate* proto = sObjectMgr->GetItemTemplate(itemId);
+                if (!proto)
+                    continue;
+
+                if (proto->Class != ITEM_CLASS_QUEST)
+                {
+                    onlyHasQuestItems = false;
+                    break;
+                }
+
+                // If this item references another loot table, process it
+                if (const LootTemplate* refLootTemplate = LootTemplates_Reference.GetLootFor(itemId))
+                {
+                    Loot refLoot;
+                    refLootTemplate->Process(refLoot, LootTemplates_Reference, 1, bot);
+
+                    for (const LootItem& refItem : refLoot.items)
+                    {
+                        uint32 refItemId = refItem.itemid;
+                        if (!refItemId)
+                            continue;
+
+                        const ItemTemplate* refProto = sObjectMgr->GetItemTemplate(refItemId);
+                        if (!refProto)
+                            continue;
+
+                        if (refProto->Class != ITEM_CLASS_QUEST)
+                        {
+                            onlyHasQuestItems = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // If gameobject has only quest items that bot doesn’t need, skip it.
+        if (hasAnyQuestItems && onlyHasQuestItems)
+            return;
+
+        // Otherwise, loot it.
+        guid = lootGUID;
+
+        uint32 goId = go->GetEntry();
+        uint32 lockId = go->GetGOInfo()->GetLockId();
+        LockEntry const* lockInfo = sLockStore.LookupEntry(lockId);
+        if (!lockInfo)
+            return;
+
+        for (uint8 i = 0; i < 8; ++i)
+        {
+            switch (lockInfo->Type[i])
+            {
+                case LOCK_KEY_ITEM:
+                    if (lockInfo->Index[i] > 0)
+                    {
+                        reqItem = lockInfo->Index[i];
+                        guid = lootGUID;
+                    }
+                    break;
+
+                case LOCK_KEY_SKILL:
+                    if (goId == 13891 || goId == 19535)  // Serpentbloom
+                    {
+                        this->guid = lootGUID;
+                    }
+                    else if (SkillByLockType(LockType(lockInfo->Index[i])) > 0)
+                    {
+                        skillId = SkillByLockType(LockType(lockInfo->Index[i]));
+                        reqSkillValue = std::max((uint32)1, lockInfo->Skill[i]);
+                        guid = lootGUID;
+                    }
+                    break;
+
+                case LOCK_KEY_NONE:
+                    guid = lootGUID;
+                    break;
+            }
+        }
+    }
+}
+
+bool LootObject::IsNeededForQuest(Player* bot, uint32 itemId)
+{
+    for (int qs = 0; qs < MAX_QUEST_LOG_SIZE; ++qs)
+    {
+        uint32 questId = bot->GetQuestSlotQuestId(qs);
+        if (questId == 0)
+            continue;
+
+        QuestStatusData& qData = bot->getQuestStatusMap()[questId];
+        if (qData.Status != QUEST_STATUS_INCOMPLETE)
+            continue;
+
+        Quest const* qInfo = sObjectMgr->GetQuestTemplate(questId);
+        if (!qInfo)
+            continue;
+
+        for (int i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
+        {
+            if (!qInfo->RequiredItemCount[i] || (qInfo->RequiredItemCount[i] - qData.ItemCount[i]) <= 0)
+                continue;
+
+            if (qInfo->RequiredItemId[i] != itemId)
+                continue;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+WorldObject* LootObject::GetWorldObject(Player* bot)
+{
+    Refresh(bot, guid);
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+    {
+        return nullptr;
+    }
+    Creature* creature = botAI->GetCreature(guid);
+    if (creature && creature->getDeathState() == DeathState::Corpse && creature->IsInWorld())
+        return creature;
+
+    GameObject* go = botAI->GetGameObject(guid);
+    if (go && go->isSpawned() && go->IsInWorld())
+        return go;
+
+    return nullptr;
+}
+
+LootObject::LootObject(LootObject const& other)
+{
+    guid = other.guid;
+    skillId = other.skillId;
+    reqSkillValue = other.reqSkillValue;
+    reqItem = other.reqItem;
+}
+
+bool LootObject::IsLootPossible(Player* bot)
+{
+    if (IsEmpty() || !bot)
+        return false;
+
+    WorldObject* worldObj = GetWorldObject(bot);  // Store result to avoid multiple calls
+    if (!worldObj)
+        return false;
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+    {
+        return false;
+    }
+    if (reqItem && !bot->HasItemCount(reqItem, 1))
+        return false;
+
+    if (abs(worldObj->GetPositionZ() - bot->GetPositionZ()) > INTERACTION_DISTANCE -2.0f)
+        return false;
+
+    Creature* creature = botAI->GetCreature(guid);
+    if (creature && creature->getDeathState() == DeathState::Corpse)
+    {
+        if (!bot->isAllowedToLoot(creature) && skillId != SKILL_SKINNING)
+            return false;
+    }
+
+    if (skillId == SKILL_NONE)
+        return true;
+
+    if (skillId == SKILL_FISHING)
+        return false;
+
+    if (!botAI->HasSkill((SkillType)skillId))
+        return false;
+
+    if (!reqSkillValue)
+        return true;
+
+    uint32 skillValue = uint32(bot->GetSkillValue(skillId));
+    if (reqSkillValue > skillValue)
+        return false;
+    
+    if (skillId == SKILL_MINING &&
+        !bot->HasItemCount(756, 1) &&
+        !bot->HasItemCount(778, 1) &&
+        !bot->HasItemCount(1819, 1) &&
+        !bot->HasItemCount(1893, 1) &&
+        !bot->HasItemCount(1959, 1) &&
+        !bot->HasItemCount(2901, 1) &&
+        !bot->HasItemCount(9465, 1) &&
+        !bot->HasItemCount(20723, 1) &&
+        !bot->HasItemCount(40772, 1) &&
+        !bot->HasItemCount(40892, 1) &&
+        !bot->HasItemCount(40893, 1))
+    {
+        return false;  // Bot is missing a mining pick
+    }
+    
+    if (skillId == SKILL_SKINNING &&
+        !bot->HasItemCount(7005, 1) &&
+        !bot->HasItemCount(40772, 1) &&
+        !bot->HasItemCount(40893, 1) &&
+        !bot->HasItemCount(12709, 1) &&
+        !bot->HasItemCount(19901, 1))
+    {
+        return false;  // Bot is missing a skinning knife
+    }
+
+    return true;
+}
+
+bool LootObjectStack::Add(ObjectGuid guid)
+{
+    if (availableLoot.size() >= MAX_LOOT_OBJECT_COUNT)
+    {
+        availableLoot.shrink(time(nullptr) - 30);
+    }
+
+    if (availableLoot.size() >= MAX_LOOT_OBJECT_COUNT)
+    {
+        availableLoot.clear();
+    }
+
+    if (!availableLoot.insert(guid).second)
+        return false;
+
+    return true;
+}
+
+void LootObjectStack::Remove(ObjectGuid guid)
+{
+    LootTargetList::iterator i = availableLoot.find(guid);
+    if (i != availableLoot.end())
+        availableLoot.erase(i);
+}
+
+void LootObjectStack::Clear() { availableLoot.clear(); }
+
+bool LootObjectStack::CanLoot(float maxDistance)
+{
+    std::vector<LootObject> ordered = OrderByDistance(maxDistance);
+    return !ordered.empty();
+}
+
+LootObject LootObjectStack::GetLoot(float maxDistance)
+{
+    std::vector<LootObject> ordered = OrderByDistance(maxDistance);
+    return ordered.empty() ? LootObject() : *ordered.begin();
+}
+std::vector<LootObject> LootObjectStack::OrderByDistance(float maxDistance)
+{
+    availableLoot.shrink(time(nullptr) - 30);
+
+    std::map<float, LootObject> sortedMap;
+    LootTargetList safeCopy(availableLoot);
+    for (LootTargetList::iterator i = safeCopy.begin(); i != safeCopy.end(); i++)
+    {
+        ObjectGuid guid = i->guid;
+        LootObject lootObject(bot, guid);
+        if (!lootObject.IsLootPossible(bot)) // Ensure loot object is valid
+            continue;
+
+        WorldObject* worldObj = lootObject.GetWorldObject(bot);
+        if (!worldObj) // Prevent null pointer dereference
+        {
+            continue;
+        }
+
+        float distance = bot->GetDistance(worldObj);
+        if (!maxDistance || distance <= maxDistance)
+            sortedMap[distance] = lootObject;
+    }
+
+    std::vector<LootObject> result;
+    for (auto& [_, lootObject] : sortedMap)
+        result.push_back(lootObject);
+
+    return result;
+}

--- a/src/strategy/actions/AddLootAction.cpp
+++ b/src/strategy/actions/AddLootAction.cpp
@@ -51,29 +51,11 @@ bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
     if (loot.IsEmpty() || !wo)
         return false;
 
-    if (!bot->IsWithinLOSInMap(wo))
-        return false;
-
     if (loot.skillId == SKILL_NONE)
         return false;
 
     if (!loot.IsLootPossible(bot))
         return false;
-
-    if (sServerFacade->IsDistanceGreaterThan(sServerFacade->GetDistance2d(bot, wo), INTERACTION_DISTANCE))
-    {
-        std::list<Unit*> targets;
-        Acore::AnyUnfriendlyUnitInObjectRangeCheck u_check(bot, bot, sPlayerbotAIConfig->lootDistance);
-        Acore::UnitListSearcher<Acore::AnyUnfriendlyUnitInObjectRangeCheck> searcher(bot, targets, u_check);
-        Cell::VisitAllObjects(bot, searcher, sPlayerbotAIConfig->lootDistance * 1.5f);
-        if (!targets.empty())
-        {
-            std::ostringstream out;
-            out << "Kill that " << targets.front()->GetName() << " so I can loot freely";
-            botAI->TellError(out.str());
-            return false;
-        }
-    }
 
     return AddAllLootAction::AddLoot(guid);
 }

--- a/src/strategy/actions/LootAction.cpp
+++ b/src/strategy/actions/LootAction.cpp
@@ -79,8 +79,15 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
         return false;
 
     Creature* creature = botAI->GetCreature(lootObject.guid);
-    if (creature && bot->GetDistance(creature) > INTERACTION_DISTANCE)
+    if (creature && bot->GetDistance(creature) > INTERACTION_DISTANCE - 2.0f)
         return false;
+
+    // Dismount if the bot is mounted
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        botAI->SetNextCheckDelay(sPlayerbotAIConfig->lootDelay); // Small delay to avoid animation issues
+    }
 
     if (creature && creature->HasFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE))
     {
@@ -116,7 +123,7 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
     }
 
     GameObject* go = botAI->GetGameObject(lootObject.guid);
-    if (go && bot->GetDistance(go) > INTERACTION_DISTANCE)
+    if (go && bot->GetDistance(go) > INTERACTION_DISTANCE - 2.0f)
         return false;
 
     if (go && (go->GetGoState() != GO_STATE_READY))
@@ -418,6 +425,7 @@ bool StoreLootAction::Execute(Event event)
         WorldPacket packet(CMSG_AUTOSTORE_LOOT_ITEM, 1);
         packet << itemindex;
         bot->GetSession()->HandleAutostoreLootItemOpcode(packet);
+        botAI->SetNextCheckDelay(sPlayerbotAIConfig->lootDelay);
 
         if (proto->Quality > ITEM_QUALITY_NORMAL && !urand(0, 50) && botAI->HasStrategy("emote", BOT_STATE_NON_COMBAT) && sPlayerbotAIConfig->randomBotEmote)
             botAI->PlayEmote(TEXT_EMOTE_CHEER);

--- a/src/strategy/triggers/LootTriggers.cpp
+++ b/src/strategy/triggers/LootTriggers.cpp
@@ -13,9 +13,9 @@ bool LootAvailableTrigger::IsActive()
 {
     return AI_VALUE(bool, "has available loot") &&
            (sServerFacade->IsDistanceLessOrEqualThan(AI_VALUE2(float, "distance", "loot target"),
-                                                     INTERACTION_DISTANCE) ||
+                                                     INTERACTION_DISTANCE - 2.0f) ||
             AI_VALUE(GuidVector, "all targets").empty()) &&
-           !AI_VALUE2(bool, "combat", "self target") && !AI_VALUE2(bool, "mounted", "self target");
+           !AI_VALUE2(bool, "combat", "self target");
 }
 
 bool FarFromCurrentLootTrigger::IsActive()
@@ -24,7 +24,7 @@ bool FarFromCurrentLootTrigger::IsActive()
     if (!loot.IsLootPossible(bot))
         return false;
 
-    return AI_VALUE2(float, "distance", "loot target") > INTERACTION_DISTANCE;
+    return AI_VALUE2(float, "distance", "loot target") >= INTERACTION_DISTANCE - 2.0f;
 }
 
 bool CanLootTrigger::IsActive() { return AI_VALUE(bool, "can loot"); }


### PR DESCRIPTION
Resolves #120

1. Bots now correctly check nearby game objects loot tables, including referenced loot
2. Bots will dismount when trying to collect loot
3. Bots will move within interaction distance (-2.0f) to reliably gather on uneven terrain
4. Used AiPlayerbot.LootDelay after loot packet so bots don't recast Herbalism/Mining before looting has finished. Seems to fix the sparkly corpses that bots tended to leave behind too which is nice.