### PR TITLE
Add LimitTalentsExpansion config

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -529,6 +529,11 @@ AiPlayerbot.RandomBotHordeRatio = 50
 # Disable death knight for bots login
 AiPlayerbot.DisableDeathKnightLogin = 0
 
+# Enable expansion limitation for talents and glyphs - ie: level <= 60 bot only uses talents
+# available in vanilla, level <= 70 bot only uses talents available in TBC)
+# Default: 0
+AiPlayerbot.LimitTalentsExpansion = 0
+
 #
 #
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -484,6 +484,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotAllianceRatio = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAllianceRatio", 50);
     randomBotHordeRatio = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotHordeRatio", 50);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);
+    limitTalentsExpansion = sConfigMgr->GetOption<bool>("AiPlayerbot.LimitTalentsExpansion", 0);
     botActiveAlone = sConfigMgr->GetOption<int32>("AiPlayerbot.BotActiveAlone", 100);
     BotActiveAloneForceWhenInRadius = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotActiveAloneForceWhenInRadius", 150);
     BotActiveAloneForceWhenInZone = sConfigMgr->GetOption<bool>("AiPlayerbot.BotActiveAloneForceWhenInZone", 1);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -278,6 +278,7 @@ public:
     uint32 randomBotAllianceRatio;
     uint32 randomBotHordeRatio;
     bool disableDeathKnightLogin;
+    bool limitTalentsExpansion;
     uint32 botActiveAlone;
     uint32 BotActiveAloneForceWhenInRadius;
     bool BotActiveAloneForceWhenInZone;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1021,13 +1021,13 @@ void PlayerbotFactory::InitTalentsTree(bool increment /*false*/, bool use_templa
     {
         InitTalentsByTemplate(specTab);
     }
-    // always use template now
-    // else
-    // {
-    //     InitTalents(specTab);
-    //     if (bot->GetFreeTalentPoints())
-    //         InitTalents((specTab + 1) % 3);
-    // }
+    // if LimitTalentsExpansion = 1 there may be unused talent points
+    if (bot->GetFreeTalentPoints())
+        InitTalents((specTab + 1) % 3);
+
+    if (bot->GetFreeTalentPoints())
+        InitTalents((specTab + 2) % 3);
+    
     bot->SendTalentsInfoData(false);
 }
 
@@ -2620,6 +2620,12 @@ void PlayerbotFactory::InitTalentsByTemplate(uint32 specTab)
         for (std::vector<uint32>& p : sPlayerbotAIConfig->parsedSpecLinkOrder[cls][specIndex][level])
         {
             uint32 tab = p[0], row = p[1], col = p[2], lvl = p[3];
+            if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 60 && (row > 6 || (row == 6 && col != 1)))
+                continue;
+
+            if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 70 && (row > 8 || (row == 8 && col != 1)))
+                continue;
+
             uint32 talentID = 0;
             uint32 learnLevel = 0;
             std::vector<TalentEntry const*>& spells = spells_row[row];
@@ -3222,6 +3228,12 @@ void PlayerbotFactory::InitGlyphs(bool increment)
                 bot->SetGlyph(slotIndex, 0, true);
             }
         }
+    }
+
+    if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 70)
+    {
+        bot->SendTalentsInfoData(false);
+        return;
     }
 
     uint32 level = bot->GetLevel();


### PR DESCRIPTION
```
# Enable expansion limitation for talents and glyphs - ie: level <= 60 bot only uses talents
# available in vanilla, level <= 70 bot only uses talents available in TBC)
# Default: 0
AiPlayerbot.LimitTalentsExpansion = 0
```