### PR TITLE
InviteToGroupAction: minor correction

### DIFF
--- a/src/strategy/actions/InviteToGroupAction.cpp
+++ b/src/strategy/actions/InviteToGroupAction.cpp
@@ -53,8 +53,8 @@ bool InviteNearbyToGroupAction::Execute(Event event)
         if (!player)
             continue;
 
-        if (!player->GetMapId() != bot->GetMapId())
-                 continue;
+        if (player->GetMapId() != bot->GetMapId())
+            continue;
 
         if (player->GetGroup())
             continue;


### PR DESCRIPTION
Do not invite if that nearest player is not in the same map. 

Current/old code basically translated into:
```
if ((player->GetMapId() == 0 ? true : false) != bot->GetMapId())
    continue;
```