### PR TITLE
ItemUsageValue: Handle items that create required items

### DIFF
--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -121,8 +121,14 @@ ItemUsage ItemUsageValue::Calculate()
     // Identify the source of loot
     LootObject lootObject = AI_VALUE(LootObject, "loot target");
     
+    // Get GUID of loot source
+    ObjectGuid lootGuid = lootObject.guid;
+    
+    // Check if loot source is an item
+    bool isLootFromItem = lootGuid.IsItem();
+    
     // If the loot is from an item in the bot’s bags, ignore syncQuestWithPlayer
-    if (lootObject.IsItem() && botNeedsItemForQuest)
+    if (isLootFromItem && botNeedsItemForQuest)
     {
         return ITEM_USAGE_QUEST;
     }

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -464,6 +464,17 @@ uint32 ItemUsageValue::GetSmallestBagSize()
 
 bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* proto)
 {
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(player);
+    if (!botAI)
+        return false;
+
+    ChatHelper chat(botAI);
+
+    std::ostringstream msg;
+    msg << "Checking quest usefulness for " << chat.FormatItem(proto);
+
+    botAI->TellMaster(msg.str()); // Notify the master that we're checking the item
+
     for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
     {
         uint32 entry = player->GetQuestSlotQuestId(slot);
@@ -476,50 +487,75 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
         {
             if (quest->RequiredItemId[i] == proto->ItemId)
             {
-                if (GET_PLAYERBOT_AI(player) &&
-                    AI_VALUE2(uint32, "item count", proto->Name1) >= quest->RequiredItemCount[i])
+                if (botAI->AI_VALUE2(uint32, "item count", proto->Name1) >= quest->RequiredItemCount[i])
+                {
+                    botAI->TellMaster("Skipping " + chat.FormatItem(proto) + " - Already has enough.");
                     continue;
+                }
 
+                msg << " - Required for " << chat.FormatQuest(quest);
+                botAI->TellMaster(msg.str());
                 return true; // The item is directly required for a quest
             }
         }
 
-        // Check if the item creates another item that is needed for an active quest
+        // Check if the item has any spells
+        bool spellFound = false;
         for (uint8 i = 0; i < MAX_ITEM_SPELLS; i++)
         {
             uint32 spellId = proto->Spells[i].SpellId;
             if (!spellId)
                 continue;
 
+            spellFound = true;
+            botAI->TellMaster(chat.FormatItem(proto) + " has a spell: " + chat.FormatSpell(sSpellMgr->GetSpellInfo(spellId)));
+
             SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
             if (!spellInfo)
+            {
+                botAI->TellMaster("Skipping spell " + std::to_string(spellId) + " - SpellInfo not found.");
                 continue;
+            }
 
+            bool itemCreated = false;
             for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; effectIndex++)
             {
                 if (spellInfo->Effects[effectIndex].Effect == SPELL_EFFECT_CREATE_ITEM)
                 {
                     uint32 createdItemId = spellInfo->Effects[effectIndex].ItemType;
+                    itemCreated = true;
+
+                    botAI->TellMaster(chat.FormatSpell(spellInfo) + " creates " + chat.FormatItem(sObjectMgr->GetItemTemplate(createdItemId)));
 
                     // Check if the created item is required for a quest
                     for (uint8 j = 0; j < 4; j++)
                     {
                         if (quest->RequiredItemId[j] == createdItemId)
                         {
-                            if (GET_PLAYERBOT_AI(player) &&
-                                AI_VALUE2(uint32, "item count", createdItemId) >= quest->RequiredItemCount[j])
-                                continue;
+                            botAI->TellMaster(chat.FormatItem(sObjectMgr->GetItemTemplate(createdItemId)) + " is needed for " + chat.FormatQuest(quest));
 
-                            LOG_DEBUG("playerbots", "Item {} is useful because it creates quest-required item {}",
-                                      proto->ItemId, createdItemId);
+                            if (botAI->AI_VALUE2(uint32, "item count", createdItemId) >= quest->RequiredItemCount[j])
+                            {
+                                botAI->TellMaster("Skipping " + chat.FormatItem(sObjectMgr->GetItemTemplate(createdItemId)) + " - Already has enough.");
+                                continue;
+                            }
+
+                            botAI->TellMaster(chat.FormatItem(proto) + " is useful because it creates quest-required " + chat.FormatItem(sObjectMgr->GetItemTemplate(createdItemId)));
                             return true; // The item is useful because it creates a needed quest item
                         }
                     }
                 }
             }
+
+            if (!itemCreated)
+                botAI->TellMaster(chat.FormatSpell(spellInfo) + " does not create an item.");
         }
+
+        if (!spellFound)
+            botAI->TellMaster(chat.FormatItem(proto) + " has no usable spells.");
     }
 
+    botAI->TellMaster(chat.FormatItem(proto) + " - Not useful for any active quests.");
     return false; // The item is not useful for any quest the bot has
 }
 

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -8,6 +8,7 @@
 #include "AiFactory.h"
 #include "ChatHelper.h"
 #include "GuildTaskMgr.h"
+#include "LootObjectStack.h"
 #include "PlayerbotAIConfig.h"
 #include "PlayerbotFactory.h"
 #include "Playerbots.h"

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -502,7 +502,7 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
         if (!quest)
             continue;
 
-        // Check if the item itself is required for the quest
+        // Check if the item itself is needed for the quest
         for (uint8 i = 0; i < 4; i++)
         {
             if (quest->RequiredItemId[i] == proto->ItemId)
@@ -510,11 +510,11 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
                 if (AI_VALUE2(uint32, "item count", proto->Name1) >= quest->RequiredItemCount[i])
                     continue;
 
-                return true; // The item is directly required for a quest
+                return true; // Item is directly required for a quest
             }
         }
 
-        // Check if the item has any spells that create a quest-required item
+        // Check if the item has spells that create a required quest item
         for (uint8 i = 0; i < MAX_ITEM_SPELLS; i++)
         {
             uint32 spellId = proto->Spells[i].SpellId;
@@ -539,7 +539,7 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
                             if (AI_VALUE2(uint32, "item count", createdItemId) >= quest->RequiredItemCount[j])
                                 continue;
 
-                            return true; // The item is useful because it creates a needed quest item
+                            return true; // Item is useful because it creates a required quest item
                         }
                     }
                 }
@@ -547,7 +547,7 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
         }
     }
 
-    return false; // The item is not useful for any active quests
+    return false; // Item is not useful for any active quests
 }
 
 bool ItemUsageValue::IsItemNeededForSkill(ItemTemplate const* proto)

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -487,7 +487,7 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
         {
             if (quest->RequiredItemId[i] == proto->ItemId)
             {
-                if (botAI->AI_VALUE2(uint32, "item count", proto->Name1) >= quest->RequiredItemCount[i])
+                if (AI_VALUE2(uint32, "item count", proto->Name1) >= quest->RequiredItemCount[i])
                 {
                     botAI->TellMaster("Skipping " + chat.FormatItem(proto) + " - Already has enough.");
                     continue;
@@ -534,7 +534,7 @@ bool ItemUsageValue::IsItemUsefulForQuest(Player* player, ItemTemplate const* pr
                         {
                             botAI->TellMaster(chat.FormatItem(sObjectMgr->GetItemTemplate(createdItemId)) + " is needed for " + chat.FormatQuest(quest));
 
-                            if (botAI->AI_VALUE2(uint32, "item count", createdItemId) >= quest->RequiredItemCount[j])
+                            if (AI_VALUE2(uint32, "item count", createdItemId) >= quest->RequiredItemCount[j])
                             {
                                 botAI->TellMaster("Skipping " + chat.FormatItem(sObjectMgr->GetItemTemplate(createdItemId)) + " - Already has enough.");
                                 continue;

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -115,8 +115,17 @@ ItemUsage ItemUsageValue::Calculate()
     // While sync is on, do not loot quest items that are also Useful for master. Master
     if (!botAI->GetMaster() || !sPlayerbotAIConfig->syncQuestWithPlayer ||
         !IsItemUsefulForQuest(botAI->GetMaster(), proto))
+    {
         if (IsItemUsefulForQuest(bot, proto))
+        {
+            botAI->TellMaster("✔ " + chat.FormatItem(proto) + " is needed for a quest - Returning ITEM_USAGE_QUEST!");
             return ITEM_USAGE_QUEST;
+        }
+        else
+        {
+            botAI->TellMaster("❌ " + chat.FormatItem(proto) + " is NOT useful for any quest.");
+        }
+    }
 
     if (proto->Class == ITEM_CLASS_PROJECTILE && bot->CanUseItem(proto) == EQUIP_ERR_OK)
     {

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -118,12 +118,12 @@ ItemUsage ItemUsageValue::Calculate()
     {
         if (IsItemUsefulForQuest(bot, proto))
         {
-            botAI->TellMaster("✔ " + chat.FormatItem(proto) + " is needed for a quest - Returning ITEM_USAGE_QUEST!");
+            botAI->TellMaster(chat->FormatItem(proto) + " is needed for a quest - Returning ITEM_USAGE_QUEST!");
             return ITEM_USAGE_QUEST;
         }
         else
         {
-            botAI->TellMaster("❌ " + chat.FormatItem(proto) + " is NOT useful for any quest.");
+            botAI->TellMaster(chat->FormatItem(proto) + " is NOT useful for any quest.");
         }
     }
 

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -113,19 +113,47 @@ ItemUsage ItemUsageValue::Calculate()
     }
 
     // While sync is on, do not loot quest items that are also Useful for master. Master
-    if (!botAI->GetMaster() || !sPlayerbotAIConfig->syncQuestWithPlayer ||
-        !IsItemUsefulForQuest(botAI->GetMaster(), proto))
+    Player* master = botAI->GetMaster();
+    
+    if (!master)
     {
-        if (IsItemUsefulForQuest(bot, proto))
-        {
-            botAI->TellMaster(chat->FormatItem(proto) + " is needed for a quest - Returning ITEM_USAGE_QUEST!");
-            return ITEM_USAGE_QUEST;
-        }
-        else
-        {
-            botAI->TellMaster(chat->FormatItem(proto) + " is NOT useful for any quest.");
-        }
+        botAI->TellMaster(chat->FormatItem(proto) + " - Skipping master check because there is no master.");
     }
+    else
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " - Checking master's quest usefulness.");
+    }
+    
+    if (!sPlayerbotAIConfig->syncQuestWithPlayer)
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " - Skipping master quest check because quest sync is disabled.");
+    }
+    else
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " - Quest sync is enabled, checking master's quests.");
+    }
+    
+    if (master && sPlayerbotAIConfig->syncQuestWithPlayer && !IsItemUsefulForQuest(master, proto))
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " - Master does NOT need this item.");
+    }
+    else if (master && sPlayerbotAIConfig->syncQuestWithPlayer)
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " - Master NEEDS this item.");
+    }
+    
+    if (IsItemUsefulForQuest(botAI->GetBot(), proto))
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " is needed for a quest - Returning ITEM_USAGE_QUEST!");
+        return ITEM_USAGE_QUEST;
+    }
+    else
+    {
+        botAI->TellMaster(chat->FormatItem(proto) + " is NOT useful for any quest.");
+    }
+    
+    botAI->TellMaster(chat->FormatItem(proto) + " is NOT useful for any quest including my master's.");
+
 
     if (proto->Class == ITEM_CLASS_PROJECTILE && bot->CanUseItem(proto) == EQUIP_ERR_OK)
     {


### PR DESCRIPTION
Resolves issue with looting items that create quest items.

Bots were not looting openable item:
https://www.wowhead.com/wotlk/item=11912/package-of-empty-ooze-containers

which contained these items:
https://www.wowhead.com/wotlk/item=11948/empty-tainted-ooze-jar
https://www.wowhead.com/wotlk/item=11914/empty-cursed-ooze-jar

Because ItemUsageValue was returning Useless

These items were not being detected as required for the quest because they cast a spell that then creates the required item. 

1. Resolved logic to look for CREATE_ITEM spells and check if the created items are required for quests. 
2. Adheres to sync quest logic where applicable; items in the bots bags can not be looted by the master so the bot should never take sync into account in those cases.

