### PR TITLE
BattleGround: Fix bot's already cast (ranged) spells to be redirected to bot's ghost on death

### DIFF
--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -90,9 +90,6 @@ bool AutoReleaseSpiritAction::Execute(Event event)
         context->GetValue<uint32>("death count")->Set(dCount + 1);
     }
 
-    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> auto released", bot->GetGUID().ToString().c_str(),
-              bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
-
     // When bot dies in BG, wait a couple of seconds before release.
     // This prevents currently casted (ranged) spells to be re-directed to the bot's ghost.
     if (bot->InBattleground()) 
@@ -103,6 +100,9 @@ bool AutoReleaseSpiritAction::Execute(Event event)
         if (time(nullptr) - bg_release_time < 2) 
             return false;
     }
+
+    LOG_DEBUG("playerbots", "Bot {} {}:{} <{}> auto released", bot->GetGUID().ToString().c_str(),
+    bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
 
     WorldPacket packet(CMSG_REPOP_REQUEST);
     packet << uint8(0);

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -166,7 +166,7 @@ bool AutoReleaseSpiritAction::isUseful()
                 botReleaseTimes[botId] = now;
 
             // Wait 8 seconds before releasing.
-            if (now - botReleaseTimes[botId] < 8)
+            if (now - botReleaseTimes[botId] < 6)
                 return false;
         }
         // Erase the release time for this bot.

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -165,7 +165,7 @@ bool AutoReleaseSpiritAction::isUseful()
             if (botReleaseTimes.find(botId) == botReleaseTimes.end())
                 botReleaseTimes[botId] = now;
 
-            // Wait 8 seconds before releasing.
+            // Wait 6 seconds before releasing.
             if (now - botReleaseTimes[botId] < 6)
                 return false;
         }

--- a/src/strategy/actions/ReleaseSpiritAction.h
+++ b/src/strategy/actions/ReleaseSpiritAction.h
@@ -33,7 +33,7 @@ public:
     bool isUseful() override;
 
 private:
-    uint32_t bg_release_time = 0;
+    inline static std::unordered_map<uint32_t, time_t> botReleaseTimes;
     uint32_t bg_gossip_time = 0;
 };
 

--- a/src/strategy/actions/ReleaseSpiritAction.h
+++ b/src/strategy/actions/ReleaseSpiritAction.h
@@ -33,6 +33,7 @@ public:
     bool isUseful() override;
 
 private:
+    uint32_t bg_release_time = 0;
     uint32_t bg_gossip_time = 0;
 };
 


### PR DESCRIPTION
This fixes the BG issue where already cast spells would be re-directed (flying halfway across the map) to the meanwhile died bot's ghost.