### PR TITLE
Optimize Mountaction: Movement Logic with Early Return for Matching F…

### DIFF
--- a/src/strategy/actions/CheckMountStateAction.cpp
+++ b/src/strategy/actions/CheckMountStateAction.cpp
@@ -242,7 +242,7 @@ bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int3
         ((masterInShapeshiftForm == FORM_TRAVEL && botInShapeshiftForm == FORM_TRAVEL) ||
         ((masterInShapeshiftForm == FORM_FLIGHT || (masterMountType == 1 && masterSpeed == 149)) && botInShapeshiftForm == FORM_FLIGHT) ||
         ((masterInShapeshiftForm == FORM_FLIGHT_EPIC || (masterMountType == 1 && masterSpeed == 279)) && botInShapeshiftForm == FORM_FLIGHT_EPIC))
-            return true;
+        return true;
 
     // Check if master is in Travel Form and bot can do the same
     if (botAI->CanCastSpell(SPELL_TRAVEL_FORM, bot, true) &&


### PR DESCRIPTION
Added a missing check, so if both master and bot are in matching forms or master is mounted with corresponding speed, early return as there is nothing to do.

This improves logic, actions, and prevents some strange movement behavior when both master and bot already are in travel form.