### PR TITLE
playerbots.conf.dist comment fixed

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -638,10 +638,10 @@ AiPlayerbot.HunterWolfPet = 0
 #
 #
 # Specify percent of active bots
-# The default is 10. With 10% of all bots going active or inactive each minute. Regardless
-# This value is only applied to inactive areas where no real-players are detected, when
-# real-players are nearby, friend, group, guild, bg, instances etc the value is always
-# enforced to 100%
+# The default is 100%, but would be automatically adjusted if botActiveAloneSmartScale
+# is enabled. Regardless, this value is only applied to inactive areas where no real-players
+# are detected. When real-players are nearby, friend, group, guild, BGs, instances etc,
+# the value is always enforced to 100%
 AiPlayerbot.BotActiveAlone = 100
 
 # Force botActiveAlone when bot is ... of real player


### PR DESCRIPTION
Fixed comment for BotActiveAlone, now that its default value has been changed from 10% to 100%