### PR TITLE
Re-instate random bots guilds

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -394,7 +394,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     // pmo = sPerformanceMonitor->start(PERF_MON_RNDBOT, "PlayerbotFactory_Guilds");
     // LOG_INFO("playerbots", "Initializing guilds...");
     // bot->SaveToDB(false, false);
-    // InitGuild();
+    InitGuild();
     // bot->SaveToDB(false, false);
     // if (pmo)
     //    pmo->finish();


### PR DESCRIPTION
I believe this should have been enabled again at some point.

https://github.com/liyunfan1223/mod-playerbots/issues/968