### PR TITLE
Frostfire spec for fire mage

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1093,6 +1093,10 @@ AiPlayerbot.PremadeSpecName.8.2 = frost pve
 AiPlayerbot.PremadeSpecGlyph.8.2 = 42742,43339,50045,43364,43361,42751
 AiPlayerbot.PremadeSpecLink.8.2.60 = --0533030313203100030152231151
 AiPlayerbot.PremadeSpecLink.8.2.80 = 23002303110003--0533030313203100030152231351
+AiPlayerbot.PremadeSpecName.8.3 = frostfire pve
+AiPlayerbot.PremadeSpecGlyph.8.3 = 44684,44920,42751,43339,43364,45737
+AiPlayerbot.PremadeSpecLink.8.3.60 = -2305032012303331053120300051
+AiPlayerbot.PremadeSpecLink.8.3.80 = -2305032012303331053120311351-023303031
 
 #
 #

--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -304,7 +304,16 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             if (tab == 0)
                 engine->addStrategiesNoInit("arcane", "arcane aoe", nullptr);
             else if (tab == 1)
-                engine->addStrategiesNoInit("fire", "fire aoe", nullptr);
+            {
+                if (player->HasSpell(44614) /*Frostfire Bolt*/ && player->HasAura(15047) /*Ice Shards*/)
+                {
+                    engine->addStrategiesNoInit("frostfire", "frostfire aoe", nullptr);
+                }
+                else
+                {
+                    engine->addStrategiesNoInit("fire", "fire aoe", nullptr);
+                }
+            } 
             else
                 engine->addStrategiesNoInit("frost", "frost aoe", nullptr);
 

--- a/src/strategy/mage/FrostFireMageStrategy.cpp
+++ b/src/strategy/mage/FrostFireMageStrategy.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#include "FrostFireMageStrategy.h"
+
+#include "Playerbots.h"
+
+NextAction** FrostFireMageStrategy::getDefaultActions()
+{
+    return NextAction::array(0, new NextAction("frostfire bolt", ACTION_DEFAULT + 0.1f),
+                             new NextAction("shoot", ACTION_DEFAULT), NULL);
+}
+
+void FrostFireMageStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    GenericMageStrategy::InitTriggers(triggers);
+
+    triggers.push_back(
+        new TriggerNode("hot streak", NextAction::array(0, new NextAction("pyroblast", 25.0f), nullptr)));
+    triggers.push_back(
+        new TriggerNode("combustion", NextAction::array(0, new NextAction("combustion", 50.0f), nullptr)));
+    triggers.push_back(
+        new TriggerNode("icy veins", NextAction::array(0, new NextAction("icy veins", 60.0f), nullptr)));
+}
+
+void FrostFireMageAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(
+        new TriggerNode("medium aoe", NextAction::array(0, new NextAction("flamestrike", 20.0f), nullptr)));
+    triggers.push_back(
+        new TriggerNode("living bomb", NextAction::array(0, new NextAction("living bomb", 25.0f), nullptr)));
+}

--- a/src/strategy/mage/FrostFireMageStrategy.h
+++ b/src/strategy/mage/FrostFireMageStrategy.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_FROSTFIREMAGESTRATEGY_H
+#define _PLAYERBOT_FROSTFIREMAGESTRATEGY_H
+
+#include "GenericMageStrategy.h"
+
+class PlayerbotAI;
+
+class FrostFireMageStrategy : public GenericMageStrategy
+{
+public:
+    FrostFireMageStrategy(PlayerbotAI* botAI) : GenericMageStrategy(botAI) {}
+
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    std::string const getName() override { return "frostfire"; }
+    NextAction** getDefaultActions() override;
+};
+
+class FrostFireMageAoeStrategy : public CombatStrategy
+{
+public:
+    FrostFireMageAoeStrategy(PlayerbotAI* botAI) : CombatStrategy(botAI) {}
+
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    std::string const getName() override { return "frostfire aoe"; }
+};
+
+#endif

--- a/src/strategy/mage/MageAiObjectContext.cpp
+++ b/src/strategy/mage/MageAiObjectContext.cpp
@@ -7,6 +7,7 @@
 
 #include "ArcaneMageStrategy.h"
 #include "FireMageStrategy.h"
+#include "FrostFireMageStrategy.h"
 #include "FrostMageStrategy.h"
 #include "GenericMageNonCombatStrategy.h"
 #include "MageActions.h"
@@ -23,6 +24,7 @@ public:
         creators["nc"] = &MageStrategyFactoryInternal::nc;
         creators["pull"] = &MageStrategyFactoryInternal::pull;
         creators["fire aoe"] = &MageStrategyFactoryInternal::fire_aoe;
+        creators["frostfire aoe"] = &MageStrategyFactoryInternal::frostfire_aoe; 
         creators["frost aoe"] = &MageStrategyFactoryInternal::frost_aoe;
         creators["arcane aoe"] = &MageStrategyFactoryInternal::arcane_aoe;
         creators["cure"] = &MageStrategyFactoryInternal::cure;
@@ -35,6 +37,7 @@ private:
     static Strategy* nc(PlayerbotAI* botAI) { return new GenericMageNonCombatStrategy(botAI); }
     static Strategy* pull(PlayerbotAI* botAI) { return new PullStrategy(botAI, "shoot"); }
     static Strategy* fire_aoe(PlayerbotAI* botAI) { return new FireMageAoeStrategy(botAI); }
+    static Strategy* frostfire_aoe(PlayerbotAI* botAI) { return new FrostFireMageAoeStrategy(botAI); }
     static Strategy* frost_aoe(PlayerbotAI* botAI) { return new FrostMageAoeStrategy(botAI); }
     static Strategy* arcane_aoe(PlayerbotAI* botAI) { return new ArcaneMageAoeStrategy(botAI); }
     static Strategy* cure(PlayerbotAI* botAI) { return new MageCureStrategy(botAI); }
@@ -50,12 +53,14 @@ public:
     {
         creators["frost"] = &MageCombatStrategyFactoryInternal::frost;
         creators["fire"] = &MageCombatStrategyFactoryInternal::fire;
+        creators["frostfire"] = &MageCombatStrategyFactoryInternal::frostfire;
         creators["arcane"] = &MageCombatStrategyFactoryInternal::arcane;
     }
 
 private:
     static Strategy* frost(PlayerbotAI* botAI) { return new FrostMageStrategy(botAI); }
     static Strategy* fire(PlayerbotAI* botAI) { return new FireMageStrategy(botAI); }
+    static Strategy* frostfire(PlayerbotAI* botAI) { return new FrostFireMageStrategy(botAI); }
     static Strategy* arcane(PlayerbotAI* botAI) { return new ArcaneMageStrategy(botAI); }
 };
 
@@ -109,6 +114,7 @@ public:
         creators["frost nova on target"] = &MageTriggerFactoryInternal::frost_nova_on_target;
         creators["frostbite on target"] = &MageTriggerFactoryInternal::frostbite_on_target;
         creators["no focus magic"] = &MageTriggerFactoryInternal::no_focus_magic;
+        creators["frostfire bolt"] = &MageTriggerFactoryInternal::frostfire_bolt;
     }
 
 private:
@@ -143,6 +149,7 @@ private:
     static Trigger* frost_nova_on_target(PlayerbotAI* botAI) { return new FrostNovaOnTargetTrigger(botAI); }
     static Trigger* frostbite_on_target(PlayerbotAI* botAI) { return new FrostbiteOnTargetTrigger(botAI); }
     static Trigger* no_focus_magic(PlayerbotAI* botAI) { return new NoFocusMagicTrigger(botAI); }
+    static Trigger* frostfire_bolt(PlayerbotAI* botAI) { return new FrostfireBoltTrigger(botAI); }
 };
 
 class MageAiObjectContextInternal : public NamedObjectContext<Action>

--- a/src/strategy/mage/MageTriggers.h
+++ b/src/strategy/mage/MageTriggers.h
@@ -201,4 +201,10 @@ public:
     bool IsActive() override;
 };
 
+class FrostfireBoltTrigger : public DebuffTrigger
+{
+public:
+    FrostfireBoltTrigger(PlayerbotAI* botAI) : DebuffTrigger(botAI, "frostfire bolt", 1, true) {}
+};
+
 #endif


### PR DESCRIPTION
Added Frostfire specialization for Fire Mage

- This specialization is essentially a copy of Fire Mage, with Fireball replaced by Frostfire Bolt and Icy Veins added to cooldowns.
- The [spec](https://www.wowhead.com/wotlk/guide/classes/mage/fire/dps-talent-builds-glyphs-pve#frostfire-mage-0-54-17) has also been added to playerbots.conf.dist.

Implementation details:

- The distinction between a classic Fire Mage and a Frostfire Mage is determined by checking whether the bot has the "Ice Shards" talent learned and also knows the Frostfire Bolt spell.

Testing:

- Conducted few raid tests, and everything seems to be working fine.
- However, additional testing by others would be appreciated.