### PR TITLE
Fixed crash in MoveFromWhirlwindAction::Execute function

### DIFF
--- a/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
+++ b/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
@@ -6,7 +6,7 @@ bool MoveFromWhirlwindAction::Execute(Event event)
 {
     Unit* boss = nullptr;
     uint8 faction = bot->GetTeamId();
-    float targetDist = 10.0f; // Whirlwind tem alcance de 8, adicionando margem de segurança
+    float targetDist = 10.0f; // Whirlwind has a range of 8, adding a safety buffer
 
     switch (bot->GetMap()->GetDifficulty())
     {
@@ -34,17 +34,21 @@ bool MoveFromWhirlwindAction::Execute(Event event)
             break;
     }
 
+    // Ensure boss is valid before accessing its methods
     if (!boss)
     {
         return false;
     }
 
     float bossDistance = bot->GetExactDist2d(boss->GetPosition());
+    
+    // Check if the bot is already at a safe distance
     if (bossDistance > targetDist)
     {
         return false;
     }
 
+    // Move away from the boss to avoid Whirlwind
     return MoveAway(boss, targetDist - bossDistance);
 }
 

--- a/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
+++ b/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
@@ -6,8 +6,8 @@ bool MoveFromWhirlwindAction::Execute(Event event)
 {
     Unit* boss = nullptr;
     uint8 faction = bot->GetTeamId();
-    float targetDist = 10.0f; // Whirlwind has range of 8, add a couple for safety buffer
-    
+    float targetDist = 10.0f; // Whirlwind tem alcance de 8, adicionando margem de segurança
+
     switch (bot->GetMap()->GetDifficulty())
     {
         case DUNGEON_DIFFICULTY_NORMAL:
@@ -15,7 +15,7 @@ bool MoveFromWhirlwindAction::Execute(Event event)
             {
                 boss = AI_VALUE2(Unit*, "find target", "horde commander");
             }
-            else //if (faction == TEAM_HORDE)
+            else // TEAM_HORDE
             {
                 boss = AI_VALUE2(Unit*, "find target", "alliance commander");
             }
@@ -25,7 +25,7 @@ bool MoveFromWhirlwindAction::Execute(Event event)
             {
                 boss = AI_VALUE2(Unit*, "find target", "commander kolurg");
             }
-            else //if (faction == TEAM_HORDE)
+            else // TEAM_HORDE
             {
                 boss = AI_VALUE2(Unit*, "find target", "commander stoutbeard");
             }
@@ -33,11 +33,18 @@ bool MoveFromWhirlwindAction::Execute(Event event)
         default:
             break;
     }
-    float bossDistance = bot->GetExactDist2d(boss->GetPosition());
-    if (!boss || bossDistance > targetDist)
+
+    if (!boss)
     {
         return false;
     }
+
+    float bossDistance = bot->GetExactDist2d(boss->GetPosition());
+    if (bossDistance > targetDist)
+    {
+        return false;
+    }
+
     return MoveAway(boss, targetDist - bossDistance);
 }
 


### PR DESCRIPTION
This PR fixes a crash in the MoveFromWhirlwindAction::Execute function in NexusActions.cpp. The error occurred when accessing boss->GetPosition() without checking whether boss was a valid pointer. The fix adds a nullptr check before calculating the distance, preventing invalid accesses and ensuring the stability of the action execution.

Closes https://github.com/liyunfan1223/mod-playerbots/issues/1149