### PR TITLE
fix(Scripts): Correct UseMeetingStoneAction to only apply on meeting stone portals

### DIFF
--- a/src/strategy/actions/UseMeetingStoneAction.cpp
+++ b/src/strategy/actions/UseMeetingStoneAction.cpp
@@ -48,8 +48,8 @@ bool UseMeetingStoneAction::Execute(Event event)
         return false;
 
     GameObjectTemplate const* goInfo = gameObject->GetGOInfo();
-    if (!goInfo || goInfo->type != GAMEOBJECT_TYPE_SUMMONING_RITUAL)
-        return false;
+    if (!goInfo || goInfo->entry != 179944)
+		return false;
 
     return Teleport(master, bot);
 }


### PR DESCRIPTION
Currently, clicking any type 18 gameobject while targeting a playerbot will teleport it, interrupting the cast if the spell summoning the gameobject was cast by said bot. 

Example: Warlock bot casting Ritual of Summoning summons gameobject 194108 of type 18. When we click said portal to summon the actual warlock summon TV, if you have the bot targeted, you teleport the bot over to you and interrupt the cast. 

This PR corrects the issue by only applying UseMeetingStoneAction to meeting stone portals.