### PR TITLE
add ability to add or remove character with same name as account

### DIFF
--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -54,6 +54,7 @@ public:
     std::string const LookupBots(Player* master);
     uint32 GetPlayerbotsCount() { return playerBots.size(); }
     uint32 GetPlayerbotsCountByClass(uint32 cls);
+    std::vector<ObjectGuid> GetAccountBots(uint32 accountId);
 
 protected:
     virtual void OnBotLoginInternal(Player* const bot) = 0;


### PR DESCRIPTION
This fixes an issue with adding bot characters with the same name as an account name. the new commands are as follows:

`.playerbots bot add character <character name>` or
`.playerbots bot add account <account name>`

To remove, the commands are similar:

`.playerbots bot remove character <character name>` or
`.playerbots bot remove account <account name>` or
`.playerbots bot remove character *` (to remove all bots in group)