### PR TITLE
Minor improvments on logs, stats weights and aoe distance calculation

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -455,13 +455,13 @@ void RandomPlayerbotFactory::CreateRandomBots()
             {
                 Field* fields = results->Fetch();
                 uint32 accId = fields[0].Get<uint32>();
-                LOG_INFO("playerbots", "Deleting account accID: {}({})...", accId, ++deletion_count);
+                LOG_DEBUG("playerbots", "Deleting account accID: {}({})...", accId, ++deletion_count);
                 AccountMgr::DeleteAccount(accId);
             } while (results->NextRow());
         }
 
-        PlayerbotsDatabase.Execute(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_RANDOM_BOTS));
         uint32 timer = getMSTime();
+        PlayerbotsDatabase.Execute(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_RANDOM_BOTS));
         while (LoginDatabase.QueueSize())
         {
             std::this_thread::sleep_for(1s);
@@ -479,7 +479,8 @@ void RandomPlayerbotFactory::CreateRandomBots()
 
     // Calculates the total number of required accounts.
     uint32 totalAccountCount = CalculateTotalAccountCount();
-
+    uint32 timer = getMSTime();
+    
     for (uint32 accountNumber = 0; accountNumber < totalAccountCount; ++accountNumber)
     {
         std::ostringstream out;
@@ -509,12 +510,11 @@ void RandomPlayerbotFactory::CreateRandomBots()
 
         LOG_DEBUG("playerbots", "Account {} created for random bots", accountName.c_str());
     }
-
     if (account_creation)
     {
         LOG_INFO("playerbots", "Waiting for {} accounts loading into database ({} queries)...", account_creation, LoginDatabase.QueueSize());
         /* wait for async accounts create to make character create correctly */
-        uint32 timer = getMSTime();
+        
         while (LoginDatabase.QueueSize())
         {
             std::this_thread::sleep_for(1s);
@@ -527,7 +527,7 @@ void RandomPlayerbotFactory::CreateRandomBots()
     std::vector<std::pair<Player*, uint32>> playerBots;
     std::vector<WorldSession*> sessionBots;
     int bot_creation = 0;
-
+    timer = getMSTime();
     bool nameCached = false;
     for (uint32 accountNumber = 0; accountNumber < totalAccountCount; ++accountNumber)
     {
@@ -624,7 +624,6 @@ void RandomPlayerbotFactory::CreateRandomBots()
     {
         LOG_INFO("playerbots", "Waiting for {} characters loading into database ({} queries)...", bot_creation, CharacterDatabase.QueueSize());
         /* wait for characters load into database, or characters will fail to loggin */
-        uint32 timer = getMSTime();
         while (CharacterDatabase.QueueSize())
         {
             std::this_thread::sleep_for(1s);

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -111,11 +111,14 @@ void PlayerbotFactory::Init()
     uint32 maxStoreSize = sSpellMgr->GetSpellInfoStoreSize();
     for (uint32 id = 1; id < maxStoreSize; ++id)
     {
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(id);
-        if (!spellInfo)
+        if (id == 47181 || id == 50358 || id == 47242 || id == 52639 || id == 47147 || id == 7218)  // Test Enchant
             continue;
 
-        if (id == 47181 || id == 50358 || id == 47242 || id == 52639 || id == 47147 || id == 7218)  // Test Enchant
+        if (id == 15463) // Legendary Arcane Amalgamation
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(id);
+        if (!spellInfo)
             continue;
 
         uint32 requiredLevel = spellInfo->BaseLevel;

--- a/src/factory/StatsCollector.cpp
+++ b/src/factory/StatsCollector.cpp
@@ -802,7 +802,7 @@ bool StatsCollector::CheckSpellValidation(uint32 spellFamilyName, flag96 spelFal
     if (cls_ == CLASS_PALADIN && spellFamilyName == SPELLFAMILY_PALADIN && (type_ & CollectorType::MELEE_DMG))
     {
         uint32 retributionFlagsA = 0x0;
-        uint32 retributionFlagsB = 0x100000;  // shield of righteouness
+        uint32 retributionFlagsB = 0x100000 | 0x40;  // shield of righteouness | holy shield
         uint32 retributionFlagsC = 0x0;
         flag96 invalidFlags = {retributionFlagsA, retributionFlagsB, retributionFlagsC};
         if (spelFalimyFlags & invalidFlags)

--- a/src/factory/StatsWeightCalculator.cpp
+++ b/src/factory/StatsWeightCalculator.cpp
@@ -293,16 +293,24 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HASTE] += 1.0f;
     }
     else if ((cls == CLASS_PALADIN && tab == PALADIN_TAB_HOLY) ||       // holy
-             (cls == CLASS_PRIEST && tab != PRIEST_TAB_SHADOW) ||       // discipline / holy
-             (cls == CLASS_SHAMAN && tab == SHAMAN_TAB_RESTORATION) ||  // heal
+             (cls == CLASS_SHAMAN && tab == SHAMAN_TAB_RESTORATION))    // heal
+    {
+        stats_weights_[STATS_TYPE_INTELLECT] += 0.9f;
+        stats_weights_[STATS_TYPE_SPIRIT] += 0.15f;
+        stats_weights_[STATS_TYPE_HEAL_POWER] += 1.0f;
+        stats_weights_[STATS_TYPE_MANA_REGENERATION] += 0.9f;
+        stats_weights_[STATS_TYPE_CRIT] += 0.6f;
+        stats_weights_[STATS_TYPE_HASTE] += 0.8f;
+    }
+    else if ((cls == CLASS_PRIEST && tab != PRIEST_TAB_SHADOW) ||       // discipline / holy
              (cls == CLASS_DRUID && tab == DRUID_TAB_RESTORATION))
     {
         stats_weights_[STATS_TYPE_INTELLECT] += 0.8f;
-        stats_weights_[STATS_TYPE_SPIRIT] += 0.8f;
+        stats_weights_[STATS_TYPE_SPIRIT] += 0.6f;
         stats_weights_[STATS_TYPE_HEAL_POWER] += 1.0f;
-        stats_weights_[STATS_TYPE_MANA_REGENERATION] += 1.2f;
-        stats_weights_[STATS_TYPE_CRIT] += 0.7f;
-        stats_weights_[STATS_TYPE_HASTE] += 1.0f;
+        stats_weights_[STATS_TYPE_MANA_REGENERATION] += 0.9f;
+        stats_weights_[STATS_TYPE_CRIT] += 0.6f;
+        stats_weights_[STATS_TYPE_HASTE] += 0.8f;
         stats_weights_[STATS_TYPE_RANGED_DPS] += 1.0f;
     }
     else if ((cls == CLASS_WARRIOR && tab == WARRIOR_TAB_PROTECTION) ||
@@ -551,6 +559,12 @@ void StatsWeightCalculator::ApplyOverflowPenalty(Player* player)
             hit_current = player->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
             hit_current += player->GetTotalAuraModifier(SPELL_AURA_MOD_INCREASES_SPELL_PCT_TO_HIT); // suppression (18176)
             hit_current += player->GetRatingBonusValue(CR_HIT_SPELL);
+
+            if (cls == CLASS_PRIEST && tab == PRIEST_TAB_SHADOW && player->HasAura(15835)) // Shadow Focus
+                hit_current += 3;
+            if (cls == CLASS_MAGE && tab == MAGE_TAB_ARCANE && player->HasAura(12840)) // Arcane Focus
+                hit_current += 3;
+
             hit_overflow = SPELL_HIT_OVERFLOW;
             if (hit_overflow > hit_current)
                 validPoints = (hit_overflow - hit_current) / player->GetRatingMultiplier(CR_HIT_SPELL);

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -1583,7 +1583,7 @@ bool MovementAction::MoveAway(Unit* target, float distance, bool backwards)
 // just calculates average position of group and runs away from that position
 bool MovementAction::MoveFromGroup(float distance)
 {
-    LOG_ERROR("playerbots", "MovementAction::MoveFromGroup");
+    // LOG_ERROR("playerbots", "MovementAction::MoveFromGroup");
     //if (Player* master = botAI->GetMaster())
     //{
     //    return MoveAway(master);

--- a/src/strategy/raids/naxxramas/RaidNaxxActions.cpp
+++ b/src/strategy/raids/naxxramas/RaidNaxxActions.cpp
@@ -829,11 +829,6 @@ bool AnubrekhanPositionAction::Execute(Event event)
     {
         return false;
     }
-    auto* boss_ai = dynamic_cast<Anubrekhan::boss_anubrekhan::boss_anubrekhanAI*>(boss->GetAI());
-    if (!boss_ai)
-    {
-        return false;
-    }
     bool inPhase = botAI->HasAura("locust swarm", boss) || boss->GetCurrentSpell(CURRENT_GENERIC_SPELL);
     if (inPhase)
     {

--- a/src/strategy/triggers/GenericTriggers.cpp
+++ b/src/strategy/triggers/GenericTriggers.cpp
@@ -227,8 +227,7 @@ bool AoeTrigger::IsActive()
         Unit* unit = botAI->GetUnit(guid);
         if (!unit || !unit->IsAlive())
             continue;
-
-        if (unit->GetExactDist2d(current_target) <= range)
+        if (unit->GetDistance(current_target->GetPosition()) <= range)
         {
             attackers_count++;
         }


### PR DESCRIPTION
- More accurate distance calculation for whether enemy can be affected by AOE spell.
- Significantly reduce the spirit stat weight for paladin and shaman healer.
- Correctly calculate the spell hit rate overflow brought by some talents.
