### PR TITLE
Crash fix: Bots now properly turn their corpse into bones when resurr…

### DIFF
--- a/src/strategy/actions/UseMeetingStoneAction.cpp
+++ b/src/strategy/actions/UseMeetingStoneAction.cpp
@@ -221,6 +221,7 @@ bool SummonAction::Teleport(Player* summoner, Player* player)
                         return false;
     
                     bot->ResurrectPlayer(1.0f, false);
+                    bot->SpawnCorpseBones();
                     botAI->TellMasterNoFacing("I live, again!");
                     botAI->GetAiObjectContext()->GetValue<GuidVector>("prioritized targets")->Reset();
                 }


### PR DESCRIPTION
…ected so they don't have a second corpse after dying and releasing again.