### PR TITLE
Update GrindTargetValue.cpp - Added safety check

### DIFF
--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -116,9 +116,13 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_GO_INNKEEPER ||
             botAI->rpgInfo.status == RPG_DO_QUEST;
 
-        bool notHostile = !bot->IsHostileTo(unit) || (unit->ToCreature() && unit->ToCreature()->IsCivilian());
-        float aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);
-        bool outOfAggro = unit->ToCreature() && bot->GetDistance(unit) > aggroRange;
+        bool notHostile = !bot || !unit || !bot->IsHostileTo(unit) || (unit->ToCreature() && unit->ToCreature()->IsCivilian());
+        float aggroRange = 30.0f;
+        
+        if (unit && unit->ToCreature())
+            aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);
+        
+        bool outOfAggro = unit && unit->ToCreature() && bot && bot->GetDistance(unit) > aggroRange;
         if (inactiveGrindStatus && (outOfAggro || notHostile))
         {
             if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())


### PR DESCRIPTION
Crash occurred due to a segmentation fault (SIGSEGV) in the Creature::GetAggroRange function. The function is being called on a null object.