### PR TITLE
Avoid creating accounts if both maxRandom & ClassBots are set to zero

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -406,6 +406,7 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
     // Avoid creating accounts if both maxRandom & ClassBots are set to zero.
     if (sPlayerbotAIConfig->maxRandomBots == 0 &&
         sPlayerbotAIConfig->addClassAccountPoolSize == 0)
+        return 0;
 
     bool isWOTLK = sWorld->getIntConfig(CONFIG_EXPANSION) == EXPANSION_WRATH_OF_THE_LICH_KING;
 


### PR DESCRIPTION
OCD compatibility Fix for https://github.com/liyunfan1223/mod-playerbots/issues/978