### PR TITLE
Fix multithread issue on LFG and group leave

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -374,7 +374,9 @@ void PlayerbotAI::UpdateAIGroupMembership()
             PlayerbotAI* leaderAI = GET_PLAYERBOT_AI(leader);
             if (leaderAI && !leaderAI->IsRealPlayer())
             {
-                bot->RemoveFromGroup();
+                WorldPacket* packet = new WorldPacket(CMSG_GROUP_DISBAND);
+                bot->GetSession()->QueuePacket(packet);
+                // bot->RemoveFromGroup();
                 ResetStrategies();
             }
         }
@@ -399,7 +401,9 @@ void PlayerbotAI::UpdateAIGroupMembership()
         }
         if (!hasRealPlayer)
         {
-            bot->RemoveFromGroup();
+            WorldPacket* packet = new WorldPacket(CMSG_GROUP_DISBAND);
+            bot->GetSession()->QueuePacket(packet);
+            // bot->RemoveFromGroup();
             ResetStrategies();
         }
     }


### PR DESCRIPTION
Replace direct thread-unsafe funtion calls with simulated client packets.

These thread-unsafe funcs will be executed serially in WorldSessionMgr::UpdateSession instead of multi-threaded execution in Map::Update.

Some other thread unsafe crashes can also be solved in this way. The identifiers in Opcodes.cpp can help distinguish which methods are thread-safe or thread-unsafe (PROCESS_THREADSAFE or PROCESS_THREADUNSAFE)