### PR TITLE
fix classbots autogear not working when altbots autogear turned off

### DIFF
--- a/src/strategy/actions/TrainerAction.cpp
+++ b/src/strategy/actions/TrainerAction.cpp
@@ -205,7 +205,8 @@ bool AutoGearAction::Execute(Event event)
 
     if (!sPlayerbotAIConfig->autoGearCommandAltBots)
     {
-        if (!sRandomPlayerbotMgr->IsRandomBot(bot))
+        uint32 botAccountId = bot->GetSession()->GetAccountId();
+        if (!sPlayerbotAIConfig->IsInRandomAccountList(botAccountId))
         {
             botAI->TellError("You cannot use autogear on alt bots.");
             return false;


### PR DESCRIPTION
When autogearaltbots was turned off the regular random bots autogear command was not working either Im not sure if I missed this before in my previous testing or what happened but this works properly now