### PR TITLE
This might fix the possible race condition

### DIFF
--- a/src/strategy/actions/LfgActions.cpp
+++ b/src/strategy/actions/LfgActions.cpp
@@ -226,6 +226,7 @@ bool LfgAcceptAction::Execute(Event event)
         {
             sRandomPlayerbotMgr->Refresh(bot);
             botAI->ResetStrategies();
+            // bot->TeleportToHomebind();
         }
 
         botAI->Reset();


### PR DESCRIPTION
Order Reversal: In both combat and non-combat paths, sLFGMgr->UpdateProposal() is called before clearing the "lfg proposal" ID. This prevents a new proposal from overwriting the ID before it's processed.

Clear ID in Combat Case: The combat case now clears the proposal ID after updating, avoiding reprocessing the same proposal.

Quickly tested, still works ok.

If OK, should be merged before https://github.com/liyunfan1223/mod-playerbots/pull/997