### PR TITLE
Rogue bots can unlock items in their bags and in the trade window

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3179,6 +3179,12 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         else if (itemTarget)
         {
             targets.SetItemTarget(itemTarget);
+            Player* trader = bot->GetTrader();
+            if (trader)
+            {
+                targets.SetUnitTarget(trader);
+                faceTo = trader;
+            }
         }
         else
         {

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3223,6 +3223,53 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         //     LOG_DEBUG("playerbots", "Spell cast failed. - target name: {}, spellid: {}, bot name: {}, result: {}",
         //         target->GetName(), spellId, bot->GetName(), result);
         // }
+        if (HasStrategy("debug spell", BOT_STATE_NON_COMBAT))
+        {
+            std::ostringstream out;
+            out << "Spell cast failed - ";
+            out << "Spell ID: " << spellId << " (" << ChatHelper::FormatSpell(spellInfo) << "), ";
+            out << "Error Code: " << result << ", ";
+            out << "Bot: " << bot->GetName() << ", ";
+    
+            // Check spell target type
+            if (targets.GetUnitTarget())
+            {
+                out << "Target: Unit (" << targets.GetUnitTarget()->GetName() << "), ";
+            }
+            else if (targets.GetGOTarget())
+            {
+                out << "Target: GameObject (" << targets.GetGOTarget()->GetGUID() << "), ";
+            }
+            else if (targets.GetItemTarget())
+            {
+                out << "Target: Item (" << targets.GetItemTarget()->GetGUID() << "), ";
+            }
+            else
+            {
+                out << "Target: None, ";
+            }
+    
+            // Check if bot is in trade mode
+            if (bot->GetTradeData())
+            {
+                out << "Trade Mode: Active, ";
+                Item* tradeItem = bot->GetTradeData()->GetTraderData()->GetItem(TRADE_SLOT_NONTRADED);
+                if (tradeItem)
+                {
+                    out << "Trade Item: " << tradeItem->GetEntry() << " (" << tradeItem->GetGUID() << "), ";
+                }
+                else
+                {
+                    out << "Trade Item: None, ";
+                }
+            }
+            else
+            {
+                out << "Trade Mode: Inactive, ";
+            }
+    
+            TellMasterNoFacing(out);
+        }
         return false;
     }
     // if (spellInfo->Effects[0].Effect == SPELL_EFFECT_OPEN_LOCK || spellInfo->Effects[0].Effect ==

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3183,7 +3183,8 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             Player* trader = bot->GetTrader();
             if (trader)
             {
-                targets.SetUnitTarget(trader);
+                targets.SetUnitTarget(bot);
+                // targets.SetUnitTarget(trader);
                 faceTo = trader;
             }
         }

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3181,19 +3181,15 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         else if (itemTarget)
         {
             Player* trader = bot->GetTrader();
-            TradeData* tradeData = bot->GetTradeData();
-            Item* lockbox = tradeData ? tradeData->GetItem(TRADE_SLOT_NONTRADED) : nullptr; // Prevents null pointer crash
-        
-            // Only SetTradeItemTarget if a locked item exists
-            if (trader && lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked())
+            if (trader)
             {
                 targets.SetTradeItemTarget(bot);
-                // targets.SetUnitTarget(bot);
+                targets.SetUnitTarget(bot);
                 faceTo = trader;
             }
             else
             {
-                targets.SetItemTarget(itemTarget); // Normal item targeting outside of trade
+                targets.SetItemTarget(itemTarget);
             }
         }
         else

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3185,7 +3185,6 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             {
                 targets.SetTradeItemTarget(bot);
                 targets.SetUnitTarget(bot);
-                // targets.SetUnitTarget(trader);
                 faceTo = trader;
             }
             else

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3133,7 +3133,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
     Spell* spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
 
     SpellCastTargets targets;
-    if (spellInfo->Targets & TARGET_FLAG_ITEM)
+    if (spellInfo->Targets & TARGET_FLAG_ITEM || spellInfo->Targets & TARGET_FLAG_GAMEOBJECT_ITEM)
     {
         Item* item = itemTarget ? itemTarget : aiObjectContext->GetValue<Item*>("item for spell", spellId)->Get();
         targets.SetItemTarget(item);
@@ -3175,6 +3175,10 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             bot->GetSession()->HandleGameObjectUseOpcode(packetgouse);
             targets.SetGOTarget(go);
             faceTo = go;
+        }
+        else if (itemTarget)
+        {
+            targets.SetItemTarget(itemTarget);
         }
         else
         {
@@ -3308,7 +3312,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, float x, float y, float z, Item* ite
     Spell* spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
 
     SpellCastTargets targets;
-    if (spellInfo->Targets & TARGET_FLAG_ITEM)
+    if (spellInfo->Targets & TARGET_FLAG_ITEM || spellInfo->Targets & TARGET_FLAG_GAMEOBJECT_ITEM)
     {
         Item* item = itemTarget ? itemTarget : aiObjectContext->GetValue<Item*>("item for spell", spellId)->Get();
         targets.SetItemTarget(item);

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3181,15 +3181,26 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         else if (itemTarget)
         {
             Player* trader = bot->GetTrader();
-            if (trader)
+            TradeData* tradeData = bot->GetTradeData();
+        
+            if (trader && tradeData)
             {
-                targets.SetTradeItemTarget(bot);
-                targets.SetUnitTarget(bot);
-                faceTo = trader;
+                Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
+                
+                if (lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked()) // Only SetTradeItemTarget if a locked item exists
+                {
+                    targets.SetTradeItemTarget(bot);
+                    targets.SetUnitTarget(bot);
+                    faceTo = trader;
+                }
+                else
+                {
+                    targets.SetItemTarget(itemTarget); // Fallback to normal item targeting because no lockbox is in the trade window
+                }
             }
             else
             {
-                targets.SetItemTarget(itemTarget);
+                targets.SetItemTarget(itemTarget); // Normal item targeting outside of trade
             }
         }
         else

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3133,7 +3133,8 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
     Spell* spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
 
     SpellCastTargets targets;
-    if (spellInfo->Targets & TARGET_FLAG_ITEM || spellInfo->Targets & TARGET_FLAG_GAMEOBJECT_ITEM)
+    if (spellInfo->Effects[0].Effect != SPELL_EFFECT_OPEN_LOCK &&
+        (spellInfo->Targets & TARGET_FLAG_ITEM || spellInfo->Targets & TARGET_FLAG_GAMEOBJECT_ITEM))
     {
         Item* item = itemTarget ? itemTarget : aiObjectContext->GetValue<Item*>("item for spell", spellId)->Get();
         targets.SetItemTarget(item);

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -174,6 +174,7 @@ PlayerbotAI::PlayerbotAI(Player* bot)
     botOutgoingPacketHandlers.AddHandler(SMSG_RESURRECT_REQUEST, "resurrect request");
     botOutgoingPacketHandlers.AddHandler(SMSG_INVENTORY_CHANGE_FAILURE, "cannot equip");
     botOutgoingPacketHandlers.AddHandler(SMSG_TRADE_STATUS, "trade status");
+    botOutgoingPacketHandlers.AddHandler(SMSG_TRADE_STATUS_EXTENDED, "trade status extended");
     botOutgoingPacketHandlers.AddHandler(SMSG_LOOT_RESPONSE, "loot response");
     botOutgoingPacketHandlers.AddHandler(SMSG_ITEM_PUSH_RESULT, "item push result");
     botOutgoingPacketHandlers.AddHandler(SMSG_PARTY_COMMAND_RESULT, "party command");

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3234,15 +3234,19 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             // Check spell target type
             if (targets.GetUnitTarget())
             {
-                out << "Target: Unit (" << targets.GetUnitTarget()->GetName() << "), ";
+                out << "Target: Unit (" << targets.GetUnitTarget()->GetName() 
+                    << ", Low GUID: " << targets.GetUnitTarget()->GetGUID().GetCounter()
+                    << ", High GUID: " << targets.GetUnitTarget()->GetGUID().GetHigh() << "), ";
             }
             else if (targets.GetGOTarget())
             {
-                out << "Target: GameObject (" << targets.GetGOTarget()->GetGUID() << "), ";
+                out << "Target: GameObject (Low GUID: " << targets.GetGOTarget()->GetGUID().GetCounter()
+                    << ", High GUID: " << targets.GetGOTarget()->GetGUID().GetHigh() << "), ";
             }
             else if (targets.GetItemTarget())
             {
-                out << "Target: Item (" << targets.GetItemTarget()->GetGUID() << "), ";
+                out << "Target: Item (Low GUID: " << targets.GetItemTarget()->GetGUID().GetCounter()
+                    << ", High GUID: " << targets.GetItemTarget()->GetGUID().GetHigh() << "), ";
             }
             else
             {
@@ -3256,7 +3260,9 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
                 Item* tradeItem = bot->GetTradeData()->GetTraderData()->GetItem(TRADE_SLOT_NONTRADED);
                 if (tradeItem)
                 {
-                    out << "Trade Item: " << tradeItem->GetEntry() << " (" << tradeItem->GetGUID() << "), ";
+                    out << "Trade Item: " << tradeItem->GetEntry() 
+                        << " (Low GUID: " << tradeItem->GetGUID().GetCounter()
+                        << ", High GUID: " << tradeItem->GetGUID().GetHigh() << "), ";
                 }
                 else
                 {

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3182,21 +3182,14 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         {
             Player* trader = bot->GetTrader();
             TradeData* tradeData = bot->GetTradeData();
+            Item* lockbox = tradeData ? tradeData->GetItem(TRADE_SLOT_NONTRADED) : nullptr; // Prevents null pointer crash
         
-            if (trader && tradeData)
+            // Only SetTradeItemTarget if a locked item exists
+            if (trader && lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked())
             {
-                Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
-                
-                if (lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked()) // Only SetTradeItemTarget if a locked item exists
-                {
-                    targets.SetTradeItemTarget(bot);
-                    targets.SetUnitTarget(bot);
-                    faceTo = trader;
-                }
-                else
-                {
-                    targets.SetItemTarget(itemTarget); // Fallback to normal item targeting because no lockbox is in the trade window
-                }
+                targets.SetTradeItemTarget(bot);
+                targets.SetUnitTarget(bot);
+                faceTo = trader;
             }
             else
             {

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3228,7 +3228,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             std::ostringstream out;
             out << "Spell cast failed - ";
             out << "Spell ID: " << spellId << " (" << ChatHelper::FormatSpell(spellInfo) << "), ";
-            out << "Error Code: " << result << ", ";
+            out << "Error Code: " << static_cast<int>(result) << " (0x" << std::hex << static_cast<int>(result) << std::dec << "), ";
             out << "Bot: " << bot->GetName() << ", ";
     
             // Check spell target type
@@ -3238,19 +3238,17 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
                     << ", Low GUID: " << targets.GetUnitTarget()->GetGUID().GetCounter()
                     << ", High GUID: " << static_cast<uint32>(targets.GetUnitTarget()->GetGUID().GetHigh()) << "), ";
             }
-            else if (targets.GetGOTarget())
+
+            if (targets.GetGOTarget())
             {
                 out << "Target: GameObject (Low GUID: " << targets.GetGOTarget()->GetGUID().GetCounter()
                     << ", High GUID: " << static_cast<uint32>(targets.GetGOTarget()->GetGUID().GetHigh()) << "), ";
             }
-            else if (targets.GetItemTarget())
+
+            if (targets.GetItemTarget())
             {
                 out << "Target: Item (Low GUID: " << targets.GetItemTarget()->GetGUID().GetCounter()
                     << ", High GUID: " << static_cast<uint32>(targets.GetItemTarget()->GetGUID().GetHigh()) << "), ";
-            }
-            else
-            {
-                out << "Target: None, ";
             }
     
             // Check if bot is in trade mode

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3188,7 +3188,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             if (trader && lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked())
             {
                 targets.SetTradeItemTarget(bot);
-                targets.SetUnitTarget(bot);
+                // targets.SetUnitTarget(bot);
                 faceTo = trader;
             }
             else

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3179,13 +3179,17 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         }
         else if (itemTarget)
         {
-            targets.SetItemTarget(itemTarget);
             Player* trader = bot->GetTrader();
             if (trader)
             {
+                targets.SetTradeItemTarget(bot);
                 targets.SetUnitTarget(bot);
                 // targets.SetUnitTarget(trader);
                 faceTo = trader;
+            }
+            else
+            {
+                targets.SetItemTarget(itemTarget);
             }
         }
         else

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3236,17 +3236,17 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             {
                 out << "Target: Unit (" << targets.GetUnitTarget()->GetName() 
                     << ", Low GUID: " << targets.GetUnitTarget()->GetGUID().GetCounter()
-                    << ", High GUID: " << targets.GetUnitTarget()->GetGUID().GetHigh() << "), ";
+                    << ", High GUID: " << static_cast<uint32>(targets.GetUnitTarget()->GetGUID().GetHigh()) << "), ";
             }
             else if (targets.GetGOTarget())
             {
                 out << "Target: GameObject (Low GUID: " << targets.GetGOTarget()->GetGUID().GetCounter()
-                    << ", High GUID: " << targets.GetGOTarget()->GetGUID().GetHigh() << "), ";
+                    << ", High GUID: " << static_cast<uint32>(targets.GetGOTarget()->GetGUID().GetHigh()) << "), ";
             }
             else if (targets.GetItemTarget())
             {
                 out << "Target: Item (Low GUID: " << targets.GetItemTarget()->GetGUID().GetCounter()
-                    << ", High GUID: " << targets.GetItemTarget()->GetGUID().GetHigh() << "), ";
+                    << ", High GUID: " << static_cast<uint32>(targets.GetItemTarget()->GetGUID().GetHigh()) << "), ";
             }
             else
             {
@@ -3262,7 +3262,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
                 {
                     out << "Trade Item: " << tradeItem->GetEntry() 
                         << " (Low GUID: " << tradeItem->GetGUID().GetCounter()
-                        << ", High GUID: " << tradeItem->GetGUID().GetHigh() << "), ";
+                        << ", High GUID: " << static_cast<uint32>(tradeItem->GetGUID().GetHigh()) << "), ";
                 }
                 else
                 {
@@ -3276,6 +3276,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
     
             TellMasterNoFacing(out);
         }
+
         return false;
     }
     // if (spellInfo->Effects[0].Effect == SPELL_EFFECT_OPEN_LOCK || spellInfo->Effects[0].Effect ==

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -75,6 +75,7 @@
 #include "WhoAction.h"
 #include "WtsAction.h"
 #include "OpenItemAction.h"
+#include "UnlockItemAction.h"
 
 class ChatActionContext : public NamedObjectContext<Action>
 {
@@ -82,6 +83,7 @@ public:
     ChatActionContext()
     {
         creators["open items"] = &ChatActionContext::open_items;
+        creators["unlock items"] = &ChatActionContext::unlock_items;
         creators["range"] = &ChatActionContext::range;
         creators["stats"] = &ChatActionContext::stats;
         creators["quests"] = &ChatActionContext::quests;
@@ -183,6 +185,7 @@ public:
 
 private:
     static Action* open_items(PlayerbotAI* botAI) { return new OpenItemAction(botAI); }
+    static Action* unlock_items(PlayerbotAI* botAI) { return new UnlockItemAction(botAI); }
     static Action* range(PlayerbotAI* botAI) { return new RangeAction(botAI); }
     static Action* flag(PlayerbotAI* botAI) { return new FlagAction(botAI); }
     static Action* craft(PlayerbotAI* botAI) { return new SetCraftAction(botAI); }

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -76,6 +76,7 @@
 #include "WtsAction.h"
 #include "OpenItemAction.h"
 #include "UnlockItemAction.h"
+#include "UnlockTradedItemAction.h"
 
 class ChatActionContext : public NamedObjectContext<Action>
 {
@@ -84,6 +85,7 @@ public:
     {
         creators["open items"] = &ChatActionContext::open_items;
         creators["unlock items"] = &ChatActionContext::unlock_items;
+        creators["unlock traded item"] = &ChatActionContext::unlock_traded_item;
         creators["range"] = &ChatActionContext::range;
         creators["stats"] = &ChatActionContext::stats;
         creators["quests"] = &ChatActionContext::quests;
@@ -186,6 +188,7 @@ public:
 private:
     static Action* open_items(PlayerbotAI* botAI) { return new OpenItemAction(botAI); }
     static Action* unlock_items(PlayerbotAI* botAI) { return new UnlockItemAction(botAI); }
+    static Action* unlock_traded_item(PlayerbotAI* botAI) { return new UnlockTradedItemAction(botAI); }
     static Action* range(PlayerbotAI* botAI) { return new RangeAction(botAI); }
     static Action* flag(PlayerbotAI* botAI) { return new FlagAction(botAI); }
     static Action* craft(PlayerbotAI* botAI) { return new SetCraftAction(botAI); }

--- a/src/strategy/actions/OpenItemAction.cpp
+++ b/src/strategy/actions/OpenItemAction.cpp
@@ -59,7 +59,7 @@ bool OpenItemAction::CanOpenItem(Item* item)
         return false;
 
     // Check if the item has the openable flag
-    return itemTemplate->Flags & ITEM_FLAG_HAS_LOOT;
+    return (itemTemplate->Flags & ITEM_FLAG_HAS_LOOT) && (!item->IsLocked());
 }
 
 void OpenItemAction::OpenItem(Item* item, uint8 bag, uint8 slot)

--- a/src/strategy/actions/OpenItemAction.cpp
+++ b/src/strategy/actions/OpenItemAction.cpp
@@ -58,8 +58,9 @@ bool OpenItemAction::CanOpenItem(Item* item)
     if (!itemTemplate)
         return false;
 
-    // Check if the item has the openable flag
-    return (itemTemplate->Flags & ITEM_FLAG_HAS_LOOT) && (!item->IsLocked());
+    // Check if the item has the openable flag and is not locked
+    return (itemTemplate->Flags & ITEM_FLAG_HAS_LOOT) && 
+       (itemTemplate->LockID == 0 || !item->IsLocked());
 }
 
 void OpenItemAction::OpenItem(Item* item, uint8 bag, uint8 slot)

--- a/src/strategy/actions/OpenItemAction.cpp
+++ b/src/strategy/actions/OpenItemAction.cpp
@@ -40,12 +40,6 @@ bool OpenItemAction::Execute(Event event)
         }
     }
 
-    // If no openable items found
-    if (!foundOpenable)
-    {
-        botAI->TellError("No openable items in inventory.");
-    }
-
     return foundOpenable;
 }
 

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -114,6 +114,30 @@ bool TradeStatusAction::Execute(Event event)
             bot->SetFacingToObject(trader);
     
         BeginTrade();
+    
+        // Detect if a lockbox is in the Do Not Trade slot and unlock it automatically
+        TradeData* tradeData = trader->GetTradeData();
+        if (tradeData)
+        {
+            Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
+            if (lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked()) // Only locked items
+            {
+                if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804)) // Ensure bot is a Rogue with Pick Lock
+                {
+                    botAI->TellMaster("Let me unlock that for you...");
+    
+                    uint32 spellId = 1804; // Pick Lock spell ID
+                    botAI->CastSpell(spellId, bot, false, lockbox); // Cast Pick Lock on the traded item
+    
+                    botAI->SetNextCheckDelay(4000); // Wait 4 seconds before accepting the trade
+                }
+            }
+        }
+    
+        return true;
+    }
+
+        
 /*
         // Detect if a lockbox is in the Do Not Trade slot
         TradeData* tradeData = trader->GetTradeData();
@@ -133,8 +157,6 @@ bool TradeStatusAction::Execute(Event event)
             }
         }
 */  
-        return true;
-    }
     return false;
 }
 

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -132,6 +132,14 @@ bool TradeStatusAction::Execute(Event event)
     
                     botAI->SetNextCheckDelay(4000); // Wait 4 seconds before accepting the trade
                 }
+                else
+                {
+                    botAI->TellMaster("Not a rogue, or no Pick lock spell");
+                }
+            }
+            else
+            {
+                botAI->TellMaster("No lockbox, Invalid LockID, or box is not locked");
             }
         }
         else

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -107,11 +107,29 @@ bool TradeStatusAction::Execute(Event event)
     {
         if (!bot->HasInArc(CAST_ANGLE_IN_FRONT, trader, sPlayerbotAIConfig->sightDistance))
             bot->SetFacingToObject(trader);
-
+    
         BeginTrade();
+    
+        // Detect if a lockbox is in the Do Not Trade slot
+        TradeData* tradeData = trader->GetTradeData();
+        if (tradeData)
+        {
+            Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
+            if (lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked()) // Only locked items
+            {
+                if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804)) // Check if bot is a Rogue with Pick Lock
+                {
+                    uint32 spellId = 1804; // Pick Lock spell ID
+                    botAI->CastSpell(spellId, bot, false, lockbox);
+    
+                    botAI->TellMaster("Let me unlock that for you...");
+                    botAI->SetNextCheckDelay(4000); // Wait 4 seconds before accepting the trade
+                }
+            }
+        }
+    
         return true;
     }
-
     return false;
 }
 

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -26,7 +26,7 @@ bool TradeStatusAction::Execute(Event event)
     PlayerbotAI* traderBotAI = GET_PLAYERBOT_AI(trader);
     
     // Allow both the master and group members to trade
-    if (trader != master && !traderBotAI && !bot->GetGroup() && !bot->GetGroup()->IsMember(trader->GetGUID()))
+    if (trader != master && !traderBotAI && (!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())))
     {
         bot->Whisper("I'm kind of busy now", LANG_UNIVERSAL, trader);
         return false;

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -134,6 +134,10 @@ bool TradeStatusAction::Execute(Event event)
                 }
             }
         }
+        else
+        {
+            botAI->TellMaster("No trade data found");
+        }
     
         return true;
     }

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -109,7 +109,7 @@ bool TradeStatusAction::Execute(Event event)
             bot->SetFacingToObject(trader);
     
         BeginTrade();
-    
+/*
         // Detect if a lockbox is in the Do Not Trade slot
         TradeData* tradeData = trader->GetTradeData();
         if (tradeData)
@@ -127,7 +127,7 @@ bool TradeStatusAction::Execute(Event event)
                 }
             }
         }
-    
+*/  
         return true;
     }
     return false;

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -15,6 +15,7 @@
 #include "Playerbots.h"
 #include "RandomPlayerbotMgr.h"
 #include "SetCraftAction.h"
+#include "Action.h"
 
 bool TradeStatusAction::Execute(Event event)
 {
@@ -127,7 +128,7 @@ bool TradeStatusAction::Execute(Event event)
                     botAI->TellMaster("Let me unlock that for you...");
     
                     uint32 spellId = 1804; // Pick Lock spell ID
-                    botAI->CastSpell(spellId, bot, false, lockbox); // Cast Pick Lock on the traded item
+                    botAI->CastSpell(spellId, bot, lockbox); // Cast Pick Lock on the traded item
     
                     botAI->SetNextCheckDelay(4000); // Wait 4 seconds before accepting the trade
                 }

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -24,12 +24,17 @@ bool TradeStatusAction::Execute(Event event)
         return false;
 
     PlayerbotAI* traderBotAI = GET_PLAYERBOT_AI(trader);
-    if (trader != master && !traderBotAI)
+    
+    // Allow both the master and group members to trade
+    if (trader != master && !traderBotAI && !bot->GetGroup() && !bot->GetGroup()->IsMember(trader->GetGUID()))
     {
         bot->Whisper("I'm kind of busy now", LANG_UNIVERSAL, trader);
+        return false;
     }
 
-    if ((trader != master || !botAI->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_ALLOW_ALL, true, master)) &&
+    // Allow trades from group members or bots
+    if ((!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())) &&
+        (trader != master || !botAI->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_ALLOW_ALL, true, master)) &&
         !traderBotAI)
     {
         WorldPacket p;

--- a/src/strategy/actions/TradeStatusAction.cpp
+++ b/src/strategy/actions/TradeStatusAction.cpp
@@ -15,7 +15,6 @@
 #include "Playerbots.h"
 #include "RandomPlayerbotMgr.h"
 #include "SetCraftAction.h"
-#include "Action.h"
 
 bool TradeStatusAction::Execute(Event event)
 {
@@ -26,7 +25,7 @@ bool TradeStatusAction::Execute(Event event)
 
     PlayerbotAI* traderBotAI = GET_PLAYERBOT_AI(trader);
     
-    // Allow both the master and group members to trade
+    // Allow the master and group members to trade
     if (trader != master && !traderBotAI && (!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())))
     {
         bot->Whisper("I'm kind of busy now", LANG_UNIVERSAL, trader);
@@ -113,63 +112,11 @@ bool TradeStatusAction::Execute(Event event)
     {
         if (!bot->HasInArc(CAST_ANGLE_IN_FRONT, trader, sPlayerbotAIConfig->sightDistance))
             bot->SetFacingToObject(trader);
-    
+
         BeginTrade();
-    
-        // Detect if a lockbox is in the Do Not Trade slot and unlock it automatically
-        TradeData* tradeData = trader->GetTradeData();
-        if (tradeData)
-        {
-            Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
-            if (lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked()) // Only locked items
-            {
-                if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804)) // Ensure bot is a Rogue with Pick Lock
-                {
-                    botAI->TellMaster("Let me unlock that for you...");
-    
-                    uint32 spellId = 1804; // Pick Lock spell ID
-                    botAI->CastSpell(spellId, bot, lockbox); // Cast Pick Lock on the traded item
-    
-                    botAI->SetNextCheckDelay(4000); // Wait 4 seconds before accepting the trade
-                }
-                else
-                {
-                    botAI->TellMaster("Not a rogue, or no Pick lock spell");
-                }
-            }
-            else
-            {
-                botAI->TellMaster("No lockbox, Invalid LockID, or box is not locked");
-            }
-        }
-        else
-        {
-            botAI->TellMaster("No trade data found");
-        }
-    
+
         return true;
     }
-
-        
-/*
-        // Detect if a lockbox is in the Do Not Trade slot
-        TradeData* tradeData = trader->GetTradeData();
-        if (tradeData)
-        {
-            Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
-            if (lockbox && lockbox->GetTemplate()->LockID > 0 && lockbox->IsLocked()) // Only locked items
-            {
-                if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804)) // Check if bot is a Rogue with Pick Lock
-                {
-                    uint32 spellId = 1804; // Pick Lock spell ID
-                    botAI->CastSpell(spellId, bot, false, lockbox);
-    
-                    botAI->TellMaster("Let me unlock that for you...");
-                    botAI->SetNextCheckDelay(4000); // Wait 4 seconds before accepting the trade
-                }
-            }
-        }
-*/  
     return false;
 }
 

--- a/src/strategy/actions/TradeStatusExtendedAction.cpp
+++ b/src/strategy/actions/TradeStatusExtendedAction.cpp
@@ -58,10 +58,18 @@ bool TradeStatusExtendedAction::Execute(Event event)
         {
             botAI->TellMaster("Detecting locked item in trade...");
 
-            if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804)) // Pick Lock spell
+            // Get the actual item reference from TradeData
+            Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
+            if (!lockbox)
+            {
+                botAI->TellMaster("Error: Cannot find the lockbox item.");
+                return false;
+            }
+
+            if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804) && lockbox->IsLocked()) // Pick Lock spell
             {
                 botAI->TellMaster("Let me unlock that for you...");
-                botAI->CastSpell(1804, bot, nullptr); // Attempt to cast Pick Lock
+                botAI->CastSpell(1804, bot, lockbox); // Attempt to cast Pick Lock on the lockbox
                 botAI->SetNextCheckDelay(4000); // Delay before accepting trade
             }
             else

--- a/src/strategy/actions/TradeStatusExtendedAction.cpp
+++ b/src/strategy/actions/TradeStatusExtendedAction.cpp
@@ -11,6 +11,10 @@ bool TradeStatusExtendedAction::Execute(Event event)
     if (!trader)
         return false;
 
+    TradeData* tradeData = trader->GetTradeData();
+    if (!tradeData)
+        return false;
+
     WorldPacket p(event.getPacket());
     p.rpos(0);
 

--- a/src/strategy/actions/TradeStatusExtendedAction.cpp
+++ b/src/strategy/actions/TradeStatusExtendedAction.cpp
@@ -1,0 +1,75 @@
+#include "TradeStatusExtendedAction.h"
+#include "Event.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "WorldPacket.h"
+#include "TradeData.h"
+
+bool TradeStatusExtendedAction::Execute(Event event)
+{
+    Player* trader = bot->GetTrader();
+    if (!trader)
+        return false;
+
+    WorldPacket p(event.getPacket());
+    p.rpos(0);
+
+    uint8 isTraderData;
+    uint32 unknown1, slotCount1, slotCount2, tradeGold, spellCast;
+    p >> isTraderData;
+    p >> unknown1;
+    p >> slotCount1;
+    p >> slotCount2;
+    p >> tradeGold;
+    p >> spellCast;
+
+    for (uint8 i = 0; i < TRADE_SLOT_COUNT; ++i)
+    {
+        uint8 tradeSlot;
+        p >> tradeSlot;
+
+        if (tradeSlot >= TRADE_SLOT_COUNT)
+            break; // End of packet
+
+        uint32 itemId, displayId, count, wrapped, lockId;
+        uint64 giftCreator, creator;
+        uint32 permEnchant, gem1, gem2, gem3;
+        uint32 spellCharges, suffixFactor, randomProp, maxDurability, durability;
+
+        p >> itemId;
+        p >> displayId;
+        p >> count;
+        p >> wrapped;
+        p >> giftCreator;
+        p >> permEnchant;
+        p >> gem1;
+        p >> gem2;
+        p >> gem3;
+        p >> creator;
+        p >> spellCharges;
+        p >> suffixFactor;
+        p >> randomProp;
+        p >> lockId;
+        p >> maxDurability;
+        p >> durability;
+
+        // Check for locked items in "Do Not Trade" slot
+        if (tradeSlot == TRADE_SLOT_NONTRADED && lockId > 0)
+        {
+            botAI->TellMaster("Detecting locked item in trade...");
+
+            if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804)) // Pick Lock spell
+            {
+                botAI->TellMaster("Let me unlock that for you...");
+                botAI->CastSpell(1804, bot, nullptr); // Attempt to cast Pick Lock
+                botAI->SetNextCheckDelay(4000); // Delay before accepting trade
+            }
+            else
+            {
+                botAI->TellMaster("I can't unlock this item.");
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/strategy/actions/TradeStatusExtendedAction.cpp
+++ b/src/strategy/actions/TradeStatusExtendedAction.cpp
@@ -60,20 +60,17 @@ bool TradeStatusExtendedAction::Execute(Event event)
         // Check for locked items in "Do Not Trade" slot
         if (tradeSlot == TRADE_SLOT_NONTRADED && lockId > 0)
         {
-            botAI->TellMaster("Detecting locked item in trade...");
-
             // Get the actual item reference from TradeData
             Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
             if (!lockbox)
             {
-                botAI->TellMaster("Error: Cannot find the lockbox item.");
                 return false;
             }
 
             if (bot->getClass() == CLASS_ROGUE && bot->HasSpell(1804) && lockbox->IsLocked()) // Pick Lock spell
             {
-                botAI->TellMaster("Let me unlock that for you...");
-                botAI->CastSpell(1804, bot, lockbox); // Attempt to cast Pick Lock on the lockbox
+                // botAI->CastSpell(1804, bot, lockbox); // Attempt to cast Pick Lock on the lockbox
+                botAI->DoSpecificAction("unlock traded item");
                 botAI->SetNextCheckDelay(4000); // Delay before accepting trade
             }
             else

--- a/src/strategy/actions/TradeStatusExtendedAction.h
+++ b/src/strategy/actions/TradeStatusExtendedAction.h
@@ -1,0 +1,17 @@
+#ifndef _PLAYERBOT_TRADESTATUSEXTENDEDACTION_H
+#define _PLAYERBOT_TRADESTATUSEXTENDEDACTION_H
+
+#include "QueryItemUsageAction.h"
+
+class Player;
+class PlayerbotAI;
+
+class TradeStatusExtendedAction : public QueryItemUsageAction
+{
+public:
+    TradeStatusExtendedAction(PlayerbotAI* botAI) : QueryItemUsageAction(botAI, "trade status extended") {}
+
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/strategy/actions/UnlockItemAction.cpp
+++ b/src/strategy/actions/UnlockItemAction.cpp
@@ -22,10 +22,6 @@ bool UnlockItemAction::Execute(Event event)
             UnlockItem(item, INVENTORY_SLOT_BAG_0, slot);
             foundLockedItem = true;
         }
-        else
-        {
-            botAI->TellError("CanUnlockItem returned false");
-        }
     }
 
     // Check items in the bags
@@ -44,17 +40,7 @@ bool UnlockItemAction::Execute(Event event)
                 UnlockItem(item, bag, slot);
                 foundLockedItem = true;
             }
-            else
-            {
-                botAI->TellError("CanUnlockItem returned false");
-            }
         }
-    }
-
-    // If no locked items found
-    if (!foundLockedItem)
-    {
-        botAI->TellError("No locked items in inventory.");
     }
 
     return foundLockedItem;
@@ -115,12 +101,6 @@ bool UnlockItemAction::CanUnlockItem(Item* item)
 
 void UnlockItemAction::UnlockItem(Item* item, uint8 bag, uint8 slot)
 {
-    if (!bot->HasSpell(PICK_LOCK_SPELL_ID))
-    {
-        botAI->TellError("Cannot unlock, Pick Lock spell is missing.");
-        return;
-    }
-
     // Use CastSpell to unlock the item
     if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot, item))
     {

--- a/src/strategy/actions/UnlockItemAction.cpp
+++ b/src/strategy/actions/UnlockItemAction.cpp
@@ -1,0 +1,128 @@
+#include "UnlockItemAction.h"
+#include "PlayerbotAI.h"
+#include "ItemTemplate.h"
+#include "WorldPacket.h"
+#include "Player.h"
+#include "ObjectMgr.h"
+#include "SpellInfo.h"
+
+#define PICK_LOCK_SPELL_ID 1804
+
+bool UnlockItemAction::Execute(Event event)
+{
+    bool foundLockedItem = false;
+
+    // Check main inventory slots
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+    {
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+
+        if (item && CanUnlockItem(item))
+        {
+            UnlockItem(item, INVENTORY_SLOT_BAG_0, slot);
+            foundLockedItem = true;
+        }
+    }
+
+    // Check items in the bags
+    for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
+    {
+        Bag* bagItem = bot->GetBagByPos(bag);
+        if (!bagItem)
+            continue;
+
+        for (uint32 slot = 0; slot < bagItem->GetBagSize(); ++slot)
+        {
+            Item* item = bot->GetItemByPos(bag, slot);
+
+            if (item && CanUnlockItem(item))
+            {
+                UnlockItem(item, bag, slot);
+                foundLockedItem = true;
+            }
+        }
+    }
+
+    // If no locked items found
+    if (!foundLockedItem)
+    {
+        botAI->TellError("No locked items in inventory.");
+    }
+
+    return foundLockedItem;
+}
+
+bool UnlockItemAction::CanUnlockItem(Item* item)
+{
+    if (!item)
+        return false;
+
+    ItemTemplate const* itemTemplate = item->GetTemplate();
+    if (!itemTemplate)
+        return false;
+
+    // Ensure the bot has Lockpicking skill
+    if (!botAI->HasSkill(SKILL_LOCKPICKING))
+        return false;
+
+    // Ensure the item is locked
+    if (itemTemplate->LockID == 0 || !item->IsLocked())
+        return false;
+
+    // Check if the bot's Lockpicking skill is high enough
+    uint32 lockId = itemTemplate->LockID;
+    LockEntry const* lockInfo = sLockStore.LookupEntry(lockId);
+    if (!lockInfo)
+        return false;
+
+    bool canUnlock = false;
+
+    for (uint8 j = 0; j < 8; ++j)
+    {
+        if (lockInfo->Type[j] == LOCK_KEY_SKILL)
+        {
+            uint32 skillId = SkillByLockType(LockType(lockInfo->Index[j]));
+            if (skillId == SKILL_LOCKPICKING)
+            {
+                uint32 requiredSkill = lockInfo->Skill[j];
+                uint32 botSkill = bot->GetSkillValue(SKILL_LOCKPICKING);
+
+                if (botSkill >= requiredSkill)
+                {
+                    canUnlock = true;
+                }
+                else
+                {
+                    std::ostringstream out;
+                    out << "Lockpicking skill too low (" << botSkill << "/" << requiredSkill << ") to unlock: " 
+                        << item->GetTemplate()->Name1;
+                    botAI->TellMaster(out.str());
+                }
+            }
+        }
+    }
+
+    return canUnlock;
+}
+
+void UnlockItemAction::UnlockItem(Item* item, uint8 bag, uint8 slot)
+{
+    if (!bot->HasSpell(PICK_LOCK_SPELL_ID))
+    {
+        botAI->TellError("Cannot unlock, Pick Lock spell is missing.");
+        return;
+    }
+
+    // Use CastSpell to unlock the item
+    if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot, item))
+    {
+        std::ostringstream out;
+        out << "Used Pick Lock on: " << item->GetTemplate()->Name1;
+        botAI->TellMaster(out.str());
+    }
+    else
+    {
+        botAI->TellError("Failed to cast Pick Lock.");
+    }
+}
+

--- a/src/strategy/actions/UnlockItemAction.cpp
+++ b/src/strategy/actions/UnlockItemAction.cpp
@@ -22,6 +22,10 @@ bool UnlockItemAction::Execute(Event event)
             UnlockItem(item, INVENTORY_SLOT_BAG_0, slot);
             foundLockedItem = true;
         }
+        else
+        {
+            botAI->TellError("CanUnlockItem returned false");
+        }
     }
 
     // Check items in the bags

--- a/src/strategy/actions/UnlockItemAction.cpp
+++ b/src/strategy/actions/UnlockItemAction.cpp
@@ -40,6 +40,10 @@ bool UnlockItemAction::Execute(Event event)
                 UnlockItem(item, bag, slot);
                 foundLockedItem = true;
             }
+            else
+            {
+                botAI->TellError("CanUnlockItem returned false");
+            }
         }
     }
 

--- a/src/strategy/actions/UnlockItemAction.h
+++ b/src/strategy/actions/UnlockItemAction.h
@@ -1,0 +1,20 @@
+#ifndef _PLAYERBOT_UNLOCKITEMACTION_H
+#define _PLAYERBOT_UNLOCKITEMACTION_H
+
+#include "GenericSpellActions.h"
+
+class PlayerbotAI;
+
+class UnlockItemAction : public CastSpellAction
+{
+public:
+    UnlockItemAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "unlock item") { }
+
+    bool Execute(Event event) override;
+
+private:
+    bool CanUnlockItem(Item* item);
+    void UnlockItem(Item* item, uint8 bag, uint8 slot);
+};
+
+#endif

--- a/src/strategy/actions/UnlockItemAction.h
+++ b/src/strategy/actions/UnlockItemAction.h
@@ -1,14 +1,14 @@
 #ifndef _PLAYERBOT_UNLOCKITEMACTION_H
 #define _PLAYERBOT_UNLOCKITEMACTION_H
 
-#include "GenericSpellActions.h"
+#include "Action.h"
 
 class PlayerbotAI;
 
-class UnlockItemAction : public CastSpellAction
+class UnlockItemAction : public Action
 {
 public:
-    UnlockItemAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "unlock item") { }
+    UnlockItemAction(PlayerbotAI* botAI) : Action(botAI, "unlock item") { }
 
     bool Execute(Event event) override;
 

--- a/src/strategy/actions/UnlockTradedItemAction.cpp
+++ b/src/strategy/actions/UnlockTradedItemAction.cpp
@@ -85,7 +85,7 @@ void UnlockTradedItemAction::UnlockItem(Item* item)
     }
 
     // Use CastSpell to unlock the item
-    if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot, item))
+    botAI->CastSpell(PICK_LOCK_SPELL_ID, bot->GetTrader(), item); // Unit target is trader
     {
         std::ostringstream out;
         out << "Used Pick Lock on: " << item->GetTemplate()->Name1;

--- a/src/strategy/actions/UnlockTradedItemAction.cpp
+++ b/src/strategy/actions/UnlockTradedItemAction.cpp
@@ -85,7 +85,7 @@ void UnlockTradedItemAction::UnlockItem(Item* item)
     }
 
     // Use CastSpell to unlock the item
-    if botAI->CastSpell(PICK_LOCK_SPELL_ID, bot->GetTrader(), item); // Unit target is trader
+    if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot->GetTrader(), item)) // Unit target is trader
     {
         std::ostringstream out;
         out << "Used Pick Lock on: " << item->GetTemplate()->Name1;

--- a/src/strategy/actions/UnlockTradedItemAction.cpp
+++ b/src/strategy/actions/UnlockTradedItemAction.cpp
@@ -1,0 +1,98 @@
+#include "UnlockTradedItemAction.h"
+#include "Playerbots.h"
+#include "TradeData.h"
+#include "SpellInfo.h"
+
+#define PICK_LOCK_SPELL_ID 1804
+
+bool UnlockTradedItemAction::Execute(Event event)
+{
+    Player* trader = bot->GetTrader();
+    if (!trader)
+        return false; // No active trade session
+
+    TradeData* tradeData = trader->GetTradeData();
+    if (!tradeData)
+        return false; // No trade data available
+
+    Item* lockbox = tradeData->GetItem(TRADE_SLOT_NONTRADED);
+    if (!lockbox)
+    {
+        botAI->TellError("No item in the Do Not Trade slot.");
+        return false;
+    }
+
+    if (!CanUnlockItem(lockbox))
+    {
+        botAI->TellError("Cannot unlock this item.");
+        return false;
+    }
+
+    UnlockItem(lockbox);
+    return true;
+}
+
+bool UnlockTradedItemAction::CanUnlockItem(Item* item)
+{
+    if (!item)
+        return false;
+
+    ItemTemplate const* itemTemplate = item->GetTemplate();
+    if (!itemTemplate)
+        return false;
+
+    // Ensure the bot is a rogue and has Lockpicking skill
+    if (bot->getClass() != CLASS_ROGUE || !botAI->HasSkill(SKILL_LOCKPICKING))
+        return false;
+
+    // Ensure the item is actually locked
+    if (itemTemplate->LockID == 0 || !item->IsLocked())
+        return false;
+
+    // Check if the bot's Lockpicking skill is high enough
+    uint32 lockId = itemTemplate->LockID;
+    LockEntry const* lockInfo = sLockStore.LookupEntry(lockId);
+    if (!lockInfo)
+        return false;
+
+    uint32 botSkill = bot->GetSkillValue(SKILL_LOCKPICKING);
+    for (uint8 j = 0; j < 8; ++j)
+    {
+        if (lockInfo->Type[j] == LOCK_KEY_SKILL && SkillByLockType(LockType(lockInfo->Index[j])) == SKILL_LOCKPICKING)
+        {
+            uint32 requiredSkill = lockInfo->Skill[j];
+            if (botSkill >= requiredSkill)
+                return true;
+            else
+            {
+                std::ostringstream out;
+                out << "Lockpicking skill too low (" << botSkill << "/" << requiredSkill << ") to unlock: " 
+                    << item->GetTemplate()->Name1;
+                botAI->TellMaster(out.str());
+            }
+        }
+    }
+
+    return false;
+}
+
+void UnlockTradedItemAction::UnlockItem(Item* item)
+{
+    if (!bot->HasSpell(PICK_LOCK_SPELL_ID))
+    {
+        botAI->TellError("Cannot unlock, Pick Lock spell is missing.");
+        return;
+    }
+
+    // Use CastSpell to unlock the item
+    if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot, false, item))
+    {
+        std::ostringstream out;
+        out << "Used Pick Lock on: " << item->GetTemplate()->Name1;
+        botAI->TellMaster(out.str());
+    }
+    else
+    {
+        botAI->TellError("Failed to cast Pick Lock.");
+    }
+}

--- a/src/strategy/actions/UnlockTradedItemAction.cpp
+++ b/src/strategy/actions/UnlockTradedItemAction.cpp
@@ -85,7 +85,7 @@ void UnlockTradedItemAction::UnlockItem(Item* item)
     }
 
     // Use CastSpell to unlock the item
-    botAI->CastSpell(PICK_LOCK_SPELL_ID, bot->GetTrader(), item); // Unit target is trader
+    if botAI->CastSpell(PICK_LOCK_SPELL_ID, bot->GetTrader(), item); // Unit target is trader
     {
         std::ostringstream out;
         out << "Used Pick Lock on: " << item->GetTemplate()->Name1;

--- a/src/strategy/actions/UnlockTradedItemAction.cpp
+++ b/src/strategy/actions/UnlockTradedItemAction.cpp
@@ -88,7 +88,7 @@ void UnlockTradedItemAction::UnlockItem(Item* item)
     if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot->GetTrader(), item)) // Unit target is trader
     {
         std::ostringstream out;
-        out << "Used Pick Lock on: " << item->GetTemplate()->Name1;
+        out << "Picking Lock on traded item: " << item->GetTemplate()->Name1;
         botAI->TellMaster(out.str());
     }
     else

--- a/src/strategy/actions/UnlockTradedItemAction.cpp
+++ b/src/strategy/actions/UnlockTradedItemAction.cpp
@@ -85,7 +85,7 @@ void UnlockTradedItemAction::UnlockItem(Item* item)
     }
 
     // Use CastSpell to unlock the item
-    if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot, false, item))
+    if (botAI->CastSpell(PICK_LOCK_SPELL_ID, bot, item))
     {
         std::ostringstream out;
         out << "Used Pick Lock on: " << item->GetTemplate()->Name1;

--- a/src/strategy/actions/UnlockTradedItemAction.h
+++ b/src/strategy/actions/UnlockTradedItemAction.h
@@ -1,0 +1,20 @@
+#ifndef _PLAYERBOT_UNLOCKTRADEDITEMACTION_H
+#define _PLAYERBOT_UNLOCKTRADEDITEMACTION_H
+
+#include "Action.h"
+
+class PlayerbotAI;
+
+class UnlockTradedItemAction : public Action
+{
+public:
+    UnlockTradedItemAction(PlayerbotAI* botAI) : Action(botAI, "unlock traded item") {}
+
+    bool Execute(Event event) override;
+
+private:
+    bool CanUnlockItem(Item* item);
+    void UnlockItem(Item* item);
+};
+
+#endif

--- a/src/strategy/actions/WorldPacketActionContext.h
+++ b/src/strategy/actions/WorldPacketActionContext.h
@@ -37,6 +37,7 @@
 #include "TellCastFailedAction.h"
 #include "TellMasterAction.h"
 #include "TradeStatusAction.h"
+#include "TradeStatusExtendedAction.h"
 #include "UseMeetingStoneAction.h"
 #include "NamedObjectContext.h"
 

--- a/src/strategy/actions/WorldPacketActionContext.h
+++ b/src/strategy/actions/WorldPacketActionContext.h
@@ -65,6 +65,7 @@ public:
         creators["check mount state"] = &WorldPacketActionContext::check_mount_state;
         creators["remember taxi"] = &WorldPacketActionContext::remember_taxi;
         creators["accept trade"] = &WorldPacketActionContext::accept_trade;
+        creators["trade status extended"] = &WorldPacketActionContext::trade_status_extended;
         creators["store loot"] = &WorldPacketActionContext::store_loot;
 
         // quest
@@ -117,6 +118,7 @@ private:
     static Action* party_command(PlayerbotAI* botAI) { return new PartyCommandAction(botAI); }
     static Action* store_loot(PlayerbotAI* botAI) { return new StoreLootAction(botAI); }
     static Action* accept_trade(PlayerbotAI* botAI) { return new TradeStatusAction(botAI); }
+    static Action* trade_status_extended(PlayerbotAI* botAI) { return new TradeStatusExtendedAction(botAI); }
     static Action* remember_taxi(PlayerbotAI* botAI) { return new RememberTaxiAction(botAI); }
     static Action* check_mount_state(PlayerbotAI* botAI) { return new CheckMountStateAction(botAI); }
     static Action* area_trigger(PlayerbotAI* botAI) { return new AreaTriggerAction(botAI); }

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -98,6 +98,8 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("qi", NextAction::array(0, new NextAction("query item usage", relevance), nullptr)));
     triggers.push_back(
 	    new TriggerNode("unlock items", NextAction::array(0, new NextAction("unlock items", relevance), nullptr)));
+    triggers.push_back(
+	    new TriggerNode("unlock traded item", NextAction::array(0, new NextAction("unlock traded item", relevance), nullptr)));
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)
@@ -174,4 +176,5 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("open items");
     supported.push_back("qi");
     supported.push_back("unlock items");
+    supported.push_back("unlock traded item");
 }

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -96,6 +96,8 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
 	    new TriggerNode("open items", NextAction::array(0, new NextAction("open items", relevance), nullptr)));
     triggers.push_back(
         new TriggerNode("qi", NextAction::array(0, new NextAction("query item usage", relevance), nullptr)));
+    triggers.push_back(
+	    new TriggerNode("unlock items", NextAction::array(0, new NextAction("unlock items", relevance), nullptr)));
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)
@@ -171,4 +173,5 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("calc");
     supported.push_back("open items");
     supported.push_back("qi");
+    supported.push_back("unlock items");
 }

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -35,6 +35,7 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
                                                                           new NextAction("taxi", relevance), nullptr)));
     triggers.push_back(new TriggerNode("taxi done", NextAction::array(0, new NextAction("taxi", relevance), nullptr)));
     triggers.push_back(new TriggerNode("trade status", NextAction::array(0, new NextAction("accept trade", relevance), new NextAction("equip upgrades", relevance), nullptr)));
+    triggers.push_back(new TriggerNode("trade status extended", NextAction::array(0, new NextAction("trade status extended", relevance), nullptr)));
     triggers.push_back(new TriggerNode("area trigger", NextAction::array(0, new NextAction("reach area trigger", relevance), nullptr)));
     triggers.push_back(new TriggerNode("within area trigger", NextAction::array(0, new NextAction("area trigger", relevance), nullptr)));
     triggers.push_back(new TriggerNode("loot response", NextAction::array(0, new NextAction("store loot", relevance), nullptr)));

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -39,7 +39,10 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     triggers.push_back(new TriggerNode("area trigger", NextAction::array(0, new NextAction("reach area trigger", relevance), nullptr)));
     triggers.push_back(new TriggerNode("within area trigger", NextAction::array(0, new NextAction("area trigger", relevance), nullptr)));
     triggers.push_back(new TriggerNode("loot response", NextAction::array(0, new NextAction("store loot", relevance), nullptr)));
-    triggers.push_back(new TriggerNode("item push result", NextAction::array(0, new NextAction("query item usage", relevance), new NextAction("equip upgrades", relevance), nullptr)));
+    triggers.push_back(new TriggerNode("item push result", NextAction::array(0, new NextAction("unlock items", relevance),
+                                                                                new NextAction("open items", relevance),
+                                                                                new NextAction("query item usage", relevance), 
+                                                                                new NextAction("equip upgrades", relevance), nullptr)));
     triggers.push_back(new TriggerNode("ready check finished", NextAction::array(0, new NextAction("finish ready check", relevance), nullptr)));
     // triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("security check", relevance), new NextAction("check mail", relevance), nullptr)));
     triggers.push_back(new TriggerNode("guild invite", NextAction::array(0, new NextAction("guild accept", relevance), nullptr)));

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -18,6 +18,7 @@ public:
     {
         creators["open items"] = &ChatTriggerContext::open_items;
         creators["unlock items"] = &ChatTriggerContext::unlock_items;
+        creators["unlock traded item"] = &ChatTriggerContext::unlock_traded_item;
         creators["quests"] = &ChatTriggerContext::quests;
         creators["stats"] = &ChatTriggerContext::stats;
         creators["leave"] = &ChatTriggerContext::leave;
@@ -134,6 +135,7 @@ public:
 private:
     static Trigger* open_items(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "open items"); }
     static Trigger* unlock_items(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "unlock items"); }
+    static Trigger* unlock_traded_item(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "unlock traded item"); }
     static Trigger* ra(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "ra"); }
     static Trigger* range(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "range"); }
     static Trigger* flag(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "flag"); }

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -17,6 +17,7 @@ public:
     ChatTriggerContext()
     {
         creators["open items"] = &ChatTriggerContext::open_items;
+        creators["unlock items"] = &ChatTriggerContext::unlock_items;
         creators["quests"] = &ChatTriggerContext::quests;
         creators["stats"] = &ChatTriggerContext::stats;
         creators["leave"] = &ChatTriggerContext::leave;
@@ -132,6 +133,7 @@ public:
 
 private:
     static Trigger* open_items(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "open items"); }
+    static Trigger* unlock_items(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "unlock items"); }
     static Trigger* ra(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "ra"); }
     static Trigger* range(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "range"); }
     static Trigger* flag(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "flag"); }

--- a/src/strategy/triggers/WorldPacketTriggerContext.h
+++ b/src/strategy/triggers/WorldPacketTriggerContext.h
@@ -29,6 +29,7 @@ public:
         creators["check mount state"] = &WorldPacketTriggerContext::check_mount_state;
         creators["activate taxi"] = &WorldPacketTriggerContext::taxi;
         creators["trade status"] = &WorldPacketTriggerContext::trade_status;
+        creators["trade status extended"] = &WorldPacketTriggerContext::trade_status_extended;
         creators["loot response"] = &WorldPacketTriggerContext::loot_response;
         creators["out of react range"] = &WorldPacketTriggerContext::out_of_react_range;
 
@@ -108,6 +109,7 @@ private:
     static Trigger* out_of_react_range(PlayerbotAI* botAI) { return new OutOfReactRangeTrigger(botAI); }
     static Trigger* loot_response(PlayerbotAI* botAI) { return new WorldPacketTrigger(botAI, "loot response"); }
     static Trigger* trade_status(PlayerbotAI* botAI) { return new WorldPacketTrigger(botAI, "trade status"); }
+    static Trigger* trade_status_extended(PlayerbotAI* botAI) { return new WorldPacketTrigger(botAI, "trade status extended"); }
     static Trigger* cannot_equip(PlayerbotAI* botAI) { return new WorldPacketTrigger(botAI, "cannot equip"); }
     static Trigger* check_mount_state(PlayerbotAI* botAI) { return new WorldPacketTrigger(botAI, "check mount state"); }
     static Trigger* area_trigger(PlayerbotAI* botAI) { return new WorldPacketTrigger(botAI, "area trigger"); }

--- a/src/strategy/values/ItemForSpellValue.cpp
+++ b/src/strategy/values/ItemForSpellValue.cpp
@@ -71,6 +71,9 @@ Item* ItemForSpellValue::Calculate()
     if (!strcmpi(spellInfo->SpellName[0], "disenchant"))
         return nullptr;
 
+    if (!strcmpi(spellInfo->SpellName[0], "pick lock"))
+        return nullptr;
+
     for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; slot++)
     {
         itemForSpell = GetItemFitsToSpellRequirements(slot, spellInfo);


### PR DESCRIPTION
1. Added handling for SMSG_TRADE_STATUS_EXTENDED packets to trigger when items are placed into the Will Not Be Traded slot of the trade window. Only contains logic for lockboxes at the moment, but can be expanded. Rogues with Pick Lock will automatically perform the "unlocked traded items" action when a locked box is in the correct slot.
2. CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
   - Handle SPELL_EFFECT_OPEN_LOCK spells explicitly since it can be cast on Objects, Items, and Trade Window Items
   - During SPELL_EFFECT_OPEN_LOCK block: Assign the correct target using SetItemTarget and SetTradeItemTarget
   - Added comprehensive output for CastSpell failure when the bot has the "debug spell" non-combat strategy
4. Added chat commands: 
   - "unlock items" the bot will attempt to unlock any items in their bags
   - "unlock traded items" will attempt to unlock any item in the Will Not Be Traded slot
6. Allow trade with all group members
7. Perform unlock and open item actions when "item push result" is triggered so bots automatically open and unlock looted items when possible.

Known issue: Trade window must be closed when performing "unlock items" on items in the bots inventory. This is due to Pick Lock being intercepted in CastSpell and having the ItemTarget assigned based on the trade window being present. Simply close the trade window when asking the bot to unlock items in their own bags to prevent the issue. I'll have a look at resolving that tomorrow.

Final thoughts: Control auto-open/unlock with config settings or strategies?