### PR TITLE
Item Usage and Loot Roll

### DIFF
--- a/src/strategy/actions/LootRollAction.cpp
+++ b/src/strategy/actions/LootRollAction.cpp
@@ -66,7 +66,7 @@ bool LootRollAction::Execute(Event event)
                     break;
                 default:
                     if (StoreLootAction::IsLootAllowed(itemId, botAI))
-                        vote = NEED;
+                        vote = CalculateRollVote(proto); // Ensure correct Need/Greed behavior
                     break;
             }
         }


### PR DESCRIPTION
1. Corrected conditions to return ITEM_USAGE_DISENCHANT and ITEM_USAGE_AH in ItemUsageValue.cpp
2. Use CalculateRollVote instead of returning NEED in IsLootAllowed in LootRollAction.cpp. This was the cause of bots rolling need on many items even if they had no use for it e.g trade goods and recipes. It now calculates the roll vote correctly for these items.