### PR TITLE
Auto do quest feature (new rpg strategy)

### DIFF
--- a/src/LootObjectStack.cpp
+++ b/src/LootObjectStack.cpp
@@ -9,7 +9,7 @@
 #include "Playerbots.h"
 #include "Unit.h"
 
-#define MAX_LOOT_OBJECT_COUNT 10
+#define MAX_LOOT_OBJECT_COUNT 200
 
 LootTarget::LootTarget(ObjectGuid guid) : guid(guid), asOfTime(time(nullptr)) {}
 

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -15,9 +15,11 @@
 #include "ChannelMgr.h"
 #include "CharacterPackets.h"
 #include "CreatureAIImpl.h"
+#include "CreatureData.h"
 #include "EmoteAction.h"
 #include "Engine.h"
 #include "ExternalEventHelper.h"
+#include "GameObjectData.h"
 #include "GameTime.h"
 #include "GuildMgr.h"
 #include "GuildTaskMgr.h"
@@ -32,6 +34,7 @@
 #include "MoveSplineInit.h"
 #include "NewRpgStrategy.h"
 #include "ObjectGuid.h"
+#include "ObjectMgr.h"
 #include "PerformanceMonitor.h"
 #include "Player.h"
 #include "PlayerbotAIConfig.h"
@@ -2291,6 +2294,37 @@ std::string PlayerbotAI::GetLocalizedAreaName(const AreaTableEntry* entry)
         return entry->area_name[sWorld->GetDefaultDbcLocale()];
 
     return "";
+}
+
+std::string PlayerbotAI::GetLocalizedCreatureName(uint32 entry)
+{
+    std::string name;
+    const CreatureLocale* cl = sObjectMgr->GetCreatureLocale(entry);
+    if (cl)
+        ObjectMgr::GetLocaleString(cl->Name, sWorld->GetDefaultDbcLocale(), name);
+    if (name.empty())
+    {
+        CreatureTemplate const* ct = sObjectMgr->GetCreatureTemplate(entry);
+        if (ct)
+            name = ct->Name;
+    }
+    return name;
+}
+
+
+std::string PlayerbotAI::GetLocalizedGameObjectName(uint32 entry)
+{
+    std::string name;
+    const GameObjectLocale* gl = sObjectMgr->GetGameObjectLocale(entry);
+    if (gl)
+        ObjectMgr::GetLocaleString(gl->Name, sWorld->GetDefaultDbcLocale(), name);
+    if (name.empty())
+    {
+        GameObjectTemplate const* gt = sObjectMgr->GetGameObjectTemplate(entry);
+        if (gt)
+            name = gt->name;
+    }
+    return name;
 }
 
 std::vector<Player*> PlayerbotAI::GetPlayersInGroup()

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -208,7 +208,7 @@ PlayerbotAI::PlayerbotAI(Player* bot)
     masterIncomingPacketHandlers.AddHandler(CMSG_PUSHQUESTTOPARTY, "quest share");
     botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_COMPLETE, "quest update complete");
     botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_ADD_KILL, "quest update add kill");
-    botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_ADD_ITEM, "quest update add item");
+    // botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_ADD_ITEM, "quest update add item"); // SMSG_QUESTUPDATE_ADD_ITEM no longer used
     botOutgoingPacketHandlers.AddHandler(SMSG_QUEST_CONFIRM_ACCEPT, "confirm quest");
 }
 

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -14,6 +14,7 @@
 #include "BudgetValues.h"
 #include "ChannelMgr.h"
 #include "CharacterPackets.h"
+#include "Common.h"
 #include "CreatureAIImpl.h"
 #include "CreatureData.h"
 #include "EmoteAction.h"
@@ -2290,10 +2291,15 @@ const AreaTableEntry* PlayerbotAI::GetCurrentZone()
 
 std::string PlayerbotAI::GetLocalizedAreaName(const AreaTableEntry* entry)
 {
+    std::string name;
     if (entry)
-        return entry->area_name[sWorld->GetDefaultDbcLocale()];
+    {
+        name = entry->area_name[sWorld->GetDefaultDbcLocale()];
+        if (name.empty())
+            name = entry->area_name[LOCALE_enUS];
+    }
 
-    return "";
+    return name;
 }
 
 std::string PlayerbotAI::GetLocalizedCreatureName(uint32 entry)

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -15,6 +15,7 @@
 #include "Common.h"
 #include "Event.h"
 #include "Item.h"
+#include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
 #include "PlayerbotAIBase.h"
 #include "PlayerbotAIConfig.h"
@@ -579,6 +580,7 @@ public:
     static bool IsHealingSpell(uint32 spellFamilyName, flag96 spelFalimyFlags);
     static SpellFamilyNames Class2SpellFamilyName(uint8 cls);
     NewRpgInfo rpgInfo;
+    NewRpgStatistic rpgStatistic;
 
 private:
     static void _fillGearScoreData(Player* player, Item* item, std::vector<uint32>* gearScore, uint32& twoHandScore,

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -13,6 +13,7 @@
 #include "ChatFilter.h"
 #include "ChatHelper.h"
 #include "Common.h"
+#include "CreatureData.h"
 #include "Event.h"
 #include "Item.h"
 #include "NewRpgInfo.h"
@@ -436,7 +437,8 @@ public:
     const AreaTableEntry* GetCurrentArea();
     const AreaTableEntry* GetCurrentZone();
     static std::string GetLocalizedAreaName(const AreaTableEntry* entry);
-
+    static std::string GetLocalizedCreatureName(uint32 entry);
+    static std::string GetLocalizedGameObjectName(uint32 entry);
     bool TellMaster(std::ostringstream& stream, PlayerbotSecurityLevel securityLevel = PLAYERBOT_SECURITY_ALLOW_ALL);
     bool TellMaster(std::string const text, PlayerbotSecurityLevel securityLevel = PLAYERBOT_SECURITY_ALLOW_ALL);
     bool TellMasterNoFacing(std::ostringstream& stream,

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -583,6 +583,7 @@ public:
     static SpellFamilyNames Class2SpellFamilyName(uint8 cls);
     NewRpgInfo rpgInfo;
     NewRpgStatistic rpgStatistic;
+    std::unordered_set<uint32> lowPriorityQuest;
 
 private:
     static void _fillGearScoreData(Player* player, Item* item, std::vector<uint32>* gearScore, uint32& twoHandScore,

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2860,7 +2860,7 @@ void RandomPlayerbotMgr::PrintStats()
         // LOG_INFO("playerbots", "    GO_INNKEEPER: {}", rpgStatusCount[RPG_GO_INNKEEPER]);
         // LOG_INFO("playerbots", "    NEAR_RANDOM: {}", rpgStatusCount[RPG_NEAR_RANDOM]);
         // LOG_INFO("playerbots", "    NEAR_NPC: {}", rpgStatusCount[RPG_NEAR_NPC]);
-        LOG_INFO("playerbots", "Bots quest:");
+        LOG_INFO("playerbots", "Bots total quests:");
         LOG_INFO("playerbots", "    Accepted: {}, Completed: {}, Rewarded: {}, Dropped: {}",
             rpgStasticTotal.questAccepted, rpgStasticTotal.questCompleted, rpgStasticTotal.questRewarded, rpgStasticTotal.questDropped);
     }

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1458,6 +1458,82 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
               tlocs.size());
 }
 
+void RandomPlayerbotMgr::PrepareZone2LevelBracket()
+{
+    // Classic WoW - Low - level zones
+    zone2LevelBracket[1] = {5, 12}; // Dun Morogh
+    zone2LevelBracket[12] = {5, 12}; // Elwynn Forest
+    zone2LevelBracket[14] = {5, 12}; // Durotar
+    zone2LevelBracket[85] = {5, 12}; // Tirisfal Glades
+    zone2LevelBracket[141] = {5, 12}; // Teldrassil
+    zone2LevelBracket[215] = {5, 12}; // Mulgore
+    zone2LevelBracket[3430] = {5, 12}; // Eversong Woods
+    zone2LevelBracket[3524] = {5, 12}; // Azuremyst Isle
+
+    // Classic WoW - Mid - level zones
+    zone2LevelBracket[17] = {10, 25}; // Barrens
+    zone2LevelBracket[38] = {10, 20}; // Loch Modan
+    zone2LevelBracket[40] = {10, 21}; // Westfall
+    zone2LevelBracket[130] = {10, 23}; // Silverpine Forest
+    zone2LevelBracket[148] = {10, 21}; // Darkshore
+    zone2LevelBracket[3433] = {10, 22}; // Ghostlands
+    zone2LevelBracket[3525] = {10, 21}; // Bloodmyst Isle
+
+    // Classic WoW - High - level zones
+    zone2LevelBracket[10] = {19, 33}; // Deadwind Pass
+    zone2LevelBracket[11] = {21, 30}; // Wetlands
+    zone2LevelBracket[44] = {16, 28}; // Redridge Mountains
+    zone2LevelBracket[267] = {20, 34}; // Hillsbrad Foothills
+    zone2LevelBracket[331] = {18, 33}; // Ashenvale
+    zone2LevelBracket[400] = {24, 36}; // Thousand Needles
+    zone2LevelBracket[406] = {16, 29}; // Stonetalon Mountains
+
+    // Classic WoW - Higher - level zones
+    zone2LevelBracket[3] = {36, 46}; // Badlands
+    zone2LevelBracket[8] = {36, 46}; // Swamp of Sorrows
+    zone2LevelBracket[15] = {35, 46}; // Dustwallow Marsh
+    zone2LevelBracket[16] = {45, 52}; // Azshara
+    zone2LevelBracket[33] = {32, 47}; // Stranglethorn Vale
+    zone2LevelBracket[45] = {30, 42}; // Arathi Highlands
+    zone2LevelBracket[47] = {42, 51}; // Hinterlands
+    zone2LevelBracket[51] = {45, 51}; // Searing Gorge
+    zone2LevelBracket[357] = {40, 52}; // Feralas
+    zone2LevelBracket[405] = {30, 41}; // Desolace
+    zone2LevelBracket[440] = {41, 52}; // Tanaris
+
+    // Classic WoW - Top - level zones
+    zone2LevelBracket[4] = {52, 57}; // Blasted Lands
+    zone2LevelBracket[28] = {50, 60}; // Western Plaguelands
+    zone2LevelBracket[46] = {51, 60}; // Burning Steppes
+    zone2LevelBracket[139] = {54, 62}; // Eastern Plaguelands
+    zone2LevelBracket[361] = {47, 57}; // Felwood
+    zone2LevelBracket[490] = {49, 56}; // Un'Goro Crater
+    zone2LevelBracket[618] = {54, 61}; // Winterspring
+    zone2LevelBracket[1377] = {54, 63}; // Silithus
+
+    // The Burning Crusade - Zones
+    zone2LevelBracket[3483] = {56, 66}; // Hellfire Peninsula
+    zone2LevelBracket[3518] = {64, 70}; // Nagrand
+    zone2LevelBracket[3519] = {62, 73}; // Terokkar Forest
+    zone2LevelBracket[3520] = {66, 73}; // Shadowmoon Valley
+    zone2LevelBracket[3521] = {60, 67}; // Zangarmarsh
+    zone2LevelBracket[3522] = {64, 73}; // Blade's Edge Mountains
+    zone2LevelBracket[3523] = {67, 73}; // Netherstorm
+    zone2LevelBracket[4080] = {68, 73}; // Isle of Quel'Danas
+
+    // Wrath of the Lich King - Zones
+    zone2LevelBracket[65] = {71, 77}; // Dragonblight
+    zone2LevelBracket[66] = {74, 80}; // Zul'Drak
+    zone2LevelBracket[67] = {77, 80}; // Storm Peaks
+    zone2LevelBracket[210] = {77, 80}; // Icecrown Glacier
+    zone2LevelBracket[394] = {72, 78}; // Grizzly Hills
+    zone2LevelBracket[495] = {68, 74}; // Howling Fjord
+    zone2LevelBracket[2817] = {77, 80}; // Crystalsong Forest
+    zone2LevelBracket[3537] = {68, 75}; // Borean Tundra
+    zone2LevelBracket[3711] = {75, 80}; // Sholazar Basin
+    zone2LevelBracket[4197] = {79, 80}; // Wintergrasp
+}
+
 void RandomPlayerbotMgr::PrepareTeleportCache()
 {
     uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
@@ -1534,6 +1610,7 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
 
     if (sPlayerbotAIConfig->enableNewRpgStrategy)
     {
+        PrepareZone2LevelBracket();
         LOG_INFO("playerbots", "Preparing innkeepers locations for level...");
         results = WorldDatabase.Query(
         "SELECT "
@@ -1578,28 +1655,7 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
                 uint32 level = area->area_level;
                 for (int i = 5; i <= maxLevel; i++)
                 {
-                    std::vector<WorldLocation>& locs = locsPerLevelCache[i];
-                    int counter = 0;
-                    WorldLocation levelLoc;
-                    for (auto& checkLoc : locs)
-                    {
-                        if (loc.GetMapId() != checkLoc.GetMapId())
-                            continue;
-                        
-                        if (loc.GetExactDist(checkLoc) > 1500.0f)
-                            continue;
-                        
-                        if (zoneId != 
-                            map->GetZoneId(1, checkLoc.GetPositionX(), checkLoc.GetPositionY(), checkLoc.GetPositionZ()))
-                            continue;
-
-                        counter++;
-                        levelLoc = checkLoc;
-                        if (counter >= 15)
-                            break;
-                    }
-
-                    if (counter < 15)
+                    if (zone2LevelBracket.find(zoneId) == zone2LevelBracket.end() || !zone2LevelBracket[zoneId].InsideBracket(i))
                         continue;
 
                     if (!(entry->hostileMask & 4))
@@ -1610,11 +1666,26 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
                     {
                         allianceStarterPerLevelCache[i].push_back(loc);
                     }
-                    LOG_DEBUG("playerbots", "Area: {} Level: {} creature_entry: {} add to: {} {}({},{},{},{})", area->ID,
-                            level, c_entry, i, counter, levelLoc.GetPositionX(), levelLoc.GetPositionY(),
-                            levelLoc.GetPositionZ(), levelLoc.GetMapId());
+                    // if (!zone2LevelBracket[zoneId].low)
+                    //     zone2LevelBracket[zoneId].low = i;
+                    // else
+                    //     zone2LevelBracket[zoneId].low = std::min(zone2LevelBracket[zoneId].low, (uint32)i);
+                    // if (!zone2LevelBracket[zoneId].high)
+                    //     zone2LevelBracket[zoneId].high = i;
+                    // else
+                    //     zone2LevelBracket[zoneId].high = std::max(zone2LevelBracket[zoneId].high, (uint32)i);
+                    // LOG_DEBUG("playerbots", "Area: {} Level: {} creature_entry: {} add to: {} {}({},{},{},{})", area->ID,
+                    //         level, c_entry, i, counter, levelLoc.GetPositionX(), levelLoc.GetPositionY(),
+                    //         levelLoc.GetPositionZ(), levelLoc.GetMapId());
                 }
             } while (results->NextRow());
+        }
+
+        for (auto item : zone2LevelBracket)
+        {
+            const AreaTableEntry* entry = sAreaTableStore.LookupEntry(item.first);
+            std::string zone_name = PlayerbotAI::GetLocalizedAreaName(entry);
+            LOG_INFO("playerbots", "Zone: {} ({}) [{}, {}]", item.first, zone_name, item.second.low, item.second.high);
         }
         // add all initial position
         for (uint32 i = 1; i < MAX_RACES; i++)
@@ -1763,6 +1834,10 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
     if (bot->InBattleground())
         return;
 
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (botAI && botAI->HasPlayerNearby(300.0f))
+        return;
+    
     uint32 level = bot->GetLevel();
     uint8 race = bot->getRace();
     std::vector<WorldLocation>* locs = nullptr;
@@ -1785,6 +1860,10 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
 void RandomPlayerbotMgr::RandomTeleportGrindForLevel(Player* bot)
 {
     if (bot->InBattleground())
+        return;
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (botAI && botAI->HasPlayerNearby(300.0f))
         return;
 
     uint32 level = bot->GetLevel();

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2861,8 +2861,8 @@ void RandomPlayerbotMgr::PrintStats()
         // LOG_INFO("playerbots", "    NEAR_RANDOM: {}", rpgStatusCount[RPG_NEAR_RANDOM]);
         // LOG_INFO("playerbots", "    NEAR_NPC: {}", rpgStatusCount[RPG_NEAR_NPC]);
         LOG_INFO("playerbots", "Bots total quests:");
-        LOG_INFO("playerbots", "    Accepted: {}, Completed: {}, Rewarded: {}, Dropped: {}",
-            rpgStasticTotal.questAccepted, rpgStasticTotal.questCompleted, rpgStasticTotal.questRewarded, rpgStasticTotal.questDropped);
+        LOG_INFO("playerbots", "    Accepted: {}, Rewarded: {}, Dropped: {}",
+            rpgStasticTotal.questAccepted, rpgStasticTotal.questRewarded, rpgStasticTotal.questDropped);
     }
 
     LOG_INFO("playerbots", "Bots engine:", dead);

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1818,10 +1818,6 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
     if (bot->InBattleground())
         return;
 
-    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-    if (botAI && botAI->HasPlayerNearby(300.0f))
-        return;
-    
     uint32 level = bot->GetLevel();
     uint8 race = bot->getRace();
     std::vector<WorldLocation>* locs = nullptr;
@@ -1844,10 +1840,6 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
 void RandomPlayerbotMgr::RandomTeleportGrindForLevel(Player* bot)
 {
     if (bot->InBattleground())
-        return;
-
-    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-    if (botAI && botAI->HasPlayerNearby(300.0f))
         return;
 
     uint32 level = bot->GetLevel();

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -371,7 +371,7 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
             sRandomPlayerbotMgr->CheckLfgQueue();
     }
 
-    if (time(nullptr) > (printStatsTimer + 300))
+    if (sPlayerbotAIConfig->randomBotAutologin && time(nullptr) > (printStatsTimer + 300))
     {
         if (!printStatsTimer)
         {
@@ -1513,7 +1513,7 @@ void RandomPlayerbotMgr::PrepareZone2LevelBracket()
     zone2LevelBracket[1377] = {54, 63}; // Silithus
 
     // The Burning Crusade - Zones
-    zone2LevelBracket[3483] = {56, 66}; // Hellfire Peninsula
+    zone2LevelBracket[3483] = {58, 66}; // Hellfire Peninsula
     zone2LevelBracket[3518] = {64, 70}; // Nagrand
     zone2LevelBracket[3519] = {62, 73}; // Terokkar Forest
     zone2LevelBracket[3520] = {66, 73}; // Shadowmoon Valley

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1667,27 +1667,10 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
                     {
                         allianceStarterPerLevelCache[i].push_back(loc);
                     }
-                    // if (!zone2LevelBracket[zoneId].low)
-                    //     zone2LevelBracket[zoneId].low = i;
-                    // else
-                    //     zone2LevelBracket[zoneId].low = std::min(zone2LevelBracket[zoneId].low, (uint32)i);
-                    // if (!zone2LevelBracket[zoneId].high)
-                    //     zone2LevelBracket[zoneId].high = i;
-                    // else
-                    //     zone2LevelBracket[zoneId].high = std::max(zone2LevelBracket[zoneId].high, (uint32)i);
-                    // LOG_DEBUG("playerbots", "Area: {} Level: {} creature_entry: {} add to: {} {}({},{},{},{})", area->ID,
-                    //         level, c_entry, i, counter, levelLoc.GetPositionX(), levelLoc.GetPositionY(),
-                    //         levelLoc.GetPositionZ(), levelLoc.GetMapId());
                 }
             } while (results->NextRow());
         }
 
-        for (auto item : zone2LevelBracket)
-        {
-            const AreaTableEntry* entry = sAreaTableStore.LookupEntry(item.first);
-            std::string zone_name = PlayerbotAI::GetLocalizedAreaName(entry);
-            // LOG_INFO("playerbots", "Zone: {} ({}) [{}, {}]", item.first, zone_name, item.second.low, item.second.high);
-        }
         // add all initial position
         for (uint32 i = 1; i < MAX_RACES; i++)
         {
@@ -2853,13 +2836,7 @@ void RandomPlayerbotMgr::PrintStats()
         LOG_INFO("playerbots", "    Idle: {}, Rest: {}, GoGrind: {}, GoInnkeeper: {}, MoveRandom: {}, MoveNpc: {}, DoQuest: {}",
             rpgStatusCount[RPG_IDLE], rpgStatusCount[RPG_REST], rpgStatusCount[RPG_GO_GRIND], rpgStatusCount[RPG_GO_INNKEEPER],
             rpgStatusCount[RPG_NEAR_RANDOM], rpgStatusCount[RPG_NEAR_NPC], rpgStatusCount[RPG_DO_QUEST]);
-            
-        // LOG_INFO("playerbots", "    IDLE: {}", rpgStatusCount[RPG_IDLE]);
-        // LOG_INFO("playerbots", "    REST: {}", rpgStatusCount[RPG_REST]);
-        // LOG_INFO("playerbots", "    GO_GRIND: {}", rpgStatusCount[RPG_GO_GRIND]);
-        // LOG_INFO("playerbots", "    GO_INNKEEPER: {}", rpgStatusCount[RPG_GO_INNKEEPER]);
-        // LOG_INFO("playerbots", "    NEAR_RANDOM: {}", rpgStatusCount[RPG_NEAR_RANDOM]);
-        // LOG_INFO("playerbots", "    NEAR_NPC: {}", rpgStatusCount[RPG_NEAR_NPC]);
+
         LOG_INFO("playerbots", "Bots total quests:");
         LOG_INFO("playerbots", "    Accepted: {}, Rewarded: {}, Dropped: {}",
             rpgStasticTotal.questAccepted, rpgStasticTotal.questRewarded, rpgStasticTotal.questDropped);

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1628,8 +1628,7 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
         "position_y, "
         "position_z, "
         "orientation, "
-        "t.faction, "
-        "t.entry "
+        "t.faction "
         "FROM "
         "creature c "
         "INNER JOIN creature_template t on c.id1 = t.entry "
@@ -1651,7 +1650,6 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
                 float z = fields[3].Get<float>();
                 float orient = fields[4].Get<float>();
                 uint32 faction = fields[5].Get<uint32>();
-                uint32 c_entry = fields[6].Get<uint32>();
                 const FactionTemplateEntry* entry = sFactionTemplateStore.LookupEntry(faction);
 
                 WorldLocation loc(mapId, x + cos(orient) * 5.0f, y + sin(orient) * 5.0f, z + 0.5f, orient + M_PI);
@@ -1659,14 +1657,13 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
                 Map* map = sMapMgr->FindMap(loc.GetMapId(), 0);
                 if (!map)
                     continue;
-                const AreaTableEntry* area = sAreaTableStore.LookupEntry(map->GetAreaId(1, x, y, z));
+                const AreaTableEntry* area = sAreaTableStore.LookupEntry(map->GetAreaId(PHASEMASK_NORMAL, x, y, z));
                 uint32 zoneId = area->zone ? area->zone : area->ID;
-                uint32 level = area->area_level;
-                for (int i = 5; i <= maxLevel; i++)
+                if (zone2LevelBracket.find(zoneId) == zone2LevelBracket.end())
+                    continue;
+                LevelBracket bracket = zone2LevelBracket[zoneId];
+                for (int i = bracket.low; i <= bracket.high; i++)
                 {
-                    if (zone2LevelBracket.find(zoneId) == zone2LevelBracket.end() || !zone2LevelBracket[zoneId].InsideBracket(i))
-                        continue;
-
                     if (!(entry->hostileMask & 4))
                     {
                         hordeStarterPerLevelCache[i].push_back(loc);

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1686,7 +1686,7 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
         {
             const AreaTableEntry* entry = sAreaTableStore.LookupEntry(item.first);
             std::string zone_name = PlayerbotAI::GetLocalizedAreaName(entry);
-            LOG_INFO("playerbots", "Zone: {} ({}) [{}, {}]", item.first, zone_name, item.second.low, item.second.high);
+            // LOG_INFO("playerbots", "Zone: {} ({}) [{}, {}]", item.first, zone_name, item.second.low, item.second.high);
         }
         // add all initial position
         for (uint32 i = 1; i < MAX_RACES; i++)

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -171,12 +171,19 @@ public:
     static uint8 GetTeamClassIdx(bool isAlliance, uint8 claz) { return isAlliance * 20 + claz; }
 
     void PrepareAddclassCache();
+    void PrepareZone2LevelBracket();
     void PrepareTeleportCache();
     void Init();
     std::map<uint8, std::unordered_set<ObjectGuid>> addclassCache;
     std::map<uint8, std::vector<WorldLocation>> locsPerLevelCache;
     std::map<uint8, std::vector<WorldLocation>> allianceStarterPerLevelCache;
     std::map<uint8, std::vector<WorldLocation>> hordeStarterPerLevelCache;
+    struct LevelBracket {
+        uint32 low;
+        uint32 high;
+        bool InsideBracket(uint32 val) { return val >= low && val <= high; }
+    };
+    std::map<uint32, LevelBracket> zone2LevelBracket;
     std::map<uint8, std::vector<WorldLocation>> bankerLocsPerLevelCache;
 protected:
     void OnBotLoginInternal(Player* const bot) override;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -960,13 +960,8 @@ void PlayerbotFactory::ResetQuests()
         // remove all quest entries for 'entry' from quest log
         for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
         {
-            uint32 quest = bot->GetQuestSlotQuestId(slot);
-            if (quest == entry)
-            {
-                bot->SetQuestSlot(slot, 0);
-            }
+            bot->SetQuestSlot(slot, 0);
         }
-
         // reset rewarded for restart repeatable quest
         bot->getQuestStatusMap().erase(entry);
         // bot->getQuestStatusMap()[entry].m_rewarded = false;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1585,7 +1585,8 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             continue;
 
         if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
-            (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST))
+            (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
+            (slot != EQUIPMENT_SLOT_RANGED))
             continue;
 
         Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1584,6 +1584,10 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
             continue;
 
+        if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
+            (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST))
+            continue;
+
         Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
 
         if (second_chance && oldItem)
@@ -1753,6 +1757,10 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                 continue;
 
             if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
+                continue;
+            
+            if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
+                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST))
                 continue;
 
             if (Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -31,6 +31,7 @@
 #include "PlayerbotAIConfig.h"
 #include "PlayerbotDbStore.h"
 #include "Playerbots.h"
+#include "QuestDef.h"
 #include "RandomItemMgr.h"
 #include "RandomPlayerbotFactory.h"
 #include "ReputationMgr.h"
@@ -974,25 +975,23 @@ void PlayerbotFactory::ClearSpells()
 
 void PlayerbotFactory::ResetQuests()
 {
+    for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
+    {
+        bot->SetQuestSlot(slot, 0);
+    }
     ObjectMgr::QuestMap const& questTemplates = sObjectMgr->GetQuestTemplates();
     for (ObjectMgr::QuestMap::const_iterator i = questTemplates.begin(); i != questTemplates.end(); ++i)
     {
         Quest const* quest = i->second;
 
         uint32 entry = quest->GetQuestId();
+        if (bot->GetQuestStatus(entry) == QUEST_STATUS_NONE)
+            continue;
+        
+        bot->RemoveRewardedQuest(entry);
+        bot->RemoveActiveQuest(entry, false);
 
-        // remove all quest entries for 'entry' from quest log
-        for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
-        {
-            bot->SetQuestSlot(slot, 0);
-        }
-        // reset rewarded for restart repeatable quest
-        bot->getQuestStatusMap().erase(entry);
-        // bot->getQuestStatusMap()[entry].m_rewarded = false;
-        // bot->getQuestStatusMap()[entry].m_status = QUEST_STATUS_NONE;
     }
-    // bot->UpdateForQuestWorldObjects();
-    CharacterDatabase.Execute("DELETE FROM character_queststatus WHERE guid = {}", bot->GetGUID().GetCounter());
 }
 
 void PlayerbotFactory::InitSpells() { InitAvailableSpells(); }

--- a/src/strategy/actions/AcceptQuestAction.cpp
+++ b/src/strategy/actions/AcceptQuestAction.cpp
@@ -87,7 +87,7 @@ bool AcceptQuestAction::Execute(Event event)
     {
         std::stringstream ss;
         ss << "AcceptQuestAction [" << qInfo->GetTitle() << "] - [" << std::to_string(qInfo->GetQuestId()) << "]";
-        LOG_INFO("playerbots", "{}", ss.str().c_str());
+        LOG_DEBUG("playerbots", "{}", ss.str().c_str());
         // botAI->TellMaster(ss.str());
     }
 

--- a/src/strategy/actions/ActionContext.h
+++ b/src/strategy/actions/ActionContext.h
@@ -247,6 +247,7 @@ public:
         creators["new rpg go innkeeper"] = &ActionContext::new_rpg_go_innkeeper;
         creators["new rpg move random"] = &ActionContext::new_rpg_move_random;
         creators["new rpg move npc"] = &ActionContext::new_rpg_move_npc;
+        creators["new rpg do quest"] = &ActionContext::new_rpg_do_quest;
     }
 
 private:
@@ -428,6 +429,7 @@ private:
     static Action* new_rpg_go_innkeeper(PlayerbotAI* ai) { return new NewRpgGoInnKeeperAction(ai); }
     static Action* new_rpg_move_random(PlayerbotAI* ai) { return new NewRpgMoveRandomAction(ai); }
     static Action* new_rpg_move_npc(PlayerbotAI* ai) { return new NewRpgMoveNpcAction(ai); }
+    static Action* new_rpg_do_quest(PlayerbotAI* ai) { return new NewRpgDoQuestAction(ai); }
 };
 
 #endif

--- a/src/strategy/actions/AddLootAction.cpp
+++ b/src/strategy/actions/AddLootAction.cpp
@@ -46,7 +46,7 @@ bool AddAllLootAction::AddLoot(ObjectGuid guid) { return AI_VALUE(LootObjectStac
 bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
 {
     LootObject loot(bot, guid);
-    // botAI->TellMasterNoFacing("guid: " + std::to_string(guid.GetCounter()));
+    
     WorldObject* wo = loot.GetWorldObject(bot);
     if (loot.IsEmpty() || !wo)
         return false;
@@ -56,6 +56,5 @@ bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
 
     if (!loot.IsLootPossible(bot))
         return false;
-    // botAI->TellMasterNoFacing("Add loot! " + std::to_string(guid.GetCounter()));
     return AddAllLootAction::AddLoot(guid);
 }

--- a/src/strategy/actions/AddLootAction.cpp
+++ b/src/strategy/actions/AddLootAction.cpp
@@ -46,7 +46,7 @@ bool AddAllLootAction::AddLoot(ObjectGuid guid) { return AI_VALUE(LootObjectStac
 bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
 {
     LootObject loot(bot, guid);
-
+    // botAI->TellMasterNoFacing("guid: " + std::to_string(guid.GetCounter()));
     WorldObject* wo = loot.GetWorldObject(bot);
     if (loot.IsEmpty() || !wo)
         return false;
@@ -56,6 +56,6 @@ bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
 
     if (!loot.IsLootPossible(bot))
         return false;
-
+    // botAI->TellMasterNoFacing("Add loot! " + std::to_string(guid.GetCounter()));
     return AddAllLootAction::AddLoot(guid);
 }

--- a/src/strategy/actions/AddLootAction.cpp
+++ b/src/strategy/actions/AddLootAction.cpp
@@ -46,7 +46,7 @@ bool AddAllLootAction::AddLoot(ObjectGuid guid) { return AI_VALUE(LootObjectStac
 bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
 {
     LootObject loot(bot, guid);
-    
+
     WorldObject* wo = loot.GetWorldObject(bot);
     if (loot.IsEmpty() || !wo)
         return false;
@@ -56,5 +56,6 @@ bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
 
     if (!loot.IsLootPossible(bot))
         return false;
+
     return AddAllLootAction::AddLoot(guid);
 }

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -90,6 +90,7 @@ public:
         creators["log"] = &ChatActionContext::log;
         creators["los"] = &ChatActionContext::los;
         creators["rpg status"] = &ChatActionContext::rpg_status;
+        creators["rpg do quest"] = &ChatActionContext::rpg_do_quest;
         creators["aura"] = &ChatActionContext::aura;
         creators["drop"] = &ChatActionContext::drop;
         creators["clean quest log"] = &ChatActionContext::clean_quest_log;
@@ -261,6 +262,7 @@ private:
     static Action* log(PlayerbotAI* botAI) { return new LogLevelAction(botAI); }
     static Action* los(PlayerbotAI* botAI) { return new TellLosAction(botAI); }
     static Action* rpg_status(PlayerbotAI* botAI) { return new TellRpgStatusAction(botAI); }
+    static Action* rpg_do_quest(PlayerbotAI* botAI) { return new StartRpgDoQuestAction(botAI); }
     static Action* aura(PlayerbotAI* ai) { return new TellAuraAction(ai); }
     static Action* ll(PlayerbotAI* botAI) { return new LootStrategyAction(botAI); }
     static Action* ss(PlayerbotAI* botAI) { return new SkipSpellsListAction(botAI); }

--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -48,14 +48,6 @@ bool AttackAnythingAction::isUseful()
     if (!target)
         return false;
 
-    bool inactiveGrindStatus = botAI->rpgInfo.status == NewRpgStatus::GO_GRIND ||
-                               botAI->rpgInfo.status == NewRpgStatus::NEAR_NPC ||
-                               botAI->rpgInfo.status == NewRpgStatus::REST ||
-                               botAI->rpgInfo.status == NewRpgStatus::GO_INNKEEPER;
-
-    if (inactiveGrindStatus && bot->GetDistance(target) > 25.0f)
-        return false;
-
     std::string const name = std::string(target->GetName());
     // Check for invalid targets: Dummy, Charge Target, Melee Target, Ranged Target
     if (!name.empty() &&

--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -34,14 +34,11 @@ bool AttackAnythingAction::isUseful()
     if (!botAI->AllowActivity(GRIND_ACTIVITY))  // Bot not allowed to be active
         return false;
 
-    if (!AI_VALUE(bool, "can move around"))
+    if (botAI->HasStrategy("stay", BOT_STATE_NON_COMBAT))
         return false;
-    
-        
-    // if (context->GetValue<TravelTarget*>("travel target")->Get()->isTraveling() &&
-    //     ChooseRpgTargetAction::isFollowValid(
-    //         bot, *context->GetValue<TravelTarget*>("travel target")->Get()->getPosition()))  // Bot is traveling
-    //     return false;
+
+    if (bot->IsInCombat())
+        return false;
 
     Unit* target = GetTarget();
 

--- a/src/strategy/actions/DropQuestAction.cpp
+++ b/src/strategy/actions/DropQuestAction.cpp
@@ -132,6 +132,7 @@ bool CleanQuestLogAction::Execute(Event event)
             }
 
             // Remove quest
+            botAI->rpgStatistic.questDropped++;
             bot->SetQuestSlot(slot, 0);
             bot->TakeQuestSourceItem(questId, false);
             bot->SetQuestStatus(questId, QUEST_STATUS_NONE);

--- a/src/strategy/actions/QuestAction.cpp
+++ b/src/strategy/actions/QuestAction.cpp
@@ -260,6 +260,7 @@ bool QuestAction::AcceptQuest(Quest const* quest, ObjectGuid questGiver)
 
 bool QuestUpdateCompleteAction::Execute(Event event)
 {
+    // the action can hardly be triggered
     WorldPacket p(event.getPacket());
     p.rpos(0);
 
@@ -272,18 +273,21 @@ bool QuestUpdateCompleteAction::Execute(Event event)
     Quest const* qInfo = sObjectMgr->GetQuestTemplate(questId);
     if (qInfo)
     {
-        std::map<std::string, std::string> placeholders;
+        // std::map<std::string, std::string> placeholders;
+        // placeholders["%quest_link"] = format;
+        
+        // if (botAI->HasStrategy("debug quest", BotState::BOT_STATE_NON_COMBAT) || botAI->HasStrategy("debug rpg", BotState::BOT_STATE_COMBAT))
+        // {
+            //     LOG_INFO("playerbots", "{} => Quest [ {} ] completed", bot->GetName(), qInfo->GetTitle());
+            //     bot->Say("Quest [ " + format + " ] completed", LANG_UNIVERSAL);
+            // }
         const auto format = ChatHelper::FormatQuest(qInfo);
-        placeholders["%quest_link"] = format;
-
-        if (botAI->HasStrategy("debug quest", BotState::BOT_STATE_NON_COMBAT) || botAI->HasStrategy("debug rpg", BotState::BOT_STATE_COMBAT))
-        {
-            LOG_INFO("playerbots", "{} => Quest [ {} ] completed", bot->GetName(), qInfo->GetTitle());
-            bot->Say("Quest [ " + format + " ] completed", LANG_UNIVERSAL);
-        }
-        botAI->TellMasterNoFacing("Quest completed " + format);
+        if (botAI->GetMaster())
+            botAI->TellMasterNoFacing("Quest completed " + format);
         BroadcastHelper::BroadcastQuestUpdateComplete(botAI, bot, qInfo);
         botAI->rpgStatistic.questCompleted++;
+        // LOG_DEBUG("playerbots", "[New rpg] {} complete quest {}", bot->GetName(), qInfo->GetQuestId());
+        // botAI->rpgStatistic.questCompleted++;
     }
 
     return true;

--- a/src/strategy/actions/QuestAction.cpp
+++ b/src/strategy/actions/QuestAction.cpp
@@ -9,6 +9,7 @@
 #include "Chat.h"
 #include "ChatHelper.h"
 #include "Event.h"
+#include "ObjectMgr.h"
 #include "Playerbots.h"
 #include "ReputationMgr.h"
 #include "ServerFacade.h"
@@ -311,9 +312,10 @@ bool QuestUpdateAddKillAction::Execute(Event event)
         const GameObjectTemplate* info = sObjectMgr->GetGameObjectTemplate(entry);
         if (info)
         {
-            BroadcastHelper::BroadcastQuestUpdateAddKill(botAI, bot, qInfo, available, required, info->name);
+            std::string infoName = botAI->GetLocalizedGameObjectName(entry);
+            BroadcastHelper::BroadcastQuestUpdateAddKill(botAI, bot, qInfo, available, required, infoName);
             std::ostringstream out;
-            out << info->name << " " << available << "/" << required << " " << ChatHelper::FormatQuest(qInfo);
+            out << infoName << " " << available << "/" << required << " " << ChatHelper::FormatQuest(qInfo);
             botAI->TellMasterNoFacing(out.str());
         }
     }
@@ -322,9 +324,10 @@ bool QuestUpdateAddKillAction::Execute(Event event)
         CreatureTemplate const* info = sObjectMgr->GetCreatureTemplate(entry);
         if (info)
         {
-            BroadcastHelper::BroadcastQuestUpdateAddKill(botAI, bot, qInfo, available, required, info->Name);
+            std::string infoName = botAI->GetLocalizedCreatureName(entry);
+            BroadcastHelper::BroadcastQuestUpdateAddKill(botAI, bot, qInfo, available, required, infoName);
             std::ostringstream out;
-            out << info->Name << " " << available << "/" << required << " " << ChatHelper::FormatQuest(qInfo);
+            out << infoName << " " << available << "/" << required << " " << ChatHelper::FormatQuest(qInfo);
             botAI->TellMasterNoFacing(out.str());
         }
     }    

--- a/src/strategy/actions/QuestAction.h
+++ b/src/strategy/actions/QuestAction.h
@@ -66,4 +66,11 @@ public:
     bool Execute(Event event) override;
 };
 
+class QuestItemPushResultAction : public Action
+{
+public:
+    QuestItemPushResultAction(PlayerbotAI* ai) : Action(ai, "quest item push result") {}
+    bool Execute(Event event) override;;
+};
+
 #endif

--- a/src/strategy/actions/TalkToQuestGiverAction.cpp
+++ b/src/strategy/actions/TalkToQuestGiverAction.cpp
@@ -173,7 +173,6 @@ void TalkToQuestGiverAction::RewardMultipleItem(Quest const* quest, Object* ques
     std::ostringstream outid;
     if (!botAI->IsAlt() || sPlayerbotAIConfig->autoPickReward == "yes")
     {
-        // Pick the first item of the best rewards.
         bestIds = BestRewards(quest);
         if (!bestIds.empty())
         {

--- a/src/strategy/actions/WorldPacketActionContext.h
+++ b/src/strategy/actions/WorldPacketActionContext.h
@@ -79,7 +79,8 @@ public:
         creators["quest update failed timer"] = &WorldPacketActionContext::quest_update_failed_timer;
         creators["quest update complete"] = &WorldPacketActionContext::quest_update_complete;
         creators["turn in query quest"] = &WorldPacketActionContext::turn_in_query_quest;
-
+        creators["quest item push result"] = &WorldPacketActionContext::quest_item_push_result;
+        
         creators["party command"] = &WorldPacketActionContext::party_command;
         creators["tell cast failed"] = &WorldPacketActionContext::tell_cast_failed;
         creators["accept duel"] = &WorldPacketActionContext::accept_duel;
@@ -139,6 +140,7 @@ private:
     static Action* quest_update_failed(PlayerbotAI* ai) { return new QuestUpdateFailedAction(ai); }
     static Action* quest_update_failed_timer(PlayerbotAI* ai) { return new QuestUpdateFailedTimerAction(ai); }
     static Action* quest_update_complete(PlayerbotAI* botAI) { return new QuestUpdateCompleteAction(botAI); }
+    static Action* quest_item_push_result(PlayerbotAI* ai) { return new QuestItemPushResultAction(ai); }
 
     static Action* turn_in_quest(PlayerbotAI* botAI) { return new TalkToQuestGiverAction(botAI); }
     static Action* accept_quest(PlayerbotAI* botAI) { return new AcceptQuestAction(botAI); }

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -107,6 +107,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("log");
     supported.push_back("los");
     supported.push_back("rpg status");
+    supported.push_back("rpg do quest");
     supported.push_back("aura");
     supported.push_back("drop");
     supported.push_back("share");

--- a/src/strategy/generic/CombatStrategy.cpp
+++ b/src/strategy/generic/CombatStrategy.cpp
@@ -12,8 +12,9 @@ void CombatStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("enemy out of spell",
                                        NextAction::array(0, new NextAction("reach spell", ACTION_HIGH), nullptr)));
+    // drop target relevance 99 (lower than Worldpacket triggers)
     triggers.push_back(
-        new TriggerNode("invalid target", NextAction::array(0, new NextAction("drop target", 100), nullptr)));
+        new TriggerNode("invalid target", NextAction::array(0, new NextAction("drop target", 99), nullptr)));
     triggers.push_back(
         new TriggerNode("mounted", NextAction::array(0, new NextAction("check mount state", 54), nullptr)));
     // triggers.push_back(new TriggerNode("out of react range", NextAction::array(0, new NextAction("flee to master",

--- a/src/strategy/generic/GrindingStrategy.cpp
+++ b/src/strategy/generic/GrindingStrategy.cpp
@@ -7,13 +7,17 @@
 
 #include "Playerbots.h"
 
-NextAction** GrindingStrategy::getDefaultActions() { return nullptr; }
+NextAction** GrindingStrategy::getDefaultActions()
+{
+    return NextAction::array(0,
+        new NextAction("drink", 4.2f),
+        new NextAction("food", 4.1f),
+        nullptr);
+}
 
 void GrindingStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     // reduce lower than loot
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 4.2f), nullptr)));
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 4.1f), nullptr)));
     triggers.push_back(
         new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 4.0f), nullptr)));
 }

--- a/src/strategy/generic/GrindingStrategy.cpp
+++ b/src/strategy/generic/GrindingStrategy.cpp
@@ -11,6 +11,7 @@ NextAction** GrindingStrategy::getDefaultActions() { return nullptr; }
 
 void GrindingStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+    // reduce lower than loot
     triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 4.2f), nullptr)));
     triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 4.1f), nullptr)));
     triggers.push_back(

--- a/src/strategy/generic/GrindingStrategy.cpp
+++ b/src/strategy/generic/GrindingStrategy.cpp
@@ -11,10 +11,10 @@ NextAction** GrindingStrategy::getDefaultActions() { return nullptr; }
 
 void GrindingStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 3.2f), nullptr)));
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 3.1f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 10.2f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 10.1f), nullptr)));
     triggers.push_back(
-        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 3.0f), nullptr)));
+        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 10.0f), nullptr)));
 }
 
 void MoveRandomStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/strategy/generic/GrindingStrategy.cpp
+++ b/src/strategy/generic/GrindingStrategy.cpp
@@ -11,10 +11,10 @@ NextAction** GrindingStrategy::getDefaultActions() { return nullptr; }
 
 void GrindingStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 10.2f), nullptr)));
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 10.1f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 3.2f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 3.1f), nullptr)));
     triggers.push_back(
-        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 10.0f), nullptr)));
+        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 3.0f), nullptr)));
 }
 
 void MoveRandomStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/strategy/generic/GrindingStrategy.cpp
+++ b/src/strategy/generic/GrindingStrategy.cpp
@@ -11,10 +11,10 @@ NextAction** GrindingStrategy::getDefaultActions() { return nullptr; }
 
 void GrindingStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 10.2f), nullptr)));
-    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 10.1f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("drink", 4.2f), nullptr)));
+    triggers.push_back(new TriggerNode("timer", NextAction::array(0, new NextAction("food", 4.1f), nullptr)));
     triggers.push_back(
-        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 10.0f), nullptr)));
+        new TriggerNode("no target", NextAction::array(0, new NextAction("attack anything", 4.0f), nullptr)));
 }
 
 void MoveRandomStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/strategy/generic/LootNonCombatStrategy.cpp
+++ b/src/strategy/generic/LootNonCombatStrategy.cpp
@@ -13,13 +13,13 @@ void LootNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("far from loot target", NextAction::array(0, new NextAction("move to loot", 7.0f), nullptr)));
     triggers.push_back(new TriggerNode("can loot", NextAction::array(0, new NextAction("open loot", 8.0f), nullptr)));
-    triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("add all loot", 1.0f), nullptr)));
+    triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("add all loot", 5.0f), nullptr)));
 }
 
 void GatherStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(
-        new TriggerNode("timer", NextAction::array(0, new NextAction("add gathering loot", 2.0f), nullptr)));
+        new TriggerNode("timer", NextAction::array(0, new NextAction("add gathering loot", 5.0f), nullptr)));
 }
 
 void RevealStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/strategy/generic/QuestStrategies.cpp
+++ b/src/strategy/generic/QuestStrategies.cpp
@@ -27,12 +27,6 @@ void DefaultQuestStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         "gossip hello", NextAction::array(0, new NextAction("talk to quest giver", relevance), nullptr)));
     triggers.push_back(new TriggerNode(
         "complete quest", NextAction::array(0, new NextAction("talk to quest giver", relevance), nullptr)));
-    
-    /// @FIXME:These actions can never be triggered as action always be cleared after drop target (change engine)
-    // triggers.push_back(new TriggerNode(
-    //     "quest update add kill", NextAction::array(0, new NextAction("quest update add kill", relevance), nullptr)));
-    // triggers.push_back(new TriggerNode(
-    //     "quest update add item", NextAction::array(0, new NextAction("quest update add item", relevance), nullptr)));
 }
 
 DefaultQuestStrategy::DefaultQuestStrategy(PlayerbotAI* botAI) : QuestStrategy(botAI) {}

--- a/src/strategy/generic/QuestStrategies.cpp
+++ b/src/strategy/generic/QuestStrategies.cpp
@@ -27,6 +27,12 @@ void DefaultQuestStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         "gossip hello", NextAction::array(0, new NextAction("talk to quest giver", relevance), nullptr)));
     triggers.push_back(new TriggerNode(
         "complete quest", NextAction::array(0, new NextAction("talk to quest giver", relevance), nullptr)));
+    
+    /// @FIXME:These actions can never be triggered as action always be cleared after drop target (change engine)
+    // triggers.push_back(new TriggerNode(
+    //     "quest update add kill", NextAction::array(0, new NextAction("quest update add kill", relevance), nullptr)));
+    // triggers.push_back(new TriggerNode(
+    //     "quest update add item", NextAction::array(0, new NextAction("quest update add item", relevance), nullptr)));
 }
 
 DefaultQuestStrategy::DefaultQuestStrategy(PlayerbotAI* botAI) : QuestStrategy(botAI) {}

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -79,7 +79,7 @@ WorldPacketHandlerStrategy::WorldPacketHandlerStrategy(PlayerbotAI* botAI) : Pas
 
     // quests
     supported.push_back("quest update add kill");
-    supported.push_back("quest update add item");
+    // supported.push_back("quest update add item");
     supported.push_back("quest update failed");
     supported.push_back("quest update failed timer");
     supported.push_back("quest update complete");

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -39,6 +39,8 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     triggers.push_back(new TriggerNode("within area trigger", NextAction::array(0, new NextAction("area trigger", relevance), nullptr)));
     triggers.push_back(new TriggerNode("loot response", NextAction::array(0, new NextAction("store loot", relevance), nullptr)));
     triggers.push_back(new TriggerNode("item push result", NextAction::array(0, new NextAction("query item usage", relevance), new NextAction("equip upgrades", relevance), nullptr)));
+    triggers.push_back(new TriggerNode("item push result", NextAction::array(0, new NextAction("quest item push result", relevance), nullptr)));
+    
     triggers.push_back(new TriggerNode("ready check finished", NextAction::array(0, new NextAction("finish ready check", relevance), nullptr)));
     // triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("security check", relevance), new NextAction("check mail", relevance), nullptr)));
     triggers.push_back(new TriggerNode("guild invite", NextAction::array(0, new NextAction("guild accept", relevance), nullptr)));

--- a/src/strategy/rogue/RogueActions.cpp
+++ b/src/strategy/rogue/RogueActions.cpp
@@ -8,7 +8,17 @@
 #include "Event.h"
 #include "ObjectGuid.h"
 #include "Player.h"
+#include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
+
+bool CastStealthAction::isUseful()
+{
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (target && bot->GetDistance(target) >= sPlayerbotAIConfig->spellDistance)
+        return false;
+    return true;
+}
+
 
 bool CastStealthAction::isPossible()
 {

--- a/src/strategy/rogue/RogueActions.h
+++ b/src/strategy/rogue/RogueActions.h
@@ -44,7 +44,7 @@ public:
     CastStealthAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "stealth") {}
 
     std::string const GetTargetName() override { return "self target"; }
-
+    bool isUseful() override;
     bool isPossible() override;
 };
 

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -7,6 +7,7 @@
 #include "ChatHelper.h"
 #include "G3D/Vector2.h"
 #include "GossipDef.h"
+#include "IVMapMgr.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
 #include "Object.h"
@@ -335,7 +336,7 @@ bool NewRpgDoQuestAction::DoIncompleteQuest()
         float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
 
         // double check for GetQuestPOIPosAndObjectiveIdx
-        if (dz == INVALID_HEIGHT)
+        if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
             return false;
 
         WorldPosition pos(bot->GetMapId(), dx, dy, dz);
@@ -427,8 +428,9 @@ bool NewRpgDoQuestAction::DoCompletedQuest()
         float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
 
         // double check for GetQuestPOIPosAndObjectiveIdx
-        if (dz == INVALID_HEIGHT)
+        if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
             return false;
+        
         WorldPosition pos(bot->GetMapId(), dx, dy, dz);
         botAI->rpgInfo.do_quest.lastReachPOI = 0;
         botAI->rpgInfo.do_quest.pos = pos;

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -386,21 +386,19 @@ bool NewRpgDoQuestAction::DoCompletedQuest()
             botAI->rpgInfo.ChangeToIdle();
             return false;
         }
-        // get the place to get rewarded
-        if (GetQuestPOIPosAndObjectiveIdx(questId, poiInfo, true))
-        {
-            float dx = poiInfo[0].pos.x, dy = poiInfo[0].pos.y;
-            // z = MAX_HEIGHT as we do not know accurate z
-            float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+        assert(poiInfo.size() > 0);
+        // now we get the place to get rewarded
+        float dx = poiInfo[0].pos.x, dy = poiInfo[0].pos.y;
+        // z = MAX_HEIGHT as we do not know accurate z
+        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
 
-            // double check for GetQuestPOIPosAndObjectiveIdx
-            if (dz == INVALID_HEIGHT)
-                return false;
-            WorldPosition pos(bot->GetMapId(), dx, dy, dz);
-            botAI->rpgInfo.do_quest.lastReachPOI = 0;
-            botAI->rpgInfo.do_quest.pos = pos;
-            botAI->rpgInfo.do_quest.objectiveIdx = -1;
-        }
+        // double check for GetQuestPOIPosAndObjectiveIdx
+        if (dz == INVALID_HEIGHT)
+            return false;
+        WorldPosition pos(bot->GetMapId(), dx, dy, dz);
+        botAI->rpgInfo.do_quest.lastReachPOI = 0;
+        botAI->rpgInfo.do_quest.pos = pos;
+        botAI->rpgInfo.do_quest.objectiveIdx = -1;
     }
 
     if (botAI->rpgInfo.do_quest.pos == WorldPosition())

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -230,7 +230,7 @@ bool NewRpgMoveNpcAction::Execute(Event event)
     if (!info.near_npc.npc)
     {
         // No npc can be found, switch to IDLE
-        ObjectGuid npc = ChooseNpcToInteract();
+        ObjectGuid npc = ChooseNpcOrGameObjectToInteract();
         if (npc.IsEmpty())
         {
             info.ChangeToIdle();
@@ -247,7 +247,7 @@ bool NewRpgMoveNpcAction::Execute(Event event)
         if (!info.near_npc.lastReach)
         {
             info.near_npc.lastReach = getMSTime();
-            InteractWithNpcForQuest(info.near_npc.npc);
+            InteractWithNpcOrGameObjectForQuest(info.near_npc.npc);
             return true;
         }
 

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -301,9 +301,12 @@ bool NewRpgDoQuestAction::DoIncompleteQuest()
         uint32 objectiveIdx = poiInfo[rndIdx].objectiveIdx;
 
         float dx = nearestPoi.x, dy = nearestPoi.y;
+
         // z = MAX_HEIGHT as we do not know accurate z
-        WorldPosition pos(bot->GetMapId(), dx, dy,
-            std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy)));
+        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+        if (dz == INVALID_HEIGHT)
+            return false;
+        WorldPosition pos(bot->GetMapId(), dx, dy, dz);
         botAI->rpgInfo.do_quest.pos = pos;
         botAI->rpgInfo.do_quest.objectiveIdx = objectiveIdx;
     }

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -9,6 +9,7 @@
 #include "GossipDef.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
+#include "Object.h"
 #include "ObjectAccessor.h"
 #include "ObjectDefines.h"
 #include "ObjectGuid.h"
@@ -222,25 +223,27 @@ bool NewRpgMoveRandomAction::Execute(Event event)
 bool NewRpgMoveNpcAction::Execute(Event event)
 {
     NewRpgInfo& info = botAI->rpgInfo;
-    if (!info.near_npc.pos)
+    if (!info.near_npc.npc)
     {
         // No npc can be found, switch to IDLE
-        GuidPosition pos = ChooseNpcToInteract();
-        if (pos.IsEmpty())
+        ObjectGuid npc = ChooseNpcToInteract();
+        if (npc.IsEmpty())
         {
             info.ChangeToIdle();
             return true;
         }
-        info.near_npc.pos = pos;
+        info.near_npc.npc = npc;
         info.near_npc.lastReach = 0;
         return true;
     }
-    if (bot->GetDistance(info.near_npc.pos) <= INTERACTION_DISTANCE)
+
+    Unit* unit = botAI->GetUnit(info.near_npc.npc);
+    if (unit && bot->GetDistance(unit) <= INTERACTION_DISTANCE)
     {
         if (!info.near_npc.lastReach)
         {
             info.near_npc.lastReach = getMSTime();
-            InteractWithNpcForQuest(info.near_npc.pos);
+            InteractWithNpcForQuest(info.near_npc.npc);
             return true;
         }
 
@@ -248,12 +251,12 @@ bool NewRpgMoveNpcAction::Execute(Event event)
             return false;
 
         // has reached the npc for more than `npcStayTime`, select the next target
-        info.near_npc.pos = GuidPosition();
+        info.near_npc.npc = ObjectGuid();
         info.near_npc.lastReach = 0;
     }
     else
     {
-        return MoveNpcTo(info.near_npc.pos);
+        return MoveNpcTo(info.near_npc.npc);
     }
     return true;
 }

--- a/src/strategy/rpg/NewRpgAction.cpp
+++ b/src/strategy/rpg/NewRpgAction.cpp
@@ -97,6 +97,9 @@ bool NewRpgStatusUpdateAction::Execute(Event event)
                     for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
                     {
                         uint32 questId = bot->GetQuestSlotQuestId(slot);
+                        if (botAI->lowPriorityQuest.find(questId) != botAI->lowPriorityQuest.end())
+                            continue;
+
                         std::vector<POIInfo> poiInfo;
                         if (GetQuestPOIPosAndObjectiveIdx(questId, poiInfo, true))
                         {
@@ -376,8 +379,12 @@ bool NewRpgDoQuestAction::DoIncompleteQuest()
             }
             if (!hasProgression)
             {
-                // we has reach the poi for more than 2 mins but no progession
-                // may not be able to complete this quest
+                // we has reach the poi for more than 5 mins but no progession
+                // may not be able to complete this quest, marked as abandoned
+                /// @TODO: It may be better to make lowPriorityQuest a global set shared by all bots (or saved in db)
+                botAI->lowPriorityQuest.insert(questId);
+                botAI->rpgStatistic.questAbandoned++;
+                LOG_DEBUG("playerbots", "[New rpg] {} marked as abandoned quest {}", bot->GetName(), questId);
                 botAI->rpgInfo.ChangeToIdle();
                 return true;
             }

--- a/src/strategy/rpg/NewRpgAction.h
+++ b/src/strategy/rpg/NewRpgAction.h
@@ -90,6 +90,7 @@ public:
     bool Execute(Event event) override;
 protected:
     bool DoIncompleteQuest();
+    bool DoCompletedQuest();
     
     const uint32 poiStayTime = 1 * 60 * 1000;
 };

--- a/src/strategy/rpg/NewRpgAction.h
+++ b/src/strategy/rpg/NewRpgAction.h
@@ -92,7 +92,7 @@ protected:
     bool DoIncompleteQuest();
     bool DoCompletedQuest();
     
-    const uint32 poiStayTime = 2 * 60 * 1000;
+    const uint32 poiStayTime = 5 * 60 * 1000;
 };
 
 #endif

--- a/src/strategy/rpg/NewRpgAction.h
+++ b/src/strategy/rpg/NewRpgAction.h
@@ -3,9 +3,15 @@
 
 #include "Duration.h"
 #include "MovementActions.h"
+#include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
+#include "Object.h"
+#include "ObjectDefines.h"
+#include "ObjectGuid.h"
+#include "QuestDef.h"
 #include "TravelMgr.h"
 #include "PlayerbotAI.h"
+#include "NewRpgBaseAction.h"
 
 class TellRpgStatusAction : public Action
 {
@@ -15,71 +21,77 @@ public:
     bool Execute(Event event) override;
 };
 
-class NewRpgStatusUpdateAction : public Action
+class StartRpgDoQuestAction : public Action
 {
 public:
-    NewRpgStatusUpdateAction(PlayerbotAI* botAI) : Action(botAI, "new rpg status update") {}
+    StartRpgDoQuestAction(PlayerbotAI* botAI) : Action(botAI, "start rpg do quest") {}
+
+    bool Execute(Event event) override;
+};
+
+class NewRpgStatusUpdateAction : public NewRpgBaseAction
+{
+public:
+    NewRpgStatusUpdateAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg status update")
+    {
+        // int statusCount = RPG_STATUS_END - 1;
+
+        // transitionMat.resize(statusCount, std::vector<int>(statusCount, 0));
+
+        // transitionMat[RPG_IDLE][RPG_GO_GRIND] = 20;
+        // transitionMat[RPG_IDLE][RPG_GO_INNKEEPER] = 15;
+        // transitionMat[RPG_IDLE][RPG_NEAR_NPC] = 30;
+        // transitionMat[RPG_IDLE][RPG_DO_QUEST] = 35;
+    }
     bool Execute(Event event) override;
 protected:
-    // const int32 setGrindInterval = 5 * 60 * 1000;
-    // const int32 setNpcInterval = 1 * 60 * 1000;
+    // static NewRpgStatusTransitionProb transitionMat;
     const int32 statusNearNpcDuration = 5 * 60 * 1000;
     const int32 statusNearRandomDuration = 5 * 60 * 1000;
     const int32 statusRestDuration = 30 * 1000;
-    WorldPosition SelectRandomGrindPos();
-    WorldPosition SelectRandomInnKeeperPos();
+    const int32 statusDoQuestDuration = 30 * 60 * 1000;
 };
 
-class NewRpgGoFarAwayPosAction : public MovementAction
+class NewRpgGoGrindAction : public NewRpgBaseAction
 {
 public:
-    NewRpgGoFarAwayPosAction(PlayerbotAI* botAI, std::string name) : MovementAction(botAI, name) {}
-    bool MoveFarTo(WorldPosition dest);
-
-protected:
-    // WorldPosition dest;
-    const float pathFinderDis = 70.0f; // path finder
-    const uint32 stuckTime = 5 * 60 * 1000;
-};
-
-class NewRpgGoGrindAction : public NewRpgGoFarAwayPosAction
-{
-public:
-    NewRpgGoGrindAction(PlayerbotAI* botAI) : NewRpgGoFarAwayPosAction(botAI, "new rpg go grind") {}
+    NewRpgGoGrindAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg go grind") {}
     bool Execute(Event event) override;
 };
 
-class NewRpgGoInnKeeperAction : public NewRpgGoFarAwayPosAction
+class NewRpgGoInnKeeperAction : public NewRpgBaseAction
 {
 public:
-    NewRpgGoInnKeeperAction(PlayerbotAI* botAI) : NewRpgGoFarAwayPosAction(botAI, "new rpg go innkeeper") {}
+    NewRpgGoInnKeeperAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg go innkeeper") {}
     bool Execute(Event event) override;
 };
 
 
-class NewRpgMoveRandomAction : public MovementAction
+class NewRpgMoveRandomAction : public NewRpgBaseAction
 {
 public:
-    NewRpgMoveRandomAction(PlayerbotAI* botAI) : MovementAction(botAI, "new rpg move random") {}
+    NewRpgMoveRandomAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg move random") {}
     bool Execute(Event event) override;
-protected:
-    const float moveStep = 50.0f;
 };
 
-class NewRpgMoveNpcAction : public MovementAction
+class NewRpgMoveNpcAction : public NewRpgBaseAction
 {
 public:
-    NewRpgMoveNpcAction(PlayerbotAI* botAI) : MovementAction(botAI, "new rpg move npcs") {}
+    NewRpgMoveNpcAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg move npcs") {}
+    bool Execute(Event event) override;
+
+    const uint32 npcStayTime = 8 * 1000;
+};
+
+class NewRpgDoQuestAction : public NewRpgBaseAction
+{
+public:
+    NewRpgDoQuestAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg do quest") {}
     bool Execute(Event event) override;
 protected:
-    const uint32 stayTime = 8 * 1000;
-};
-
-class NewRpgQuestingAction : public NewRpgGoFarAwayPosAction
-{
-public:
-    NewRpgQuestingAction(PlayerbotAI* botAI) : NewRpgGoFarAwayPosAction(botAI, "new rpg questing") {}
-    bool Execute(Event event) override;
+    bool DoIncompleteQuest();
+    
+    const uint32 poiStayTime = 1 * 60 * 1000;
 };
 
 #endif

--- a/src/strategy/rpg/NewRpgAction.h
+++ b/src/strategy/rpg/NewRpgAction.h
@@ -92,7 +92,7 @@ protected:
     bool DoIncompleteQuest();
     bool DoCompletedQuest();
     
-    const uint32 poiStayTime = 1 * 60 * 1000;
+    const uint32 poiStayTime = 2 * 60 * 1000;
 };
 
 #endif

--- a/src/strategy/rpg/NewRpgAction.h
+++ b/src/strategy/rpg/NewRpgAction.h
@@ -34,7 +34,6 @@ class NewRpgGoFarAwayPosAction : public MovementAction
 {
 public:
     NewRpgGoFarAwayPosAction(PlayerbotAI* botAI, std::string name) : MovementAction(botAI, name) {}
-    // bool Execute(Event event) override;
     bool MoveFarTo(WorldPosition dest);
 
 protected:
@@ -74,6 +73,13 @@ public:
     bool Execute(Event event) override;
 protected:
     const uint32 stayTime = 8 * 1000;
+};
+
+class NewRpgQuestingAction : public NewRpgGoFarAwayPosAction
+{
+public:
+    NewRpgQuestingAction(PlayerbotAI* botAI) : NewRpgGoFarAwayPosAction(botAI, "new rpg questing") {}
+    bool Execute(Event event) override;
 };
 
 #endif

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -195,6 +195,9 @@ bool NewRpgBaseAction::InteractWithNpcForQuest(ObjectGuid guid)
     if (menu.Empty())
         return true;
 
+    if (!creature->IsQuestGiver())
+        return true;
+
     for (uint8 idx = 0; idx < menu.GetMenuItemCount(); idx++)
     {
         const QuestMenuItem &item = menu.GetItem(idx);

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -4,6 +4,7 @@
 #include "GameObject.h"
 #include "GossipDef.h"
 #include "GridTerrainData.h"
+#include "IVMapMgr.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
 #include "Object.h"
@@ -133,7 +134,7 @@ bool NewRpgBaseAction::MoveNpcTo(ObjectGuid guid, float distance)
     return MoveTo(mapId, x, y, z, false, false, false, true);
 }
 
-bool NewRpgBaseAction::MoveRandomNear(float moveStep)
+bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority)
 {
     float distance = rand_norm() * moveStep;
     Map* map = bot->GetMap();
@@ -163,7 +164,7 @@ bool NewRpgBaseAction::MoveRandomNear(float moveStep)
         if (map->IsInWater(bot->GetPhaseMask(), dx, dy, dz, bot->GetCollisionHeight()))
             continue;
 
-        bool moved = MoveTo(bot->GetMapId(), dx, dy, dz, false, false, false, true);
+        bool moved = MoveTo(bot->GetMapId(), dx, dy, dz, false, false, false, true, priority);
         if (moved)
             return true;
     }
@@ -580,7 +581,7 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
             
             float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
             
-            if (dz == INVALID_HEIGHT)
+            if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
                 continue;
     
             if (bot->GetZoneId() != bot->GetMap()->GetZoneId(bot->GetPhaseMask(), dx, dy, dz))
@@ -652,7 +653,7 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
         
         float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
         
-        if (dz == INVALID_HEIGHT)
+        if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
             continue;
 
         if (bot->GetZoneId() != bot->GetMap()->GetZoneId(bot->GetPhaseMask(), dx, dy, dz))

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -370,6 +370,7 @@ bool NewRpgBaseAction::OrganizeQuestLog()
             bot->GetSession()->HandleQuestLogRemoveQuest(packet);
             if (botAI->GetMaster())
                 botAI->TellMasterNoFacing("Quest dropped " + ChatHelper::FormatQuest(quest));
+            botAI->rpgStatistic.questDropped++;
             dropped++;
         }
     }
@@ -395,6 +396,7 @@ bool NewRpgBaseAction::OrganizeQuestLog()
             bot->GetSession()->HandleQuestLogRemoveQuest(packet);
             if (botAI->GetMaster())
                 botAI->TellMasterNoFacing("Quest dropped " + ChatHelper::FormatQuest(quest));
+            botAI->rpgStatistic.questDropped++;
             dropped++;
         }
     }
@@ -416,6 +418,7 @@ bool NewRpgBaseAction::OrganizeQuestLog()
         bot->GetSession()->HandleQuestLogRemoveQuest(packet);
         if (botAI->GetMaster())
             botAI->TellMasterNoFacing("Quest dropped " + ChatHelper::FormatQuest(quest));
+        botAI->rpgStatistic.questDropped++;
     }
 
     return true;

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -463,9 +463,12 @@ GuidPosition NewRpgBaseAction::ChooseNpcToInteract(bool questgiverOnly, float di
 
         if (distanceLimit && bot->GetDistance(object) > distanceLimit)
             continue;
+        
+        if (object->ToCreature() && !object->ToCreature()->IsQuestGiver())
+            continue;
 
-        // if (bot->GetQuestDialogStatus(object) < DIALOG_STATUS_AVAILABLE)
-        //     continue;
+        if (object->ToGameObject() && object->ToGameObject()->GetGoType() != GAMEOBJECT_TYPE_QUESTGIVER)
+            continue;
 
         bot->PrepareQuestMenu(guid);
         const QuestMenu &menu = bot->PlayerTalkClass->GetQuestMenu();
@@ -490,6 +493,7 @@ GuidPosition NewRpgBaseAction::ChooseNpcToInteract(bool questgiverOnly, float di
             const Quest* quest = sObjectMgr->GetQuestTemplate(item.QuestId);
             if (!quest)
                 continue;
+
             const QuestStatus &status = bot->GetQuestStatus(item.QuestId);
             if (status == QUEST_STATUS_NONE && bot->CanTakeQuest(quest, false) &&
                 bot->CanAddQuest(quest, false) && IsQuestWorthDoing(quest) && IsQuestCapableDoing(quest))

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -366,7 +366,7 @@ bool NewRpgBaseAction::OrganizeQuestLog()
         {
             LOG_DEBUG("playerbots", "[New rpg] {} drop quest {}", bot->GetName(), questId);
             WorldPacket packet(CMSG_QUESTLOG_REMOVE_QUEST);
-            packet << questId;
+            packet << (uint8)i;
             bot->GetSession()->HandleQuestLogRemoveQuest(packet);
             if (botAI->GetMaster())
                 botAI->TellMasterNoFacing("Quest dropped " + ChatHelper::FormatQuest(quest));
@@ -392,7 +392,7 @@ bool NewRpgBaseAction::OrganizeQuestLog()
         {
             LOG_DEBUG("playerbots", "[New rpg] {} drop quest {}", bot->GetName(), questId);
             WorldPacket packet(CMSG_QUESTLOG_REMOVE_QUEST);
-            packet << questId;
+            packet << (uint8)i;
             bot->GetSession()->HandleQuestLogRemoveQuest(packet);
             if (botAI->GetMaster())
                 botAI->TellMasterNoFacing("Quest dropped " + ChatHelper::FormatQuest(quest));
@@ -414,7 +414,7 @@ bool NewRpgBaseAction::OrganizeQuestLog()
         const Quest* quest = sObjectMgr->GetQuestTemplate(questId);
         LOG_DEBUG("playerbots", "[New rpg] {} drop quest {}", bot->GetName(), questId);
         WorldPacket packet(CMSG_QUESTLOG_REMOVE_QUEST);
-        packet << questId;
+        packet << (uint8)i;
         bot->GetSession()->HandleQuestLogRemoveQuest(packet);
         if (botAI->GetMaster())
             botAI->TellMasterNoFacing("Quest dropped " + ChatHelper::FormatQuest(quest));

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -519,6 +519,9 @@ ObjectGuid NewRpgBaseAction::ChooseNpcOrGameObjectToInteract(bool questgiverOnly
     if (questgiverOnly)
         return ObjectGuid();
 
+    if (possibleTargets.empty())
+        return ObjectGuid();
+    
     int idx = urand(0, possibleTargets.size() - 1);
     ObjectGuid guid = possibleTargets[idx];
     WorldObject* object = ObjectAccessor::GetCreatureOrPetOrVehicle(*bot, guid);

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -31,6 +31,12 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     if (dest == WorldPosition())
         return false;
 
+    if (dest != botAI->rpgInfo.moveFarPos)
+    {
+        // clear stuck information if it's a new dest
+        botAI->rpgInfo.SetMoveFarTo(dest);
+    }
+
     float dis = bot->GetExactDist(dest);
     if (dis < pathFinderDis)
     {
@@ -106,6 +112,11 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
 
 bool NewRpgBaseAction::MoveNpcTo(ObjectGuid guid, float distance)
 {
+    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_NORMAL))
+    {
+        return false;
+    }
+
     Unit* unit = botAI->GetUnit(guid);
     if (!unit)
         return false;
@@ -136,6 +147,11 @@ bool NewRpgBaseAction::MoveNpcTo(ObjectGuid guid, float distance)
 
 bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority)
 {
+    if (IsWaitingForLastMove(priority))
+    {
+        return false;
+    }
+    
     float distance = rand_norm() * moveStep;
     Map* map = bot->GetMap();
     const float x = bot->GetPositionX();

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -2,6 +2,7 @@
 #include "ChatHelper.h"
 #include "G3D/Vector2.h"
 #include "GossipDef.h"
+#include "GridTerrainData.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
 #include "ObjectAccessor.h"
@@ -459,9 +460,13 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
 
         if (bot->GetDistance2d(dx, dy) >= 1500.0f)
             continue;
+        
+        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+        
+        if (dz == INVALID_HEIGHT)
+            continue;
 
-        if (bot->GetZoneId() != bot->GetMap()->GetZoneId(bot->GetPhaseMask(), dx, dy,
-            std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy))))
+        if (bot->GetZoneId() != bot->GetMap()->GetZoneId(bot->GetPhaseMask(), dx, dy, dz))
             continue;
 
         poiInfo.push_back({{dx, dy}, qPoi.ObjectiveIndex});

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -318,6 +318,9 @@ bool NewRpgBaseAction::IsQuestWorthDoing(Quest const* quest)
     if (quest->IsRepeatable())
         return false;
 
+    if (quest->IsSeasonal())
+        return false;
+
     return true;
 }
 

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -207,7 +207,8 @@ bool NewRpgBaseAction::InteractWithNpcForQuest(ObjectGuid guid)
             bot->SatisfyQuestLog(false) && IsQuestWorthDoing(quest) && IsQuestCapableDoing(quest))
         {
             AcceptQuest(quest, guid);
-            botAI->TellMasterNoFacing("Quest accepted " + ChatHelper::FormatQuest(quest));
+            if (botAI->GetMaster())
+                botAI->TellMasterNoFacing("Quest accepted " + ChatHelper::FormatQuest(quest));
             BroadcastHelper::BroadcastQuestAccepted(botAI, bot, quest);
             botAI->rpgStatistic.questAccepted++;
             if (quest->IsAutoComplete())
@@ -218,7 +219,8 @@ bool NewRpgBaseAction::InteractWithNpcForQuest(ObjectGuid guid)
         if (status == QUEST_STATUS_COMPLETE && bot->CanRewardQuest(quest, 0, false))
         {
             TurnInQuest(quest, guid);
-            botAI->TellMasterNoFacing("Quest rewarded " + ChatHelper::FormatQuest(quest));
+            if (botAI->GetMaster())
+                botAI->TellMasterNoFacing("Quest rewarded " + ChatHelper::FormatQuest(quest));
             BroadcastHelper::BroadcastQuestTurnedIn(botAI, bot, quest);
             botAI->rpgStatistic.questRewarded++;
             LOG_DEBUG("playerbots", "[New rpg] {} complete quest {}", bot->GetName(), quest->GetQuestId());

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -120,7 +120,7 @@ bool NewRpgBaseAction::MoveNpcTo(GuidPosition pos, float distance)
         angle = unit->GetOrientation() +
                 (M_PI * irand(-25, 25) / 100.0);  // 45 degrees infront of target (leading it's movement)
                 
-    float rnd = 0.5 * rand_norm();
+    float rnd = rand_norm();
     x += cos(angle) * distance * rnd;
     y += sin(angle) * distance * rnd;
     if (!unit->GetMap()->CheckCollisionAndGetValidCoords(unit, unit->GetPositionX(), unit->GetPositionY(),

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -204,7 +204,7 @@ bool NewRpgBaseAction::InteractWithNpcForQuest(ObjectGuid guid)
 
         const QuestStatus &status = bot->GetQuestStatus(item.QuestId);
         if (status == QUEST_STATUS_NONE && bot->CanTakeQuest(quest, false) &&
-            bot->SatisfyQuestLog(false) && IsQuestWorthDoing(quest) && IsQuestCapableDoing(quest))
+            bot->CanAddQuest(quest, false) && IsQuestWorthDoing(quest) && IsQuestCapableDoing(quest))
         {
             AcceptQuest(quest, guid);
             if (botAI->GetMaster())
@@ -365,7 +365,9 @@ bool NewRpgBaseAction::OrganizeQuestLog()
             continue;
 
         const Quest* quest = sObjectMgr->GetQuestTemplate(questId);
-        if (!IsQuestWorthDoing(quest) || !IsQuestCapableDoing(quest)) // festival / class quest
+        if (!IsQuestWorthDoing(quest) ||
+            !IsQuestCapableDoing(quest) ||
+            bot->GetQuestStatus(questId) == QUEST_STATUS_FAILED)
         {
             LOG_DEBUG("playerbots", "[New rpg] {} drop quest {}", bot->GetName(), questId);
             WorldPacket packet(CMSG_QUESTLOG_REMOVE_QUEST);
@@ -490,7 +492,7 @@ GuidPosition NewRpgBaseAction::ChooseNpcToInteract(bool questgiverOnly, float di
                 continue;
             const QuestStatus &status = bot->GetQuestStatus(item.QuestId);
             if (status == QUEST_STATUS_NONE && bot->CanTakeQuest(quest, false) &&
-                bot->SatisfyQuestLog(false) && IsQuestWorthDoing(quest) && IsQuestCapableDoing(quest))
+                bot->CanAddQuest(quest, false) && IsQuestWorthDoing(quest) && IsQuestCapableDoing(quest))
             {
                 return GuidPosition(object);
             }

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -347,7 +347,7 @@ bool NewRpgBaseAction::IsQuestWorthDoing(Quest const* quest)
 
 bool NewRpgBaseAction::IsQuestCapableDoing(Quest const* quest)
 {
-    bool highLevelQuest = bot->GetLevel() + 4 < bot->GetQuestLevel(quest);
+    bool highLevelQuest = bot->GetLevel() + 3 < bot->GetQuestLevel(quest);
     if (highLevelQuest)
         return false;
 
@@ -474,13 +474,13 @@ ObjectGuid NewRpgBaseAction::ChooseNpcOrGameObjectToInteract(bool questgiverOnly
 
     if (possibleTargets.empty() && possibleGameObjects.empty())
         return ObjectGuid();
-    
+
     WorldObject* nearestObject = nullptr;
     for (ObjectGuid& guid: possibleTargets)
     {
         WorldObject* object = ObjectAccessor::GetWorldObject(*bot, guid);
 
-        if (!object)
+        if (!object || !object->IsInWorld())
             continue;
 
         if (distanceLimit && bot->GetDistance(object) > distanceLimit)
@@ -498,7 +498,7 @@ ObjectGuid NewRpgBaseAction::ChooseNpcOrGameObjectToInteract(bool questgiverOnly
     {
         WorldObject* object = ObjectAccessor::GetWorldObject(*bot, guid);
 
-        if (!object)
+        if (!object || !object->IsInWorld())
             continue;
 
         if (distanceLimit && bot->GetDistance(object) > distanceLimit)
@@ -525,7 +525,7 @@ ObjectGuid NewRpgBaseAction::ChooseNpcOrGameObjectToInteract(bool questgiverOnly
     if (!object)
         object = ObjectAccessor::GetGameObject(*bot, guid);
 
-    if (object)
+    if (object && object->IsInWorld())
     {
         return object->GetGUID();
     }

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -28,13 +28,13 @@ public:
 protected:
     // MOVEMENT RELATED
     bool MoveFarTo(WorldPosition dest);
-    bool MoveNpcTo(GuidPosition dest, float distance = INTERACTION_DISTANCE);
+    bool MoveNpcTo(ObjectGuid guid, float distance = INTERACTION_DISTANCE);
     bool MoveRandomNear(float moveStep = 50.0f);
     bool ForceToWait(uint32 duration, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
 
     // QUEST RELATED
     bool SearchQuestGiverAndAcceptOrReward();
-    GuidPosition ChooseNpcToInteract(bool questgiverOnly = false, float distanceLimit = 0.0f);
+    ObjectGuid ChooseNpcToInteract(bool questgiverOnly = false, float distanceLimit = 0.0f);
     bool InteractWithNpcForQuest(ObjectGuid guid);
     bool AcceptQuest(Quest const* quest, ObjectGuid guid);
     bool TurnInQuest(Quest const* quest, ObjectGuid guid);

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -1,0 +1,56 @@
+#ifndef _PLAYERBOT_NEWRPGBASEACTION_H
+#define _PLAYERBOT_NEWRPGBASEACTION_H
+
+#include "Duration.h"
+#include "LastMovementValue.h"
+#include "MovementActions.h"
+#include "NewRpgStrategy.h"
+#include "Object.h"
+#include "ObjectDefines.h"
+#include "ObjectGuid.h"
+#include "QuestDef.h"
+#include "TravelMgr.h"
+#include "PlayerbotAI.h"
+
+struct POIInfo {
+    G3D::Vector2 pos;
+    uint32 objectiveIdx;
+};
+
+/// @TODO: make it a base (composition) class for all new rpg actions
+/// All functions that may be shared by multiple actions should be declared here
+/// And we should make all actions composable instead of inheritable
+class NewRpgBaseAction : public MovementAction
+{
+public:
+    NewRpgBaseAction(PlayerbotAI* botAI, std::string name) : MovementAction(botAI, name) {}
+    
+protected:
+    // MOVEMENT RELATED
+    bool MoveFarTo(WorldPosition dest);
+    bool MoveNpcTo(GuidPosition dest, float distance = INTERACTION_DISTANCE);
+    bool MoveRandomNear(float moveSTep = 50.0f);
+    bool ForceToWait(uint32 duration, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
+
+    // QUEST RELATED
+    bool SearchQuestGiverAndAcceptOrReward();
+    GuidPosition ChooseNpcToInteract(bool questgiverOnly = false, float distanceLimit = 0.0f);
+    bool InteractWithNpcForQuest(ObjectGuid guid);
+    bool AcceptQuest(Quest const* quest, ObjectGuid guid);
+    bool TurnInQuest(Quest const* quest, ObjectGuid guid);
+    uint32 BestReward(Quest const* quest);
+
+protected:
+    uint32 SelectQuestToDo(Player* bot);
+    
+    bool GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector<POIInfo> &poiInfo);
+    static WorldPosition SelectRandomGrindPos(Player* bot);
+    static WorldPosition SelectRandomInnKeeperPos(Player* bot);
+
+protected:
+    // WorldPosition dest;
+    const float pathFinderDis = 70.0f; // path finder
+    const uint32 stuckTime = 5 * 60 * 1000;
+};
+
+#endif

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -14,7 +14,7 @@
 
 struct POIInfo {
     G3D::Vector2 pos;
-    uint32 objectiveIdx;
+    int32 objectiveIdx;
 };
 
 /// A base (composition) class for all new rpg actions
@@ -41,9 +41,10 @@ protected:
     uint32 BestReward(Quest const* quest);
     bool IsQuestWorthDoing(Quest const* quest);
     bool IsQuestCapableDoing(Quest const* quest);
+    bool OrganizeQuestLog();
 
 protected:
-    bool GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector<POIInfo> &poiInfo);
+    bool GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector<POIInfo> &poiInfo, bool toComplete = false);
     static WorldPosition SelectRandomGrindPos(Player* bot);
     static WorldPosition SelectRandomInnKeeperPos(Player* bot);
 

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -34,8 +34,9 @@ protected:
 
     // QUEST RELATED
     bool SearchQuestGiverAndAcceptOrReward();
-    ObjectGuid ChooseNpcToInteract(bool questgiverOnly = false, float distanceLimit = 0.0f);
-    bool InteractWithNpcForQuest(ObjectGuid guid);
+    ObjectGuid ChooseNpcOrGameObjectToInteract(bool questgiverOnly = false, float distanceLimit = 0.0f);
+    bool HasQuestToAcceptOrReward(WorldObject* object);
+    bool InteractWithNpcOrGameObjectForQuest(ObjectGuid guid);
     bool AcceptQuest(Quest const* quest, ObjectGuid guid);
     bool TurnInQuest(Quest const* quest, ObjectGuid guid);
     uint32 BestReward(Quest const* quest);

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -29,7 +29,7 @@ protected:
     // MOVEMENT RELATED
     bool MoveFarTo(WorldPosition dest);
     bool MoveNpcTo(GuidPosition dest, float distance = INTERACTION_DISTANCE);
-    bool MoveRandomNear(float moveSTep = 50.0f);
+    bool MoveRandomNear(float moveStep = 50.0f);
     bool ForceToWait(uint32 duration, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
 
     // QUEST RELATED

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -17,7 +17,7 @@ struct POIInfo {
     uint32 objectiveIdx;
 };
 
-/// @TODO: make it a base (composition) class for all new rpg actions
+/// A base (composition) class for all new rpg actions
 /// All functions that may be shared by multiple actions should be declared here
 /// And we should make all actions composable instead of inheritable
 class NewRpgBaseAction : public MovementAction
@@ -39,10 +39,10 @@ protected:
     bool AcceptQuest(Quest const* quest, ObjectGuid guid);
     bool TurnInQuest(Quest const* quest, ObjectGuid guid);
     uint32 BestReward(Quest const* quest);
+    bool IsQuestWorthDoing(Quest const* quest);
+    bool IsQuestCapableDoing(Quest const* quest);
 
 protected:
-    uint32 SelectQuestToDo(Player* bot);
-    
     bool GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector<POIInfo> &poiInfo);
     static WorldPosition SelectRandomGrindPos(Player* bot);
     static WorldPosition SelectRandomInnKeeperPos(Player* bot);

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -29,7 +29,7 @@ protected:
     // MOVEMENT RELATED
     bool MoveFarTo(WorldPosition dest);
     bool MoveNpcTo(ObjectGuid guid, float distance = INTERACTION_DISTANCE);
-    bool MoveRandomNear(float moveStep = 50.0f, MovementPriority priority = MovementPriority::MOVEMENT_WANDER);
+    bool MoveRandomNear(float moveStep = 50.0f, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
     bool ForceToWait(uint32 duration, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
 
     // QUEST RELATED

--- a/src/strategy/rpg/NewRpgBaseAction.h
+++ b/src/strategy/rpg/NewRpgBaseAction.h
@@ -29,7 +29,7 @@ protected:
     // MOVEMENT RELATED
     bool MoveFarTo(WorldPosition dest);
     bool MoveNpcTo(ObjectGuid guid, float distance = INTERACTION_DISTANCE);
-    bool MoveRandomNear(float moveStep = 50.0f);
+    bool MoveRandomNear(float moveStep = 50.0f, MovementPriority priority = MovementPriority::MOVEMENT_WANDER);
     bool ForceToWait(uint32 duration, MovementPriority priority = MovementPriority::MOVEMENT_NORMAL);
 
     // QUEST RELATED

--- a/src/strategy/rpg/NewRpgInfo.cpp
+++ b/src/strategy/rpg/NewRpgInfo.cpp
@@ -64,6 +64,14 @@ void NewRpgInfo::Reset()
     startT = getMSTime();
 }
 
+void NewRpgInfo::SetMoveFarTo(WorldPosition pos)
+{
+    nearestMoveFarDis = FLT_MAX;
+    stuckTs = 0;
+    stuckAttempts = 0;
+    moveFarPos = pos;
+}
+
 std::string NewRpgInfo::ToString()
 {
     std::stringstream out;

--- a/src/strategy/rpg/NewRpgInfo.cpp
+++ b/src/strategy/rpg/NewRpgInfo.cpp
@@ -4,38 +4,59 @@
 void NewRpgInfo::ChangeToGoGrind(WorldPosition pos)
 {
     Reset();
-    status = NewRpgStatus::GO_GRIND;
+    status = RPG_GO_GRIND;
+    go_grind = GoGrind();
     go_grind.pos = pos;
 }
 
 void NewRpgInfo::ChangeToGoInnkeeper(WorldPosition pos)
 {
     Reset();
-    status = NewRpgStatus::GO_INNKEEPER;
+    status = RPG_GO_INNKEEPER;
+    go_innkeeper = GoInnkeeper();
     go_innkeeper.pos = pos;
 }
 
 void NewRpgInfo::ChangeToNearNpc()
 {
     Reset();
-    status = NewRpgStatus::NEAR_NPC;
+    status = RPG_NEAR_NPC;
+    near_npc = NearNpc();
 }
 
 void NewRpgInfo::ChangeToNearRandom()
 {
-    status = NewRpgStatus::NEAR_RANDOM;
+    Reset();
+    status = RPG_NEAR_RANDOM;
+    near_random = NearRandom();
+}
+
+void NewRpgInfo::ChangeToDoQuest(uint32 questId, const Quest* quest)
+{
+    Reset();
+    status = RPG_DO_QUEST;
+    do_quest = DoQuest();
+    do_quest.questId = questId;
+    do_quest.quest = quest;
 }
 
 void NewRpgInfo::ChangeToRest()
 {
-    status = NewRpgStatus::REST;
+    Reset();
+    status = RPG_REST;
+    rest = Rest();
 }
 
 void NewRpgInfo::ChangeToIdle()
 {
-    status = NewRpgStatus::IDLE;
+    Reset();
+    status = RPG_IDLE;
 }
 
+bool NewRpgInfo::CanChangeTo(NewRpgStatus status)
+{
+    return true;
+}
 
 void NewRpgInfo::Reset()
 {
@@ -49,32 +70,39 @@ std::string NewRpgInfo::ToString()
     out << "Status: ";
     switch (status)
     {
-        case NewRpgStatus::GO_GRIND:
+        case RPG_GO_GRIND:
             out << "GO_GRIND";
             out << "\nGrindPos: " << go_grind.pos.GetMapId() << " " << go_grind.pos.GetPositionX() << " " << go_grind.pos.GetPositionY() << " " << go_grind.pos.GetPositionZ();
             out << "\nlastGoGrind: " << startT;
             break;
-        case NewRpgStatus::GO_INNKEEPER:
+        case RPG_GO_INNKEEPER:
             out << "GO_INNKEEPER";
             out << "\nInnKeeperPos: " << go_innkeeper.pos.GetMapId() << " " << go_innkeeper.pos.GetPositionX() << " " << go_innkeeper.pos.GetPositionY() << " " << go_innkeeper.pos.GetPositionZ();
             out << "\nlastGoInnKeeper: " << startT;
             break;
-        case NewRpgStatus::NEAR_NPC:
+        case RPG_NEAR_NPC:
             out << "NEAR_NPC";
-            out << "\nNpcPos: " << near_npc.pos.GetMapId() << " " << near_npc.pos.GetPositionX() << " " << near_npc.pos.GetPositionY() << " " << near_npc.pos.GetPositionZ();
+            out << "\nNpc: " << near_npc.pos.GetMapId() << " " << near_npc.pos.GetPositionX() << " " << near_npc.pos.GetPositionY() << " " << near_npc.pos.GetPositionZ() << " " << near_npc.pos.GetCounter();
             out << "\nlastNearNpc: " << startT;
             out << "\nlastReachNpc: " << near_npc.lastReach;
             break;
-        case NewRpgStatus::NEAR_RANDOM:
+        case RPG_NEAR_RANDOM:
             out << "NEAR_RANDOM";
             out << "\nlastNearRandom: " << startT;
             break;
-        case NewRpgStatus::IDLE:
+        case RPG_IDLE:
             out << "IDLE";
             break;
-        case NewRpgStatus::REST:
+        case RPG_REST:
             out << "REST";
             out << "\nlastRest: " << startT;
+            break;
+        case RPG_DO_QUEST:
+            out << "DO_QUEST";
+            out << "\nquestId: " << do_quest.questId;
+            out << "\nobjectiveIdx: " << do_quest.objectiveIdx;
+            out << "\npoiPos: " << do_quest.pos.GetMapId() << " " << do_quest.pos.GetPositionX() << " " << do_quest.pos.GetPositionY() << " " << do_quest.pos.GetPositionZ();
+            out << "\nlastReachPOI: " << do_quest.lastReachPOI;
             break;
         default:
             out << "UNKNOWN";

--- a/src/strategy/rpg/NewRpgInfo.cpp
+++ b/src/strategy/rpg/NewRpgInfo.cpp
@@ -1,0 +1,83 @@
+#include "NewRpgInfo.h"
+#include "Timer.h"
+
+void NewRpgInfo::ChangeToGoGrind(WorldPosition pos)
+{
+    Reset();
+    status = NewRpgStatus::GO_GRIND;
+    go_grind.pos = pos;
+}
+
+void NewRpgInfo::ChangeToGoInnkeeper(WorldPosition pos)
+{
+    Reset();
+    status = NewRpgStatus::GO_INNKEEPER;
+    go_innkeeper.pos = pos;
+}
+
+void NewRpgInfo::ChangeToNearNpc()
+{
+    Reset();
+    status = NewRpgStatus::NEAR_NPC;
+}
+
+void NewRpgInfo::ChangeToNearRandom()
+{
+    status = NewRpgStatus::NEAR_RANDOM;
+}
+
+void NewRpgInfo::ChangeToRest()
+{
+    status = NewRpgStatus::REST;
+}
+
+void NewRpgInfo::ChangeToIdle()
+{
+    status = NewRpgStatus::IDLE;
+}
+
+
+void NewRpgInfo::Reset()
+{
+    *this = NewRpgInfo();
+    startT = getMSTime();
+}
+
+std::string NewRpgInfo::ToString()
+{
+    std::stringstream out;
+    out << "Status: ";
+    switch (status)
+    {
+        case NewRpgStatus::GO_GRIND:
+            out << "GO_GRIND";
+            out << "\nGrindPos: " << go_grind.pos.GetMapId() << " " << go_grind.pos.GetPositionX() << " " << go_grind.pos.GetPositionY() << " " << go_grind.pos.GetPositionZ();
+            out << "\nlastGoGrind: " << startT;
+            break;
+        case NewRpgStatus::GO_INNKEEPER:
+            out << "GO_INNKEEPER";
+            out << "\nInnKeeperPos: " << go_innkeeper.pos.GetMapId() << " " << go_innkeeper.pos.GetPositionX() << " " << go_innkeeper.pos.GetPositionY() << " " << go_innkeeper.pos.GetPositionZ();
+            out << "\nlastGoInnKeeper: " << startT;
+            break;
+        case NewRpgStatus::NEAR_NPC:
+            out << "NEAR_NPC";
+            out << "\nNpcPos: " << near_npc.pos.GetMapId() << " " << near_npc.pos.GetPositionX() << " " << near_npc.pos.GetPositionY() << " " << near_npc.pos.GetPositionZ();
+            out << "\nlastNearNpc: " << startT;
+            out << "\nlastReachNpc: " << near_npc.lastReach;
+            break;
+        case NewRpgStatus::NEAR_RANDOM:
+            out << "NEAR_RANDOM";
+            out << "\nlastNearRandom: " << startT;
+            break;
+        case NewRpgStatus::IDLE:
+            out << "IDLE";
+            break;
+        case NewRpgStatus::REST:
+            out << "REST";
+            out << "\nlastRest: " << startT;
+            break;
+        default:
+            out << "UNKNOWN";
+    }
+    return out.str();
+}

--- a/src/strategy/rpg/NewRpgInfo.cpp
+++ b/src/strategy/rpg/NewRpgInfo.cpp
@@ -82,7 +82,7 @@ std::string NewRpgInfo::ToString()
             break;
         case RPG_NEAR_NPC:
             out << "NEAR_NPC";
-            out << "\nNpc: " << near_npc.pos.GetMapId() << " " << near_npc.pos.GetPositionX() << " " << near_npc.pos.GetPositionY() << " " << near_npc.pos.GetPositionZ() << " " << near_npc.pos.GetCounter();
+            out << "\nnpcEntry: " << near_npc.npc.GetCounter();
             out << "\nlastNearNpc: " << startT;
             out << "\nlastReachNpc: " << near_npc.lastReach;
             break;

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -1,0 +1,91 @@
+#ifndef _PLAYERBOT_NEWRPGINFO_H
+#define _PLAYERBOT_NEWRPGINFO_H
+
+#include "ObjectMgr.h"
+#include "QuestDef.h"
+#include "Strategy.h"
+#include "Timer.h"
+#include "TravelMgr.h"
+
+enum class NewRpgStatus
+{
+    // Going to far away place
+    GO_GRIND,
+    GO_INNKEEPER,
+    // Exploring nearby
+    NEAR_RANDOM,
+    NEAR_NPC,
+    // Do Quest (based on quest status and location)
+    QUESTING,
+    // Taking a break
+    REST,
+    // Initial status
+    IDLE
+};
+
+struct NewRpgInfo
+{
+    NewRpgInfo() {}
+    
+    // NewRpgStatus::GO_GRIND
+    struct GoGrind {
+        GoGrind() = default;
+        WorldPosition pos{};
+    };
+    // NewRpgStatus::GO_INNKEEPER
+    struct GoInnkeeper {
+        GoInnkeeper() = default;
+        WorldPosition pos{};
+    };
+    // NewRpgStatus::NEAR_NPC
+    struct NearNpc {
+        NearNpc() = default;
+        GuidPosition pos{};
+        uint32 lastReach{0};
+    };
+    // NewRpgStatus::NEAR_RANDOM
+    struct NearRandom {
+        NearRandom() = default;
+    };
+    // NewRpgStatus::QUESTING
+    struct Questing {
+        Quest* quest;
+    };
+    // NewRpgStatus::REST
+    struct Rest {
+        Rest() = default;
+    };
+    struct Idle {
+    };
+    NewRpgStatus status{NewRpgStatus::IDLE};
+
+    uint32 startT{0}; // start timestamp of the current status
+
+    // MOVE_FAR
+    float nearestMoveFarDis{FLT_MAX};
+    uint32 stuckTs{0};
+    uint32 stuckAttempts{0};
+    // END MOVE_FAR
+
+    union {
+        GoGrind go_grind;
+        GoInnkeeper go_innkeeper;
+        NearNpc near_npc;
+        NearRandom near_random;
+        Rest rest;
+        Questing questing;
+    };
+
+    bool HasStatusPersisted(uint32 maxDuration) { return startT + maxDuration < getMSTime(); }
+    void ChangeToGoGrind(WorldPosition pos);
+    void ChangeToGoInnkeeper(WorldPosition pos);
+    void ChangeToNearNpc();
+    void ChangeToNearRandom();
+    void ChangeToRest();
+    void ChangeToIdle();
+    
+    void Reset();
+    std::string ToString();
+};
+
+#endif

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -86,7 +86,7 @@ struct NewRpgInfo
         DoQuest quest;
     };
 
-    bool HasStatusPersisted(uint32 maxDuration) { return startT + maxDuration < getMSTime(); }
+    bool HasStatusPersisted(uint32 maxDuration) { return GetMSTimeDiffToNow(startT) > maxDuration; }
     void ChangeToGoGrind(WorldPosition pos);
     void ChangeToGoInnkeeper(WorldPosition pos);
     void ChangeToNearNpc();

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -104,6 +104,7 @@ struct NewRpgStatistic
 {
     uint32 questAccepted{0};
     uint32 questCompleted{0};
+    uint32 questAbandoned{0};
     uint32 questRewarded{0};
     uint32 questDropped{0};
     NewRpgStatistic operator+(const NewRpgStatistic& other) const
@@ -111,6 +112,7 @@ struct NewRpgStatistic
         NewRpgStatistic result;
         result.questAccepted = this->questAccepted + other.questAccepted;
         result.questCompleted = this->questCompleted + other.questCompleted;
+        result.questAbandoned = this->questAbandoned + other.questAbandoned;
         result.questRewarded = this->questRewarded + other.questRewarded;
         result.questDropped = this->questDropped + other.questDropped;
         return result;
@@ -119,6 +121,7 @@ struct NewRpgStatistic
     {
         this->questAccepted += other.questAccepted;
         this->questCompleted += other.questCompleted;
+        this->questAbandoned += other.questAbandoned;
         this->questRewarded += other.questRewarded;
         this->questDropped += other.questDropped;
         return *this;

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -75,6 +75,7 @@ struct NewRpgInfo
     float nearestMoveFarDis{FLT_MAX};
     uint32 stuckTs{0};
     uint32 stuckAttempts{0};
+    WorldPosition moveFarPos;
     // END MOVE_FAR
 
     union {
@@ -97,6 +98,7 @@ struct NewRpgInfo
     void ChangeToIdle();
     bool CanChangeTo(NewRpgStatus status);
     void Reset();
+    void SetMoveFarTo(WorldPosition pos);
     std::string ToString();
 };
 

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -2,6 +2,7 @@
 #define _PLAYERBOT_NEWRPGINFO_H
 
 #include "Define.h"
+#include "ObjectGuid.h"
 #include "ObjectMgr.h"
 #include "QuestDef.h"
 #include "Strategy.h"
@@ -45,7 +46,7 @@ struct NewRpgInfo
     // RPG_NEAR_NPC
     struct NearNpc {
         NearNpc() = default;
-        GuidPosition pos{};
+        ObjectGuid npc{};
         uint32 lastReach{0};
     };
     // RPG_NEAR_RANDOM

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -1,63 +1,72 @@
 #ifndef _PLAYERBOT_NEWRPGINFO_H
 #define _PLAYERBOT_NEWRPGINFO_H
 
+#include "Define.h"
 #include "ObjectMgr.h"
 #include "QuestDef.h"
 #include "Strategy.h"
 #include "Timer.h"
 #include "TravelMgr.h"
 
-enum class NewRpgStatus
+enum NewRpgStatus: int
 {
+    RPG_STATUS_START = 0,
     // Going to far away place
-    GO_GRIND,
-    GO_INNKEEPER,
+    RPG_GO_GRIND = 0,
+    RPG_GO_INNKEEPER = 1,
     // Exploring nearby
-    NEAR_RANDOM,
-    NEAR_NPC,
-    // Do Quest (based on quest status and location)
-    QUESTING,
+    RPG_NEAR_RANDOM = 2,
+    RPG_NEAR_NPC = 3,
+    // Do Quest (based on quest status)
+    RPG_DO_QUEST = 4,
     // Taking a break
-    REST,
+    RPG_REST = 5,
     // Initial status
-    IDLE
+    RPG_IDLE = 6,
+    RPG_STATUS_END = 7
 };
+
+using NewRpgStatusTransitionProb = std::vector<std::vector<int>>;
 
 struct NewRpgInfo
 {
     NewRpgInfo() {}
     
-    // NewRpgStatus::GO_GRIND
+    // RPG_GO_GRIND
     struct GoGrind {
         GoGrind() = default;
         WorldPosition pos{};
     };
-    // NewRpgStatus::GO_INNKEEPER
+    // RPG_GO_INNKEEPER
     struct GoInnkeeper {
         GoInnkeeper() = default;
         WorldPosition pos{};
     };
-    // NewRpgStatus::NEAR_NPC
+    // RPG_NEAR_NPC
     struct NearNpc {
         NearNpc() = default;
         GuidPosition pos{};
         uint32 lastReach{0};
     };
-    // NewRpgStatus::NEAR_RANDOM
+    // RPG_NEAR_RANDOM
     struct NearRandom {
         NearRandom() = default;
     };
     // NewRpgStatus::QUESTING
-    struct Questing {
-        Quest* quest;
+    struct DoQuest {
+        const Quest* quest{nullptr};
+        uint32 questId{0};
+        uint32 objectiveIdx{0};
+        WorldPosition pos{};
+        uint32 lastReachPOI{0};
     };
-    // NewRpgStatus::REST
+    // RPG_REST
     struct Rest {
         Rest() = default;
     };
     struct Idle {
     };
-    NewRpgStatus status{NewRpgStatus::IDLE};
+    NewRpgStatus status{RPG_IDLE};
 
     uint32 startT{0}; // start timestamp of the current status
 
@@ -72,8 +81,9 @@ struct NewRpgInfo
         GoInnkeeper go_innkeeper;
         NearNpc near_npc;
         NearRandom near_random;
+        DoQuest do_quest;
         Rest rest;
-        Questing questing;
+        DoQuest quest;
     };
 
     bool HasStatusPersisted(uint32 maxDuration) { return startT + maxDuration < getMSTime(); }
@@ -81,11 +91,40 @@ struct NewRpgInfo
     void ChangeToGoInnkeeper(WorldPosition pos);
     void ChangeToNearNpc();
     void ChangeToNearRandom();
+    void ChangeToDoQuest(uint32 questId, const Quest* quest);
     void ChangeToRest();
     void ChangeToIdle();
-    
+    bool CanChangeTo(NewRpgStatus status);
     void Reset();
     std::string ToString();
 };
+
+struct NewRpgStatistic
+{
+    uint32 questAccepted{0};
+    uint32 questCompleted{0};
+    uint32 questRewarded{0};
+    uint32 questDropped{0};
+    NewRpgStatistic operator+(const NewRpgStatistic& other) const
+    {
+        NewRpgStatistic result;
+        result.questAccepted = this->questAccepted + other.questAccepted;
+        result.questCompleted = this->questCompleted + other.questCompleted;
+        result.questRewarded = this->questRewarded + other.questRewarded;
+        result.questDropped = this->questDropped + other.questDropped;
+        return result;
+    }
+    NewRpgStatistic& operator+=(const NewRpgStatistic& other)
+    {
+        this->questAccepted += other.questAccepted;
+        this->questCompleted += other.questCompleted;
+        this->questRewarded += other.questRewarded;
+        this->questDropped += other.questDropped;
+        return *this;
+    }
+};
+
+// not sure is it necessary but keep it for now
+#define RPG_INFO(x, y) botAI->rpgInfo.x.y
 
 #endif

--- a/src/strategy/rpg/NewRpgInfo.h
+++ b/src/strategy/rpg/NewRpgInfo.h
@@ -56,7 +56,7 @@ struct NewRpgInfo
     struct DoQuest {
         const Quest* quest{nullptr};
         uint32 questId{0};
-        uint32 objectiveIdx{0};
+        int32 objectiveIdx{0};
         WorldPosition pos{};
         uint32 lastReachPOI{0};
     };

--- a/src/strategy/rpg/NewRpgStrategy.cpp
+++ b/src/strategy/rpg/NewRpgStrategy.cpp
@@ -11,30 +11,28 @@ NewRpgStrategy::NewRpgStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
 
 NextAction** NewRpgStrategy::getDefaultActions()
 {
+    // the releavance should be greater than grind
     return NextAction::array(0,
-        new NextAction("new rpg status update", 5.0f), 
-        // new NextAction("new rpg accept or reward quest", 4.5f),
+        new NextAction("new rpg status update", 11.0f), 
         nullptr);
 }
 
 void NewRpgStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-
-    // the releavance should be greater than grind
     triggers.push_back(
-        new TriggerNode("go grind status", NextAction::array(0, new NextAction("new rpg go grind", 4.0f), nullptr)));
+        new TriggerNode("go grind status", NextAction::array(0, new NextAction("new rpg go grind", 3.0f), nullptr)));
     
     triggers.push_back(
-        new TriggerNode("go innkeeper status", NextAction::array(0, new NextAction("new rpg go innkeeper", 4.0f), nullptr)));
+        new TriggerNode("go innkeeper status", NextAction::array(0, new NextAction("new rpg go innkeeper", 3.0f), nullptr)));
 
     triggers.push_back(
-        new TriggerNode("near random status", NextAction::array(0, new NextAction("new rpg move random", 4.0f), nullptr)));
+        new TriggerNode("near random status", NextAction::array(0, new NextAction("new rpg move random", 3.0f), nullptr)));
 
     triggers.push_back(
-        new TriggerNode("near npc status", NextAction::array(0, new NextAction("new rpg move npc", 4.0f), nullptr)));
+        new TriggerNode("near npc status", NextAction::array(0, new NextAction("new rpg move npc", 3.0f), nullptr)));
     
     triggers.push_back(
-        new TriggerNode("do quest status", NextAction::array(0, new NextAction("new rpg do quest", 4.0f), nullptr)));
+        new TriggerNode("do quest status", NextAction::array(0, new NextAction("new rpg do quest", 3.0f), nullptr)));
 }
 
 void NewRpgStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)

--- a/src/strategy/rpg/NewRpgStrategy.cpp
+++ b/src/strategy/rpg/NewRpgStrategy.cpp
@@ -11,22 +11,30 @@ NewRpgStrategy::NewRpgStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
 
 NextAction** NewRpgStrategy::getDefaultActions()
 {
-    return NextAction::array(0, new NextAction("new rpg status update", 5.0f), nullptr);
+    return NextAction::array(0,
+        new NextAction("new rpg status update", 5.0f), 
+        // new NextAction("new rpg accept or reward quest", 4.5f),
+        nullptr);
 }
 
 void NewRpgStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+
+    // the releavance should be greater than grind
     triggers.push_back(
-        new TriggerNode("go grind status", NextAction::array(0, new NextAction("new rpg go grind", 1.0f), nullptr)));
+        new TriggerNode("go grind status", NextAction::array(0, new NextAction("new rpg go grind", 4.0f), nullptr)));
     
     triggers.push_back(
-        new TriggerNode("go innkeeper status", NextAction::array(0, new NextAction("new rpg go innkeeper", 1.0f), nullptr)));
+        new TriggerNode("go innkeeper status", NextAction::array(0, new NextAction("new rpg go innkeeper", 4.0f), nullptr)));
 
     triggers.push_back(
-        new TriggerNode("near random status", NextAction::array(0, new NextAction("new rpg move random", 1.0f), nullptr)));
+        new TriggerNode("near random status", NextAction::array(0, new NextAction("new rpg move random", 4.0f), nullptr)));
 
     triggers.push_back(
-        new TriggerNode("near npc status", NextAction::array(0, new NextAction("new rpg move npc", 1.0f), nullptr)));
+        new TriggerNode("near npc status", NextAction::array(0, new NextAction("new rpg move npc", 4.0f), nullptr)));
+    
+    triggers.push_back(
+        new TriggerNode("do quest status", NextAction::array(0, new NextAction("new rpg do quest", 4.0f), nullptr)));
 }
 
 void NewRpgStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)

--- a/src/strategy/rpg/NewRpgStrategy.h
+++ b/src/strategy/rpg/NewRpgStrategy.h
@@ -6,90 +6,11 @@
 #ifndef _PLAYERBOT_NEWRPGSTRATEGY_H
 #define _PLAYERBOT_NEWRPGSTRATEGY_H
 
-#include <cstdint>
 #include "Strategy.h"
 #include "TravelMgr.h"
+#include "NewRpgInfo.h"
 
 class PlayerbotAI;
-
-enum class NewRpgStatus
-{
-    // Going to far away place
-    GO_GRIND,
-    GO_INNKEEPER,
-    // Exploring nearby
-    NEAR_RANDOM,
-    NEAR_NPC,
-    // Taking a break
-    REST,
-    // Initial status
-    IDLE
-};
-
-struct NewRpgInfo
-{
-    NewRpgStatus status{NewRpgStatus::IDLE};
-    // NewRpgStatus::GO_GRIND
-    WorldPosition grindPos{};
-    uint32 lastGoGrind{0};
-    // NewRpgStatus::GO_INNKEEPER
-    WorldPosition innKeeperPos{};
-    uint32 lastGoInnKeeper{0};
-    // NewRpgStatus::NEAR_NPC
-    GuidPosition npcPos{};
-    uint32 lastNearNpc{0};
-    uint32 lastReachNpc{0};
-    // NewRpgStatus::NEAR_RANDOM
-    uint32 lastNearRandom{0};
-    // NewRpgStatus::REST
-    uint32 lastRest{0};
-    // MOVE_FAR
-    float nearestMoveFarDis{FLT_MAX};
-    uint32 stuckTs{0};
-    uint32 stuckAttempts{0};
-    std::string ToString()
-    {
-        std::stringstream out;
-        out << "Status: ";
-        switch (status)
-        {
-            case NewRpgStatus::GO_GRIND:
-                out << "GO_GRIND";
-                out << "\nGrindPos: " << grindPos.GetMapId() << " " << grindPos.GetPositionX() << " " << grindPos.GetPositionY() << " " << grindPos.GetPositionZ();
-                out << "\nlastGoGrind: " << lastGoGrind;
-                break;
-            case NewRpgStatus::GO_INNKEEPER:
-                out << "GO_INNKEEPER";
-                out << "\nInnKeeperPos: " << innKeeperPos.GetMapId() << " " << innKeeperPos.GetPositionX() << " " << innKeeperPos.GetPositionY() << " " << innKeeperPos.GetPositionZ();
-                out << "\nlastGoInnKeeper: " << lastGoInnKeeper;
-                break;
-            case NewRpgStatus::NEAR_NPC:
-                out << "NEAR_NPC";
-                out << "\nNpcPos: " << npcPos.GetMapId() << " " << npcPos.GetPositionX() << " " << npcPos.GetPositionY() << " " << npcPos.GetPositionZ();
-                out << "\nlastNearNpc: " << lastNearNpc;
-                out << "\nlastReachNpc: " << lastReachNpc;
-                break;
-            case NewRpgStatus::NEAR_RANDOM:
-                out << "NEAR_RANDOM";
-                out << "\nlastNearRandom: " << lastNearRandom;
-                break;
-            case NewRpgStatus::IDLE:
-                out << "IDLE";
-                break;
-            case NewRpgStatus::REST:
-                out << "REST";
-                out << "\nlastRest: " << lastRest;
-                break;
-            default:
-                out << "UNKNOWN";
-        }
-        return out.str();
-    }
-    void Reset()
-    {
-        *this = NewRpgInfo();
-    }
-};
 
 class NewRpgStrategy : public Strategy
 {

--- a/src/strategy/rpg/NewRpgTriggers.h
+++ b/src/strategy/rpg/NewRpgTriggers.h
@@ -7,7 +7,7 @@
 class NewRpgStatusTrigger : public Trigger
 {
 public:
-    NewRpgStatusTrigger(PlayerbotAI* botAI, NewRpgStatus status = NewRpgStatus::IDLE)
+    NewRpgStatusTrigger(PlayerbotAI* botAI, NewRpgStatus status = RPG_IDLE)
         : Trigger(botAI, "new rpg status"), status(status)
     {
     }

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -25,6 +25,7 @@ public:
         creators["log"] = &ChatTriggerContext::log;
         creators["los"] = &ChatTriggerContext::los;
         creators["rpg status"] = &ChatTriggerContext::rpg_status;
+        creators["rpg do quest"] = &ChatTriggerContext::rpg_do_quest;
         creators["aura"] = &ChatTriggerContext::aura;
         creators["drop"] = &ChatTriggerContext::drop;
         creators["share"] = &ChatTriggerContext::share;
@@ -213,6 +214,7 @@ private:
     static Trigger* log(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "log"); }
     static Trigger* los(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "los"); }
     static Trigger* rpg_status(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg status"); }
+    static Trigger* rpg_do_quest(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg do quest"); }
     static Trigger* aura(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "aura"); }
     static Trigger* loot_all(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "add all loot"); }
     static Trigger* release(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "release"); }

--- a/src/strategy/triggers/LootTriggers.cpp
+++ b/src/strategy/triggers/LootTriggers.cpp
@@ -12,10 +12,10 @@
 bool LootAvailableTrigger::IsActive()
 {
     return AI_VALUE(bool, "has available loot") &&
+            // if loot target if empty, always pass distance check
            (sServerFacade->IsDistanceLessOrEqualThan(AI_VALUE2(float, "distance", "loot target"),
                                                      INTERACTION_DISTANCE - 2.0f) ||
-            AI_VALUE(GuidVector, "all targets").empty()) &&
-           !AI_VALUE2(bool, "combat", "self target");
+            AI_VALUE(GuidVector, "all targets").empty());
 }
 
 bool FarFromCurrentLootTrigger::IsActive()

--- a/src/strategy/triggers/TriggerContext.h
+++ b/src/strategy/triggers/TriggerContext.h
@@ -219,6 +219,7 @@ public:
         creators["go innkeeper status"] = &TriggerContext::go_innkeeper_status;
         creators["near random status"] = &TriggerContext::near_random_status;
         creators["near npc status"] = &TriggerContext::near_npc_status;
+        creators["do quest status"] = &TriggerContext::do_quest_status;
     }
 
 private:
@@ -408,10 +409,11 @@ private:
     static Trigger* rpg_craft(PlayerbotAI* botAI) { return new RpgCraftTrigger(botAI); }
     static Trigger* rpg_trade_useful(PlayerbotAI* botAI) { return new RpgTradeUsefulTrigger(botAI); }
     static Trigger* rpg_duel(PlayerbotAI* botAI) { return new RpgDuelTrigger(botAI); }
-    static Trigger* go_grind_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::GO_GRIND); }
-    static Trigger* go_innkeeper_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::GO_INNKEEPER); }
-    static Trigger* near_random_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::NEAR_RANDOM); }
-    static Trigger* near_npc_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, NewRpgStatus::NEAR_NPC); }
+    static Trigger* go_grind_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_GO_GRIND); }
+    static Trigger* go_innkeeper_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_GO_INNKEEPER); }
+    static Trigger* near_random_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_NEAR_RANDOM); }
+    static Trigger* near_npc_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_NEAR_NPC); }
+    static Trigger* do_quest_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_DO_QUEST); }
 };
 
 #endif

--- a/src/strategy/values/AvailableLootValue.cpp
+++ b/src/strategy/values/AvailableLootValue.cpp
@@ -26,5 +26,5 @@ bool CanLootValue::Calculate()
 {
     LootObject loot = AI_VALUE(LootObject, "loot target");
     return !loot.IsEmpty() && loot.GetWorldObject(bot) && loot.IsLootPossible(bot) &&
-           sServerFacade->IsDistanceLessOrEqualThan(AI_VALUE2(float, "distance", "loot target"), INTERACTION_DISTANCE);
+           sServerFacade->IsDistanceLessOrEqualThan(AI_VALUE2(float, "distance", "loot target"), INTERACTION_DISTANCE - 2);
 }

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -116,7 +116,9 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_GO_INNKEEPER ||
             botAI->rpgInfo.status == RPG_DO_QUEST;
 
-        if (inactiveGrindStatus && (bot->GetDistance(unit) > 25.0f || !bot->IsHostileTo(unit)))
+        bool notHostile = !bot->IsHostileTo(unit) || (unit->ToCreature() && unit->ToCreature()->IsCivilian());
+        bool outOfAggro = unit->ToCreature() && bot->GetDistance(unit) > (unit->ToCreature()->GetAggroRange(bot) + 10.0f);
+        if (inactiveGrindStatus && (outOfAggro || notHostile))
         {
             if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
                 needForQuestMap[unit->GetEntry()] = needForQuest(unit);
@@ -197,7 +199,9 @@ bool GrindTargetValue::needForQuest(Unit* target)
                 if (uint32 lootId = data->lootid)
                 {
                     if (LootTemplates_Creature.HaveQuestLootForPlayer(lootId, bot))
+                    {
                         return true;
+                    }
                 }
             }
         }

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -115,7 +115,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_REST ||
             botAI->rpgInfo.status == RPG_GO_INNKEEPER ||
             botAI->rpgInfo.status == RPG_DO_QUEST;
-        // unit->SetInCombatWith()
+
         if (inactiveGrindStatus && (bot->GetDistance(unit) > 25.0f || !bot->IsHostileTo(unit)))
         {
             if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -117,7 +117,8 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_DO_QUEST;
 
         bool notHostile = !bot->IsHostileTo(unit) || (unit->ToCreature() && unit->ToCreature()->IsCivilian());
-        bool outOfAggro = unit->ToCreature() && bot->GetDistance(unit) > (unit->ToCreature()->GetAggroRange(bot) + 10.0f);
+        float aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);
+        bool outOfAggro = unit->ToCreature() && bot->GetDistance(unit) > aggroRange;
         if (inactiveGrindStatus && (outOfAggro || notHostile))
         {
             if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -117,7 +117,9 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_DO_QUEST;
 
         bool notHostile = !bot->IsHostileTo(unit) || (unit->ToCreature() && unit->ToCreature()->IsCivilian());
-        float aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);
+        float aggroRange = 30.0f;
+        if (unit->ToCreature())
+            aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);
         bool outOfAggro = unit->ToCreature() && bot->GetDistance(unit) > aggroRange;
         if (inactiveGrindStatus && (outOfAggro || notHostile))
         {

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -116,7 +116,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_GO_INNKEEPER ||
             botAI->rpgInfo.status == RPG_DO_QUEST;
 
-        bool notHostile = !bot->IsHostileTo(unit) || (unit->ToCreature() && unit->ToCreature()->IsCivilian());
+        bool notHostile = !bot->IsHostileTo(unit); /*|| (unit->ToCreature() && unit->ToCreature()->IsCivilian());*/
         float aggroRange = 30.0f;
         if (unit->ToCreature())
             aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -5,6 +5,7 @@
 
 #include "GrindTargetValue.h"
 
+#include "NewRpgInfo.h"
 #include "Playerbots.h"
 #include "ReputationMgr.h"
 #include "SharedDefines.h"
@@ -52,7 +53,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
 
     float distance = 0;
     Unit* result = nullptr;
-    // std::unordered_map<uint32, bool> needForQuestMap;
+    std::unordered_map<uint32, bool> needForQuestMap;
 
     for (ObjectGuid const guid : targets)
     {
@@ -99,19 +100,6 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
 		if (!bot->InBattleground() && (int)unit->GetLevel() - (int)bot->GetLevel() > 4 && !unit->GetGUID().IsPlayer())
 		    continue;
 
-        // if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
-        //     needForQuestMap[unit->GetEntry()] = needForQuest(unit);
-
-        // if (!needForQuestMap[unit->GetEntry()])
-        // {
-        //     Creature* creature = dynamic_cast<Creature*>(unit);
-        //     if ((urand(0, 100) < 60 || (context->GetValue<TravelTarget*>("travel target")->Get()->isWorking() &&
-        //         context->GetValue<TravelTarget*>("travel target")->Get()->getDestination()->getName() != "GrindTravelDestination")))
-        //     {
-        //         continue;
-        //     }
-        // }
-
         if (Creature* creature = unit->ToCreature())
             if (CreatureTemplate const* CreatureTemplate = creature->GetCreatureTemplate())
                 if (CreatureTemplate->rank > CREATURE_ELITE_NORMAL && !AI_VALUE(bool, "can fight elite"))
@@ -120,6 +108,21 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
         if (!bot->IsWithinLOSInMap(unit))
         {
             continue;
+        }
+
+        bool inactiveGrindStatus = botAI->rpgInfo.status == RPG_GO_GRIND ||
+            botAI->rpgInfo.status == RPG_NEAR_NPC ||
+            botAI->rpgInfo.status == RPG_REST ||
+            botAI->rpgInfo.status == RPG_GO_INNKEEPER ||
+            botAI->rpgInfo.status == RPG_DO_QUEST;
+        // unit->SetInCombatWith()
+        if (inactiveGrindStatus && (bot->GetDistance(unit) > 25.0f || !bot->IsHostileTo(unit)))
+        {
+            if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
+                needForQuestMap[unit->GetEntry()] = needForQuest(unit);
+
+            if (!needForQuestMap[unit->GetEntry()])
+                continue;
         }
 
         if (group)
@@ -155,8 +158,6 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
 
 bool GrindTargetValue::needForQuest(Unit* target)
 {
-    bool justCheck = (bot->GetGUID() == target->GetGUID());
-
     QuestStatusMap& questMap = bot->getQuestStatusMap();
     for (auto& quest : questMap)
     {
@@ -170,16 +171,9 @@ bool GrindTargetValue::needForQuest(Unit* target)
 
         QuestStatus status = bot->GetQuestStatus(questId);
 
-        if ((status == QUEST_STATUS_COMPLETE && !bot->GetQuestRewardStatus(questId)))
+        if (status == QUEST_STATUS_INCOMPLETE)
         {
-            if (!justCheck && !target->hasInvolvedQuest(questId))
-                continue;
-
-            return true;
-        }
-        else if (status == QUEST_STATUS_INCOMPLETE)
-        {
-            QuestStatusData* questStatus = sTravelMgr->getQuestStatus(bot, questId);
+            const QuestStatusData* questStatus = &bot->getQuestStatusMap()[questId];
 
             if (questTemplate->GetQuestLevel() > bot->GetLevel() + 5)
                 continue;
@@ -193,34 +187,17 @@ bool GrindTargetValue::needForQuest(Unit* target)
                     int required = questTemplate->RequiredNpcOrGoCount[j];
                     int available = questStatus->CreatureOrGOCount[j];
 
-                    if (required && available < required && (target->GetEntry() == entry || justCheck))
+                    if (required && available < required && target->GetEntry() == entry)
                         return true;
-                }
-
-                if (justCheck)
-                {
-                    int32 itemId = questTemplate->RequiredItemId[j];
-
-                    if (itemId && itemId > 0)
-                    {
-                        uint32 required = questTemplate->RequiredItemCount[j];
-                        uint32 available = questStatus->ItemCount[j];
-
-                        if (required && available < required)
-                            return true;
-                    }
                 }
             }
 
-            if (!justCheck)
+            if (CreatureTemplate const* data = sObjectMgr->GetCreatureTemplate(target->GetEntry()))
             {
-                if (CreatureTemplate const* data = sObjectMgr->GetCreatureTemplate(target->GetEntry()))
+                if (uint32 lootId = data->lootid)
                 {
-                    if (uint32 lootId = data->lootid)
-                    {
-                        if (LootTemplates_Creature.HaveQuestLootForPlayer(lootId, bot))
-                            return true;
-                    }
+                    if (LootTemplates_Creature.HaveQuestLootForPlayer(lootId, bot))
+                        return true;
                 }
             }
         }

--- a/src/strategy/values/LastMovementValue.h
+++ b/src/strategy/values/LastMovementValue.h
@@ -17,6 +17,7 @@ class Unit;
 enum class MovementPriority
 {
     MOVEMENT_IDLE,
+    MOVEMENT_WANDER,
     MOVEMENT_NORMAL,
     MOVEMENT_COMBAT,
     MOVEMENT_FORCED

--- a/src/strategy/values/NearestGameObjects.cpp
+++ b/src/strategy/values/NearestGameObjects.cpp
@@ -12,24 +12,6 @@
 #include "SharedDefines.h"
 #include "SpellMgr.h"
 
-class AnyGameObjectInObjectRangeCheck
-{
-public:
-    AnyGameObjectInObjectRangeCheck(WorldObject const* obj, float range) : i_obj(obj), i_range(range) {}
-    WorldObject const& GetFocusObject() const { return *i_obj; }
-    bool operator()(GameObject* u)
-    {
-        if (u && i_obj->IsWithinDistInMap(u, i_range) && u->isSpawned() && u->GetGOInfo())
-            return true;
-
-        return false;
-    }
-
-private:
-    WorldObject const* i_obj;
-    float i_range;
-};
-
 GuidVector NearestGameObjects::Calculate()
 {
     std::list<GameObject*> targets;

--- a/src/strategy/values/NearestGameObjects.h
+++ b/src/strategy/values/NearestGameObjects.h
@@ -16,7 +16,7 @@ class NearestGameObjects : public ObjectGuidListCalculatedValue
 public:
     NearestGameObjects(PlayerbotAI* botAI, float range = sPlayerbotAIConfig->sightDistance, bool ignoreLos = false,
                        std::string const name = "nearest game objects")
-        : ObjectGuidListCalculatedValue(botAI, name, 2 * 1000), range(range), ignoreLos(ignoreLos)
+        : ObjectGuidListCalculatedValue(botAI, name, 1 * 1000), range(range), ignoreLos(ignoreLos)
     {
     }
 

--- a/src/strategy/values/NearestGameObjects.h
+++ b/src/strategy/values/NearestGameObjects.h
@@ -8,8 +8,27 @@
 
 #include "PlayerbotAIConfig.h"
 #include "Value.h"
+#include "GameObject.h"
 
 class PlayerbotAI;
+
+class AnyGameObjectInObjectRangeCheck
+{
+public:
+    AnyGameObjectInObjectRangeCheck(WorldObject const* obj, float range) : i_obj(obj), i_range(range) {}
+    WorldObject const& GetFocusObject() const { return *i_obj; }
+    bool operator()(GameObject* u)
+    {
+        if (u && i_obj->IsWithinDistInMap(u, i_range) && u->isSpawned() && u->GetGOInfo())
+            return true;
+
+        return false;
+    }
+
+private:
+    WorldObject const* i_obj;
+    float i_range;
+};
 
 class NearestGameObjects : public ObjectGuidListCalculatedValue
 {

--- a/src/strategy/values/PossibleRpgTargetsValue.cpp
+++ b/src/strategy/values/PossibleRpgTargetsValue.cpp
@@ -8,6 +8,7 @@
 #include "CellImpl.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
+#include "ObjectGuid.h"
 #include "Playerbots.h"
 #include "ServerFacade.h"
 
@@ -75,6 +76,85 @@ bool PossibleRpgTargetsValue::AcceptUnit(Unit* unit)
 
     if (urand(1, 100) < 5)
         return true;
+
+    return false;
+}
+
+
+std::vector<uint32> PossibleNewRpgTargetsValue::allowedNpcFlags;
+
+PossibleNewRpgTargetsValue::PossibleNewRpgTargetsValue(PlayerbotAI* botAI, float range)
+    : NearestUnitsValue(botAI, "possible new rpg targets", range, true)
+{
+    if (allowedNpcFlags.empty())
+    {
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_INNKEEPER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GOSSIP);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_QUESTGIVER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_FLIGHTMASTER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BANKER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GUILD_BANKER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_CLASS);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_PROFESSION);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_AMMO);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_FOOD);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_POISON);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_REAGENT);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_AUCTIONEER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_STABLEMASTER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_PETITIONER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TABARDDESIGNER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BATTLEMASTER);
+
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR);
+        allowedNpcFlags.push_back(UNIT_NPC_FLAG_REPAIR);
+    }
+}
+
+GuidVector PossibleNewRpgTargetsValue::Calculate()
+{
+    std::list<Unit*> targets;
+    FindUnits(targets);
+
+    GuidVector results;
+    std::vector<std::pair<ObjectGuid, float>> guidDistancePairs;
+    for (Unit* unit : targets)
+    {
+        if (AcceptUnit(unit) && (ignoreLos || bot->IsWithinLOSInMap(unit)))
+            guidDistancePairs.push_back({unit->GetGUID(), bot->GetExactDist(unit)});
+    }
+    // Override to sort by distance
+    std::sort(guidDistancePairs.begin(), guidDistancePairs.end(), [](const auto& a, const auto& b) {
+        return a.second < b.second;
+    });
+    
+    for (const auto& pair : guidDistancePairs) {
+        results.push_back(pair.first);
+    }
+    return results;
+}
+
+void PossibleNewRpgTargetsValue::FindUnits(std::list<Unit*>& targets)
+{
+    Acore::AnyUnitInObjectRangeCheck u_check(bot, range);
+    Acore::UnitListSearcher<Acore::AnyUnitInObjectRangeCheck> searcher(bot, targets, u_check);
+    Cell::VisitAllObjects(bot, searcher, range);
+}
+
+bool PossibleNewRpgTargetsValue::AcceptUnit(Unit* unit)
+{
+    if (unit->IsHostileTo(bot) || unit->GetTypeId() == TYPEID_PLAYER)
+        return false;
+
+    if (unit->HasFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_SPIRITHEALER))
+        return false;
+
+    for (uint32 npcFlag : allowedNpcFlags)
+    {
+        if (unit->HasFlag(UNIT_NPC_FLAGS, npcFlag))
+            return true;
+    }
 
     return false;
 }

--- a/src/strategy/values/PossibleRpgTargetsValue.cpp
+++ b/src/strategy/values/PossibleRpgTargetsValue.cpp
@@ -174,11 +174,7 @@ GuidVector PossibleNewRpgGameObjectsValue::Calculate()
     std::vector<std::pair<ObjectGuid, float>> guidDistancePairs;
     for (GameObject* go : targets)
     {
-        if (!ignoreLos && !bot->IsWithinLOSInMap(go))
-            continue;
-
         bool flagCheck = false;
-        
         for (uint32 goFlag : allowedGOFlags)
         {
             if (go->GetGoType() == goFlag)
@@ -188,6 +184,9 @@ GuidVector PossibleNewRpgGameObjectsValue::Calculate()
             }
         }
         if (!flagCheck)
+            continue;
+        
+        if (!ignoreLos && !bot->IsWithinLOSInMap(go))
             continue;
         
         guidDistancePairs.push_back({go->GetGUID(), bot->GetExactDist(go)});

--- a/src/strategy/values/PossibleRpgTargetsValue.h
+++ b/src/strategy/values/PossibleRpgTargetsValue.h
@@ -23,4 +23,16 @@ protected:
     bool AcceptUnit(Unit* unit) override;
 };
 
+class PossibleNewRpgTargetsValue : public NearestUnitsValue
+{
+public:
+    PossibleNewRpgTargetsValue(PlayerbotAI* botAI, float range = 150.0f);
+
+    static std::vector<uint32> allowedNpcFlags;
+    GuidVector Calculate() override;
+protected:
+    void FindUnits(std::list<Unit*>& targets) override;
+    bool AcceptUnit(Unit* unit) override;
+};
+
 #endif

--- a/src/strategy/values/PossibleRpgTargetsValue.h
+++ b/src/strategy/values/PossibleRpgTargetsValue.h
@@ -6,8 +6,10 @@
 #ifndef _PLAYERBOT_POSSIBLERPGTARGETSVALUE_H
 #define _PLAYERBOT_POSSIBLERPGTARGETSVALUE_H
 
+#include "NearestGameObjects.h"
 #include "NearestUnitsValue.h"
 #include "PlayerbotAIConfig.h"
+#include "SharedDefines.h"
 
 class PlayerbotAI;
 
@@ -33,6 +35,26 @@ public:
 protected:
     void FindUnits(std::list<Unit*>& targets) override;
     bool AcceptUnit(Unit* unit) override;
+};
+
+class PossibleNewRpgGameObjectsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    PossibleNewRpgGameObjectsValue(PlayerbotAI* botAI, float range = 150.0f, bool ignoreLos = true)
+        : ObjectGuidListCalculatedValue(botAI, "possible new rpg game objects"), range(range), ignoreLos(ignoreLos)
+    {
+        if (allowedGOFlags.empty())
+        {
+            allowedGOFlags.push_back(GAMEOBJECT_TYPE_QUESTGIVER);
+        }
+    }
+    
+    static std::vector<GameobjectTypes> allowedGOFlags;
+    GuidVector Calculate() override;
+
+private:
+    float range;
+    bool ignoreLos;
 };
 
 #endif

--- a/src/strategy/values/ValueContext.h
+++ b/src/strategy/values/ValueContext.h
@@ -118,6 +118,7 @@ public:
         creators["prioritized targets"] = &ValueContext::prioritized_targets;
         creators["all targets"] = &ValueContext::all_targets;
         creators["possible rpg targets"] = &ValueContext::possible_rpg_targets;
+        creators["possible new rpg targets"] = &ValueContext::possible_new_rpg_targets;
         creators["nearest adds"] = &ValueContext::nearest_adds;
         creators["nearest corpses"] = &ValueContext::nearest_corpses;
         creators["log level"] = &ValueContext::log_level;
@@ -406,6 +407,7 @@ private:
     static UntypedValue* nearest_enemy_players(PlayerbotAI* botAI) { return new NearestEnemyPlayersValue(botAI); }
     static UntypedValue* nearest_corpses(PlayerbotAI* botAI) { return new NearestCorpsesValue(botAI); }
     static UntypedValue* possible_rpg_targets(PlayerbotAI* botAI) { return new PossibleRpgTargetsValue(botAI); }
+    static UntypedValue* possible_new_rpg_targets(PlayerbotAI* botAI) { return new PossibleNewRpgTargetsValue(botAI); }
     static UntypedValue* possible_targets(PlayerbotAI* botAI) { return new PossibleTargetsValue(botAI); }
     static UntypedValue* possible_triggers(PlayerbotAI* botAI) { return new PossibleTriggersValue(botAI); }
     static UntypedValue* possible_targets_no_los(PlayerbotAI* botAI)

--- a/src/strategy/values/ValueContext.h
+++ b/src/strategy/values/ValueContext.h
@@ -119,6 +119,7 @@ public:
         creators["all targets"] = &ValueContext::all_targets;
         creators["possible rpg targets"] = &ValueContext::possible_rpg_targets;
         creators["possible new rpg targets"] = &ValueContext::possible_new_rpg_targets;
+        creators["possible new rpg game objects"] = &ValueContext::possible_new_rpg_game_objects;
         creators["nearest adds"] = &ValueContext::nearest_adds;
         creators["nearest corpses"] = &ValueContext::nearest_corpses;
         creators["log level"] = &ValueContext::log_level;
@@ -408,6 +409,7 @@ private:
     static UntypedValue* nearest_corpses(PlayerbotAI* botAI) { return new NearestCorpsesValue(botAI); }
     static UntypedValue* possible_rpg_targets(PlayerbotAI* botAI) { return new PossibleRpgTargetsValue(botAI); }
     static UntypedValue* possible_new_rpg_targets(PlayerbotAI* botAI) { return new PossibleNewRpgTargetsValue(botAI); }
+    static UntypedValue* possible_new_rpg_game_objects(PlayerbotAI* botAI) { return new PossibleNewRpgGameObjectsValue(botAI); }
     static UntypedValue* possible_targets(PlayerbotAI* botAI) { return new PossibleTargetsValue(botAI); }
     static UntypedValue* possible_triggers(PlayerbotAI* botAI) { return new PossibleTriggersValue(botAI); }
     static UntypedValue* possible_targets_no_los(PlayerbotAI* botAI)


### PR DESCRIPTION
Quest related features are added to `new rpg` strategy:
1. Prioritize aceepting or rewarding nearby quests in all states.
2. In do quest state, select and move to quest locations (via points of interest).
3. Grind and loot strategies will allow them to complete most simple quests.
4. Upon quest completion, they will return to the quest giver for rewards.
5. When quest logs is full, manage the quest log and drop inappropriate quests to ensure free slots.

Other optimization:
1. Speeds up server startup by hardcoded zone levels instead of calculating.
2. Some improvements on grind and loot strategies make the quests objective more attractive to bots.

Known Issues:
1. Quest POI has no positionz, so bots may struggle to navigate complex terrain (e.g., caves).
2. Complex quests may not be fully supported as bots can only complete simple quests such as dialogue, killing mobs, looting, and collecting game objects. When a quest is not completed for more than 30 minutes, the status will be switched.
3. Only solo quests are accepted (elite and dungeon quests are ignored).
4. Periodic teleports and teleports on levelup can break the quest procedure. As bots won't do quest in different zone or too far away from them.
5. (solved) ~Can only accept or reward quests from NPCs, not gameobjects.~

How to verify:
1. Set `EnableNewRpgStrategy=1` and monitor rndbots. Whisper `rpg status` to check the current state. Checking `playerbots rndbot stats` and logs (filtered by `accept quest` and `turned in quest`) to verify quest activity.
2. Add bots using altbots or addclass bots. Whisper `nc -follow,+grind,+new rpg` to start rpg. Whisper command `rpg do quest <questId>` to force them do the specific quest. (Make sure the quest is aceepted and can be completed nearby, currently it is within 1500y)