### PR TITLE
fix(NexusAction) Null pointer check 

### DIFF
--- a/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
+++ b/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
@@ -33,6 +33,12 @@ bool MoveFromWhirlwindAction::Execute(Event event)
         default:
             break;
     }
+    
+    if (!boss)
+    {
+        return false;
+    }
+    
     float bossDistance = bot->GetExactDist2d(boss->GetPosition());
     if (!boss || bossDistance > targetDist)
     {

--- a/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
+++ b/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
@@ -34,16 +34,18 @@ bool MoveFromWhirlwindAction::Execute(Event event)
             break;
     }
     
+    // Check if boss exists before trying to access its properties
     if (!boss)
     {
         return false;
     }
     
     float bossDistance = bot->GetExactDist2d(boss->GetPosition());
-    if (!boss || bossDistance > targetDist)
+    if (bossDistance > targetDist)
     {
         return false;
     }
+    
     return MoveAway(boss, targetDist - bossDistance);
 }
 
@@ -162,6 +164,8 @@ bool IntenseColdJumpAction::Execute(Event event)
     // This does a tiny bunnyhop that takes a couple of ms, it doesn't do a natural jump.
     // Adding extra Z offset causes floating, and appears to scale the jump speed based on Z difference.
     // Probably best to revisit once bot movement is improved
+    if (!bot) { return false; }
+    
     return JumpTo(bot->GetMap()->GetId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ() + 0.01f);
     // bot->GetMotionMaster()->MoveFall();
 }

--- a/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
+++ b/src/strategy/dungeons/wotlk/nexus/NexusActions.cpp
@@ -34,7 +34,6 @@ bool MoveFromWhirlwindAction::Execute(Event event)
             break;
     }
     
-    // Check if boss exists before trying to access its properties
     if (!boss)
     {
         return false;


### PR DESCRIPTION
This PR addresses an access violation crash. The issue was caused by dereferencing a null pointer in MoveFromWhirlwindAction::Execute() where the code was attempting to access boss->GetPosition() before checking if boss was null.

Closes https://github.com/liyunfan1223/mod-playerbots/issues/1149