### PR TITLE
ChatHelper link localization

### DIFF
--- a/src/ChatHelper.cpp
+++ b/src/ChatHelper.cpp
@@ -6,6 +6,9 @@
 #include "ChatHelper.h"
 
 #include "AiFactory.h"
+#include "Common.h"
+#include "ItemTemplate.h"
+#include "ObjectMgr.h"
 #include "Playerbots.h"
 #include "SpellInfo.h"
 
@@ -310,7 +313,16 @@ std::string const ChatHelper::FormatQuest(Quest const* quest)
     }
 
     std::ostringstream out;
-    out << "|cFFFFFF00|Hquest:" << quest->GetQuestId() << ':' << quest->GetQuestLevel() << "|h[" << quest->GetTitle() << "]|h|r";
+    QuestLocale const* locale = sObjectMgr->GetQuestLocale(quest->GetQuestId());
+    std::string questTitle;
+
+    if (locale && locale->Title.size() > sWorld->GetDefaultDbcLocale())
+        questTitle = locale->Title[sWorld->GetDefaultDbcLocale()];
+
+    if (questTitle.empty())
+        questTitle = quest->GetTitle();
+    
+    out << "|cFFFFFF00|Hquest:" << quest->GetQuestId() << ':' << quest->GetQuestLevel() << "|h[" << questTitle << "]|h|r";
     return out.str();
 }
 
@@ -318,7 +330,7 @@ std::string const ChatHelper::FormatGameobject(GameObject* go)
 {
     std::ostringstream out;
     out << "|cFFFFFF00|Hfound:" << go->GetGUID().GetRawValue() << ":" << go->GetEntry() << ":"
-        << "|h[" << go->GetNameForLocaleIdx(LOCALE_enUS) << "]|h|r";
+        << "|h[" << go->GetNameForLocaleIdx(sWorld->GetDefaultDbcLocale()) << "]|h|r";
     return out.str();
 }
 
@@ -327,8 +339,8 @@ std::string const ChatHelper::FormatWorldobject(WorldObject* wo)
     std::ostringstream out;
     out << "|cFFFFFF00|Hfound:" << wo->GetGUID().GetRawValue() << ":" << wo->GetEntry() << ":"
         << "|h[";
-    out << (wo->ToGameObject() ? ((GameObject*)wo)->GetNameForLocaleIdx(LOCALE_enUS)
-                               : wo->GetNameForLocaleIdx(LOCALE_enUS))
+    out << (wo->ToGameObject() ? ((GameObject*)wo)->GetNameForLocaleIdx(sWorld->GetDefaultDbcLocale())
+                               : wo->GetNameForLocaleIdx(sWorld->GetDefaultDbcLocale()))
         << "]|h|r";
     return out.str();
 }
@@ -361,7 +373,9 @@ std::string const ChatHelper::FormatWorldEntry(int32 entry)
 std::string const ChatHelper::FormatSpell(SpellInfo const* spellInfo)
 {
     std::ostringstream out;
-    out << "|cffffffff|Hspell:" << spellInfo->Id << "|h[" << spellInfo->SpellName[LOCALE_enUS] << "]|h|r";
+    std::string spellName = spellInfo->SpellName[sWorld->GetDefaultDbcLocale()] ?
+        spellInfo->SpellName[sWorld->GetDefaultDbcLocale()] : spellInfo->SpellName[LOCALE_enUS];
+    out << "|cffffffff|Hspell:" << spellInfo->Id << "|h[" << spellName << "]|h|r";
     return out.str();
 }
 
@@ -370,11 +384,18 @@ std::string const ChatHelper::FormatItem(ItemTemplate const* proto, uint32 count
     char color[32];
     sprintf(color, "%x", ItemQualityColors[proto->Quality]);
 
-    // const std::string &name = sObjectMgr->GetItemLocale(proto->ItemId)->Name[LOCALE_enUS];
+    std::string itemName;
+    const ItemLocale* locale = sObjectMgr->GetItemLocale(proto->ItemId);
+
+    if (locale && locale->Name.size() > sWorld->GetDefaultDbcLocale())
+        itemName = locale->Name[sWorld->GetDefaultDbcLocale()];
+    
+    if (itemName.empty())
+        itemName = proto->Name1;
 
     std::ostringstream out;
     out << "|c" << color << "|Hitem:" << proto->ItemId << ":0:0:0:0:0:0:0"
-        << "|h[" << proto->Name1 << "]|h|r";
+        << "|h[" << itemName << "]|h|r";
 
     if (count > 1)
         out << "x" << count;


### PR DESCRIPTION
Get name and title based on default dbc locale. Tested on English and Chinese locale.

Previous localization changes resulted in some crashes. Although I'm handling them carefully in this PR to avoid possible crash situations, it's still nice to do some testing, especially under different DBC.Locale configurations.

https://github.com/liyunfan1223/mod-playerbots/issues/1022