### PR TITLE
Enable new rpg strategy by default

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -82,8 +82,8 @@ AiPlayerbot.Enabled = 1
 AiPlayerbot.RandomBotAutologin = 1
 
 # Random bot count
-AiPlayerbot.MinRandomBots = 50
-AiPlayerbot.MaxRandomBots = 50
+AiPlayerbot.MinRandomBots = 500
+AiPlayerbot.MaxRandomBots = 500
 
 # Random bot accounts
 # If you are not using any expansion at all, you may have to set this manually, then
@@ -561,7 +561,7 @@ AiPlayerbot.EnableRandomBotTrading = 1
 AiPlayerbot.DisableRandomLevels = 0
 
 # Set randombots starting level here if "AiPlayerbot.DisableRandomLevels" enabled
-AiPlayerbot.RandombotStartingLevel = 5
+AiPlayerbot.RandombotStartingLevel = 1
 
 # Chance random bot has min level on first randomize (default 0.1)
 AiPlayerbot.RandomBotMinLevelChance = 0.1
@@ -692,8 +692,8 @@ AiPlayerbot.AutoDoQuests = 1
 
 # Random Bots will behave more like real players (exprimental)
 # This option will override AutoDoQuests
-# Default: 0 (disabled)
-AiPlayerbot.EnableNewRpgStrategy = 0
+# Default: 1 (enabled)
+AiPlayerbot.EnableNewRpgStrategy = 1
 
 # Quest items to leave (do not destroy)
 AiPlayerbot.RandomBotQuestItems = "6948,5175,5176,5177,5178,16309,12382,13704,11000"

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -563,8 +563,11 @@ AiPlayerbot.DisableRandomLevels = 0
 # Set randombots starting level here if "AiPlayerbot.DisableRandomLevels" enabled
 AiPlayerbot.RandombotStartingLevel = 5
 
-# Chance random bot has max level on first randomize (default 0.15)
-AiPlayerbot.RandomBotMaxLevelChance = 0.15
+# Chance random bot has min level on first randomize (default 0.1)
+AiPlayerbot.RandomBotMinLevelChance = 0.1
+
+# Chance random bot has max level on first randomize (default 0.1)
+AiPlayerbot.RandomBotMaxLevelChance = 0.1
 
 # Fix the level of random bot (won't level up by grinding)
 # Default: 0 (disable)

--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -617,7 +617,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
                                             "gather", "duel", "pvp", "buff", "mount", "emote", nullptr);
     }
 
-    if (sPlayerbotAIConfig->autoSaveMana)
+    if (sPlayerbotAIConfig->autoSaveMana && PlayerbotAI::IsHeal(player, true))
     {
         nonCombatEngine->addStrategy("save mana", false);
     }

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -120,7 +120,8 @@ bool PlayerbotAIConfig::Initialize()
     randomGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearQualityLimit", 3);
     randomGearScoreLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearScoreLimit", 0);
 
-    randomBotMaxLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMaxLevelChance", 0.15f);
+    randomBotMinLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMinLevelChance", 0.1f);
+    randomBotMaxLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMaxLevelChance", 0.1f);
     randomBotRpgChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotRpgChance", 0.20f);
 
     iterationsPerTick = sConfigMgr->GetOption<int32>("AiPlayerbot.IterationsPerTick", 100);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -86,7 +86,7 @@ public:
     float randomGearLoweringChance;
     int32 randomGearQualityLimit;
     int32 randomGearScoreLimit;
-    float randomBotMaxLevelChance;
+    float randomBotMinLevelChance, randomBotMaxLevelChance;
     float randomBotRpgChance;
     uint32 minRandomBots, maxRandomBots;
     uint32 randomBotUpdateInterval, randomBotCountChangeMinInterval, randomBotCountChangeMaxInterval;

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -275,7 +275,7 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
             sPlayerbotDbStore->Save(botAI);
         }
 
-        LOG_INFO("playerbots", "Bot {} logging out", bot->GetName().c_str());
+        LOG_DEBUG("playerbots", "Bot {} logging out", bot->GetName().c_str());
         bot->SaveToDB(false, false);
 
         WorldSession* botWorldSessionPtr = bot->GetSession();

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -543,12 +543,15 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
 
     bot->SaveToDB(false, false);
     bool addClassBot = sRandomPlayerbotMgr->IsAddclassBot(bot->GetGUID().GetCounter());
-    if (addClassBot && master && isRandomAccount && master->GetLevel() < bot->GetLevel())
+    if (addClassBot && master && isRandomAccount && abs((int)master->GetLevel() - (int)bot->GetLevel()) > 3)
     {
         // PlayerbotFactory factory(bot, master->GetLevel());
         // factory.Randomize(false);
         uint32 mixedGearScore =
             PlayerbotAI::GetMixedGearScore(master, true, false, 12) * sPlayerbotAIConfig->autoInitEquipLevelLimitRatio;
+        // work around: distinguish from 0 if no gear
+        if (mixedGearScore == 0)
+            mixedGearScore = 1;
         PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
         factory.Randomize(false);
     }
@@ -728,6 +731,9 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
             {
                 uint32 mixedGearScore = PlayerbotAI::GetMixedGearScore(master, true, false, 12) *
                                         sPlayerbotAIConfig->autoInitEquipLevelLimitRatio;
+                // work around: distinguish from 0 if no gear
+                if (mixedGearScore == 0)
+                    mixedGearScore = 1;
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
                 factory.Randomize(false);
                 return "ok, gear score limit: " + std::to_string(mixedGearScore / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) +

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -1051,6 +1051,11 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             messages.push_back("Error: Invalid Class. Try again.");
             return messages;
         }
+        if (claz == 6 && master->GetLevel() < sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL))
+        {
+            messages.push_back("Your level is too low to summon Deathknight");
+            return messages;
+        }
         uint8 teamId = master->GetTeamId(true);
         const std::unordered_set<ObjectGuid> &guidCache = sRandomPlayerbotMgr->addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(teamId == TEAM_ALLIANCE, claz)];
         for (const ObjectGuid &guid: guidCache)

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -379,7 +379,11 @@ public:
         sRandomPlayerbotMgr->OnPlayerLogout(player);
     }
 
-    void OnPlayerbotLogoutBots() override { sRandomPlayerbotMgr->LogoutAllBots(); }
+    void OnPlayerbotLogoutBots() override
+    {
+        LOG_INFO("playerbots", "Logging out all bots...");
+        sRandomPlayerbotMgr->LogoutAllBots();
+    }
 };
 
 void AddPlayerbotsScripts()

--- a/src/RandomItemMgr.cpp
+++ b/src/RandomItemMgr.cpp
@@ -2362,7 +2362,7 @@ void RandomItemMgr::BuildPotionCache()
                     continue;
                 
                 uint32 requiredLevel = proto->RequiredLevel;
-                if (requiredLevel > level || (level > 15 && requiredLevel < level - 15))
+                if (requiredLevel > level || (level > 13 && requiredLevel < level - 13))
                     continue;
 
                 if (proto->RequiredSkill)

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -981,7 +981,7 @@ void RandomPlayerbotFactory::CreateRandomArenaTeams(ArenaType type, uint32 count
         sPlayerbotAIConfig->randomBotArenaTeams.push_back(arenateam->GetId());
     }
 
-    LOG_INFO("playerbots", "{} random bot {}vs{} arena teams available", arenaTeamNumber, type, type);
+    LOG_DEBUG("playerbots", "{} random bot {}vs{} arena teams available", arenaTeamNumber, type, type);
 }
 
 std::string const RandomPlayerbotFactory::CreateRandomArenaTeamName()

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2555,8 +2555,16 @@ void RandomPlayerbotMgr::OnPlayerLogout(Player* player)
 
 void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
 {
-    LOG_INFO("playerbots", "{}/{} Bot {} logged in", playerBots.size(), sRandomPlayerbotMgr->GetMaxAllowedBotCount(),
-             bot->GetName().c_str());
+    if (_isBotLogging)
+    {
+        LOG_INFO("playerbots", "{}/{} Bot {} logged in", playerBots.size(), sRandomPlayerbotMgr->GetMaxAllowedBotCount(),
+                bot->GetName().c_str());
+        
+        if (playerBots.size() == sRandomPlayerbotMgr->GetMaxAllowedBotCount())
+        {
+            _isBotLogging = false;
+        }
+    }
 
     if (sPlayerbotAIConfig->randomBotFixedLevel)
     {

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -415,7 +415,7 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
             loginBots += updateBots;
             loginBots = std::min(loginBots, maxNewBots);
 
-            LOG_INFO("playerbots", "{} new bots", loginBots);
+            LOG_DEBUG("playerbots", "{} new bots prepared to login", loginBots);
 
             // Log in bots
             for (auto bot : availableBots)
@@ -1103,10 +1103,10 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         if (!player || !player->GetGroup())
         {
             if (player)
-                LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H",
+                LOG_DEBUG("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H",
                          player->GetLevel(), player->GetName().c_str());
             else
-                LOG_INFO("playerbots", "Bot #{}: log out", bot);
+                LOG_DEBUG("playerbots", "Bot #{}: log out", bot);
 
             SetEventValue(bot, "add", 0, 0);
             currentBots.erase(std::remove(currentBots.begin(), currentBots.end(), bot), currentBots.end());
@@ -1189,7 +1189,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
     uint32 logout = GetEventValue(bot, "logout");
     if (player && !logout && !isValid)
     {
-        LOG_INFO("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H",
+        LOG_DEBUG("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H",
                  player->GetLevel(), player->GetName().c_str());
         LogoutPlayerBot(botGUID);
         currentBots.remove(bot);

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -386,7 +386,8 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
         }
         else
         {
-            activatePrintStatsThread();
+            sRandomPlayerbotMgr->PrintStats();
+            // activatePrintStatsThread();
         }
     }
     uint32 updateBots = sPlayerbotAIConfig->randomBotsPerInterval * onlineBotFocus / 100;
@@ -2413,7 +2414,8 @@ bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* handler, cha
 
     if (cmd == "stats")
     {
-        activatePrintStatsThread();
+        sRandomPlayerbotMgr->PrintStats();
+        // activatePrintStatsThread();
         return true;
     }
 
@@ -2724,7 +2726,7 @@ void RandomPlayerbotMgr::PrintStats()
     uint32 engine_combat = 0;
     uint32 engine_dead = 0;
     std::unordered_map<NewRpgStatus, int> rpgStatusCount;
-    NewRpgStatistic rpgStasticTotal;
+    // static NewRpgStatistic rpgStasticTotal;
     std::unordered_map<uint32, int> zoneCount;
     uint8 maxBotLevel = 0;
     for (PlayerBotMap::iterator i = playerBots.begin(); i != playerBots.end(); ++i)
@@ -2802,6 +2804,7 @@ void RandomPlayerbotMgr::PrintStats()
         {
             rpgStatusCount[botAI->rpgInfo.status]++;
             rpgStasticTotal += botAI->rpgStatistic;
+            botAI->rpgStatistic = NewRpgStatistic();
         }
     }
 
@@ -2819,7 +2822,8 @@ void RandomPlayerbotMgr::PrintStats()
 
         if (((i + 1) % step == 0) || i == maxBotLevel)
         {
-            LOG_INFO("playerbots", "    {}..{}: {} alliance, {} horde", from, i, currentAlliance, currentHorde);
+            if (currentAlliance || currentHorde)
+                LOG_INFO("playerbots", "    {}..{}: {} alliance, {} horde", from, i, currentAlliance, currentHorde);
             currentAlliance = 0;
             currentHorde = 0;
             from = i + 1;

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -6,6 +6,7 @@
 #ifndef _PLAYERBOT_RANDOMPLAYERBOTMGR_H
 #define _PLAYERBOT_RANDOMPLAYERBOTMGR_H
 
+#include "NewRpgInfo.h"
 #include "ObjectGuid.h"
 #include "PlayerbotMgr.h"
 
@@ -194,6 +195,7 @@ private:
     float activityMod = 0.25;
     bool _isBotInitializing = true;
     bool _isBotLogging = true;
+    NewRpgStatistic rpgStasticTotal;
     uint32 GetEventValue(uint32 bot, std::string const event);
     std::string const GetEventData(uint32 bot, std::string const event);
     uint32 SetEventValue(uint32 bot, std::string const event, uint32 value, uint32 validIn,

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -193,6 +193,7 @@ private:
     botPID pid = botPID(1, 50, -50, 0, 0, 0);
     float activityMod = 0.25;
     bool _isBotInitializing = true;
+    bool _isBotLogging = true;
     uint32 GetEventValue(uint32 bot, std::string const event);
     std::string const GetEventData(uint32 bot, std::string const event);
     uint32 SetEventValue(uint32 bot, std::string const event, uint32 value, uint32 validIn,

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -42,6 +42,12 @@
 
 const uint64 diveMask = (1LL << 7) | (1LL << 44) | (1LL << 37) | (1LL << 38) | (1LL << 26) | (1LL << 30) | (1LL << 27) |
                         (1LL << 33) | (1LL << 24) | (1LL << 34);
+
+static std::vector<uint32> initSlotsOrder = {EQUIPMENT_SLOT_TRINKET1, EQUIPMENT_SLOT_TRINKET2, EQUIPMENT_SLOT_MAINHAND,
+    EQUIPMENT_SLOT_OFFHAND, EQUIPMENT_SLOT_RANGED, EQUIPMENT_SLOT_HEAD, EQUIPMENT_SLOT_SHOULDERS, EQUIPMENT_SLOT_CHEST,
+    EQUIPMENT_SLOT_LEGS, EQUIPMENT_SLOT_HANDS, EQUIPMENT_SLOT_NECK, EQUIPMENT_SLOT_BODY, EQUIPMENT_SLOT_WAIST,
+    EQUIPMENT_SLOT_FEET, EQUIPMENT_SLOT_WRISTS, EQUIPMENT_SLOT_FINGER1, EQUIPMENT_SLOT_FINGER2, EQUIPMENT_SLOT_BACK};
+
 uint32 PlayerbotFactory::tradeSkills[] = {SKILL_ALCHEMY,        SKILL_ENCHANTING,  SKILL_SKINNING,  SKILL_TAILORING,
                                           SKILL_LEATHERWORKING, SKILL_ENGINEERING, SKILL_HERBALISM, SKILL_MINING,
                                           SKILL_BLACKSMITHING,  SKILL_COOKING,     SKILL_FIRST_AID, SKILL_FISHING,
@@ -1595,8 +1601,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
     int32 delta = std::min(blevel, 10u);
 
     StatsWeightCalculator calculator(bot);
-    // Reverse order may work better
-    for (int32 slot = (int32)EQUIPMENT_SLOT_TABARD; slot >= (int32)EQUIPMENT_SLOT_START; slot--)
+    for (int32 slot : initSlotsOrder)
     {
         if (slot == EQUIPMENT_SLOT_TABARD || slot == EQUIPMENT_SLOT_BODY)
             continue;
@@ -1766,7 +1771,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
     /// @todo: clean up duplicate code
     if (second_chance)
     {
-        for (int32 slot = (int32)EQUIPMENT_SLOT_TABARD; slot >= (int32)EQUIPMENT_SLOT_START; slot--)
+        for (int32 slot : initSlotsOrder)
         {
             if (slot == EQUIPMENT_SLOT_TABARD || slot == EQUIPMENT_SLOT_BODY)
                 continue;
@@ -1782,9 +1787,10 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
             if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
                 continue;
-            
+
             if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
-                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST))
+                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
+                (slot != EQUIPMENT_SLOT_RANGED))
                 continue;
 
             if (Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1609,10 +1609,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
             continue;
 
-        if (level < 30 && slot == EQUIPMENT_SLOT_NECK)
-            continue;
-
-        if (level < 25 && slot == EQUIPMENT_SLOT_HEAD)
+        if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
             continue;
 
         if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
@@ -1632,7 +1629,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
         oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
 
-        uint32 desiredQuality = itemQuality;
+        int32 desiredQuality = itemQuality;
         if (urand(0, 100) < 100 * sPlayerbotAIConfig->randomGearLoweringChance && desiredQuality > ITEM_QUALITY_NORMAL)
         {
             desiredQuality--;
@@ -1667,8 +1664,10 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
                         if (!proto)
                             continue;
+                        
+                        bool shouldCheckGS = desiredQuality > ITEM_QUALITY_NORMAL;
 
-                        if (gearScoreLimit != 0 &&
+                        if (shouldCheckGS && gearScoreLimit != 0 &&
                             CalcMixedGearScore(proto->ItemLevel, proto->Quality) > gearScoreLimit)
                         {
                             continue;
@@ -1697,7 +1696,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                     }
                 }
             }
-        } while (items[slot].size() < 25 && desiredQuality-- > ITEM_QUALITY_NORMAL);
+        } while (items[slot].size() < 25 && desiredQuality-- > ITEM_QUALITY_POOR);
 
         std::vector<uint32>& ids = items[slot];
         if (ids.empty())
@@ -1779,10 +1778,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
                 continue;
 
-            if (level < 30 && slot == EQUIPMENT_SLOT_NECK)
-                continue;
-
-            if (level < 25 && slot == EQUIPMENT_SLOT_HEAD)
+            if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
                 continue;
 
             if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
@@ -3973,6 +3969,9 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destoryOld)
         {
             continue;
         }
+        
+        if (item->GetTemplate() && item->GetTemplate()->Quality < ITEM_QUALITY_UNCOMMON)
+            continue;
         int32 bestEnchantId = -1;
         float bestScore = 0;
         for (const uint32& enchantSpell : enchantSpellIdCache)

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -208,7 +208,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     // {
     //     return;
     // }
-    LOG_INFO("playerbots", "{} randomizing {} (level {} class = {})...", (incremental ? "Incremental" : "Full"),
+    LOG_DEBUG("playerbots", "{} randomizing {} (level {} class = {})...", (incremental ? "Incremental" : "Full"),
              bot->GetName().c_str(), level, bot->getClass());
     // LOG_DEBUG("playerbots", "Preparing to {} randomize...", (incremental ? "incremental" : "full"));
     Prepare();

--- a/src/factory/StatsWeightCalculator.cpp
+++ b/src/factory/StatsWeightCalculator.cpp
@@ -129,6 +129,7 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
     stats_weights_[STATS_TYPE_STAMINA] += 0.1f;
     stats_weights_[STATS_TYPE_ARMOR] += 0.001f;
     stats_weights_[STATS_TYPE_BONUS] += 1.0f;
+    stats_weights_[STATS_TYPE_MELEE_DPS] += 0.01f;
 
     if (cls == CLASS_HUNTER && (tab == HUNTER_TAB_BEASTMASTER || tab == HUNTER_TAB_SURVIVAL))
     {

--- a/src/strategy/actions/GenericActions.cpp
+++ b/src/strategy/actions/GenericActions.cpp
@@ -8,6 +8,17 @@
 #include "CreatureAI.h"
 #include "Playerbots.h"
 
+enum PetSpells
+{
+    PET_PROWL_1 = 24450,
+    PET_PROWL_2 = 24452,
+    PET_PROWL_3 = 24453,
+    PET_COWER = 1742,
+    PET_LEAP = 47482
+};
+
+static std::vector<uint32> disabledPetSpells = {PET_PROWL_1, PET_PROWL_2, PET_PROWL_3, PET_COWER, PET_LEAP};
+
 bool MeleeAction::isUseful()
 {
     // do not allow if can't attack from vehicle
@@ -44,18 +55,20 @@ bool TogglePetSpellAutoCastAction::Execute(Event event)
     {
         if (itr->second.state == PETSPELL_REMOVED)
             continue;
-        
+
         uint32 spellId = itr->first;
         const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spellId);
         if (!spellInfo->IsAutocastable())
             continue;
 
         bool shouldApply = true;
-        if (spellId == 1742 /*cower*/ || spellId == 24450 /*Prowl*/ ||
-            spellId == 47482 /*Leap*/ /* || spellId == 47481 Gnaw*/)
+        for (uint32 disabledSpell : disabledPetSpells)
         {
-            
-            shouldApply = false;
+            if (spellId == disabledSpell)
+            {
+                shouldApply = false;
+                break;
+            }
         }
         bool isAutoCast = false;
         for (unsigned int& m_autospell : pet->m_autospells)

--- a/src/strategy/mage/FrostMageStrategy.cpp
+++ b/src/strategy/mage/FrostMageStrategy.cpp
@@ -79,7 +79,8 @@ void FrostMageStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode("has pet", NextAction::array(0, new NextAction("toggle pet spell", ACTION_HIGH + 1), nullptr)));
     triggers.push_back(
         new TriggerNode("medium health", NextAction::array(0, new NextAction("ice barrier", ACTION_NORMAL), nullptr)));
-
+    triggers.push_back(
+        new TriggerNode("being attacked", NextAction::array(0, new NextAction("ice barrier", ACTION_HIGH + 1), nullptr)));
     triggers.push_back(new TriggerNode(
         "brain freeze", NextAction::array(0, new NextAction("frostfire bolt", ACTION_NORMAL + 3), nullptr)));
     // Combo cast the last charge of fingers of frost for double crits.

--- a/src/strategy/priest/GenericPriestStrategy.cpp
+++ b/src/strategy/priest/GenericPriestStrategy.cpp
@@ -56,6 +56,8 @@ void GenericPriestStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("enemy too close for spell",
                                        NextAction::array(0, new NextAction("flee", ACTION_MOVE + 9), nullptr)));
     triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("apply oil", 1.0f), nullptr)));
+    triggers.push_back(new TriggerNode("being attacked",
+        NextAction::array(0, new NextAction("power word: shield", ACTION_HIGH + 1), nullptr)));
 }
 
 PriestCureStrategy::PriestCureStrategy(PlayerbotAI* botAI) : Strategy(botAI)

--- a/src/strategy/values/EstimatedLifetimeValue.cpp
+++ b/src/strategy/values/EstimatedLifetimeValue.cpp
@@ -36,6 +36,10 @@ float EstimatedGroupDpsValue::Calculate()
             if (member == bot)  // calculated
                 continue;
 
+            // ignore real player as they may not help with damage
+            if (!GET_PLAYERBOT_AI(member) || GET_PLAYERBOT_AI(member)->IsRealPlayer())
+                continue;
+
             if (!member || !member->IsInWorld() || !member->IsAlive())
                 continue;
 


### PR DESCRIPTION
Modify the default configuration for better first-time experience.
1. Enable new rpg strategy by default, as it generally provides better immersion behavior and bots distribution on maps.
2. Increase default bots count to 500.
3. Add `RandomBotMinLevelChance` to set a default of 10% of bots starting from level 1.

Make some less important improvements for QOL.
1. Disable addclass dk in low level.
2. Ensure equipment with normal/poor quality for init=auto.
3. Cleare redundant logs at info level.