### PR TITLE
Improve XP rate config

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -369,9 +369,9 @@ AiPlayerbot.AggroDistance = 22
 #
 #
 
-# Set kill XP rate for bots (default: 1)
-# Server XP Rate * AiPlayerbot.KillXPRate
-AiPlayerbot.KillXPRate = 1
+# Set XP rate for bots (default: 1.0)
+# Server XP Rate * AiPlayerbot.PlayerbotsXPRate
+AiPlayerbot.PlayerbotsXPRate = 1.0
 
 # Health/Mana levels
 AiPlayerbot.CriticalHealth = 25

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -481,7 +481,7 @@ bool PlayerbotAIConfig::Initialize()
     autoGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearQualityLimit", 3);
     autoGearScoreLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearScoreLimit", 0);
 
-    playerbotsXPrate = sConfigMgr->GetOption<int32>("AiPlayerbot.KillXPRate", 1);
+    playerbotsXPrate = sConfigMgr->GetOption<float>("AiPlayerbot.PlayerbotsXPRate", 1.0);
     randomBotAllianceRatio = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAllianceRatio", 50);
     randomBotHordeRatio = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotHordeRatio", 50);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -275,7 +275,7 @@ public:
     bool randomBotShowCloak;
     bool randomBotFixedLevel;
     bool disableRandomLevels;
-    uint32 playerbotsXPrate;
+    float playerbotsXPrate;
     uint32 randomBotAllianceRatio;
     uint32 randomBotHordeRatio;
     bool disableDeathKnightLogin;

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -23,6 +23,8 @@
 #include "DatabaseLoader.h"
 #include "GuildTaskMgr.h"
 #include "Metric.h"
+#include "PlayerScript.h"
+#include "PlayerbotAIConfig.h"
 #include "RandomPlayerbotMgr.h"
 #include "ScriptMgr.h"
 #include "cs_playerbots.h"
@@ -83,7 +85,8 @@ public:
         PLAYERHOOK_ON_CHAT_WITH_GROUP,
         PLAYERHOOK_ON_BEFORE_CRITERIA_PROGRESS,
         PLAYERHOOK_ON_BEFORE_ACHI_COMPLETE,
-        PLAYERHOOK_CAN_PLAYER_USE_PRIVATE_CHAT
+        PLAYERHOOK_CAN_PLAYER_USE_PRIVATE_CHAT,
+        PLAYERHOOK_ON_GIVE_EXP
     }) {}
 
     void OnPlayerLogin(Player* player) override
@@ -209,6 +212,17 @@ public:
             return false;
         }
         return true;
+    }
+
+    void OnPlayerGiveXP(Player* player, uint32& amount, Unit* /*victim*/, uint8 /*xpSource*/) override
+    {
+        if (!player->GetSession()->IsBot())
+            return;
+        
+        if (sPlayerbotAIConfig->playerbotsXPrate != 1.0)
+        {
+            amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->playerbotsXPrate));
+        }
     }
 };
 

--- a/src/strategy/actions/XpGainAction.cpp
+++ b/src/strategy/actions/XpGainAction.cpp
@@ -18,21 +18,21 @@ bool XpGainAction::Execute(Event event)
 
     WorldPacket p(event.getPacket());  // (8+4+1+4+8)
     ObjectGuid guid;
-    uint32 xpgain;
-    uint8 type = 0;  // 00-kill_xp type, 01-non_kill_xp type
-    uint32 givenXp = 0;
-    float groupBonus = 0;
+    // uint32 xpgain;
+    // uint8 type = 0;  // 00-kill_xp type, 01-non_kill_xp type
+    // uint32 givenXp = 0;
+    // float groupBonus = 0;
 
     p.rpos(0);
     p >> guid;    // 8 victim
-    p >> xpgain;  // 1 given experience
-    p >> type;    // 1 00-kill_xp type, 01-non_kill_xp type
+    // p >> xpgain;  // 1 given experience
+    // p >> type;    // 1 00-kill_xp type, 01-non_kill_xp type
 
-    if (!type)
-    {
-        p >> givenXp;     // 4 experience without rested bonus
-        p >> groupBonus;  // 8 group bonus
-    }
+    // if (!type)
+    // {
+    //     p >> givenXp;     // 4 experience without rested bonus
+    //     p >> groupBonus;  // 8 group bonus
+    // }
 
     Creature* creature = botAI->GetCreature(guid);
     if (creature && !creature->GetMap()->IsDungeon())
@@ -40,15 +40,16 @@ bool XpGainAction::Execute(Event event)
         BroadcastHelper::BroadcastKill(botAI, bot, creature);
     }
 
-    if (!sRandomPlayerbotMgr->IsRandomBot(bot) || sPlayerbotAIConfig->playerbotsXPrate == 1)
-        return true;
+    // playerbotsXPrate is now implemented in OnPlayerGiveXP script
+    // if (!sRandomPlayerbotMgr->IsRandomBot(bot) || sPlayerbotAIConfig->playerbotsXPrate == 1)
+    //     return true;
     
-    Unit* victim = nullptr;
-    if (guid)
-        victim = botAI->GetUnit(guid);
+    // Unit* victim = nullptr;
+    // if (guid)
+    //     victim = botAI->GetUnit(guid);
 
-    xpgain = xpgain * (sPlayerbotAIConfig->playerbotsXPrate - 1);
-    GiveXP(xpgain, victim);
+    // xpgain = xpgain * (sPlayerbotAIConfig->playerbotsXPrate - 1);
+    // GiveXP(xpgain, victim);
 
     return true;
 }


### PR DESCRIPTION
Rename from `KillXPRate` to `PlayerbotsXPRate`.

Affect all xp including kills and quests. Allows to be set to a float number less than 1.0.