### PR TITLE
Disable Hire command

### DIFF
--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -108,7 +108,7 @@ public:
         creators["cdebug"] = &ChatTriggerContext::cdebug;
         creators["cs"] = &ChatTriggerContext::cs;
         creators["wts"] = &ChatTriggerContext::wts;
-        creators["hire"] = &ChatTriggerContext::hire;
+        // creators["hire"] = &ChatTriggerContext::hire;  // Not correctly implemented at this time, would cause crash and other issues.
         creators["craft"] = &ChatTriggerContext::craft;
         creators["flag"] = &ChatTriggerContext::craft;
         creators["range"] = &ChatTriggerContext::range;


### PR DESCRIPTION
Not correctly implemented at this time, will cause crash and other issues, as it would change the bot to the requester's account.