### PR TITLE
HasFriend can cause crashes with mulitple players, added defense checks.

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -4269,17 +4269,24 @@ bool PlayerbotAI::AllowActive(ActivityType activityType)
     // HasFriend
     if (sPlayerbotAIConfig->BotActiveAloneForceWhenIsFriend)
     {
+        if (!bot || !bot->IsInWorld() || !bot->GetGUID())
+            return false;
+
         for (auto& player : sRandomPlayerbotMgr->GetPlayers())
         {
-            if (!player || !player->IsInWorld() || !player->GetSocial() || !bot->GetGUID())
-            {
+            if (!player || !player->IsInWorld())
                 continue;
-            }
 
-            if (player->GetSocial()->HasFriend(bot->GetGUID()))
-            {
+			Player* connectedPlayer = ObjectAccessor::FindPlayer(player->GetGUID());
+            if (!connectedPlayer)
+                continue;
+
+            PlayerSocial* social = player->GetSocial();
+            if (!social)
+                continue;
+
+            if (social->HasFriend(bot->GetGUID()))
                 return true;
-            }
         }
     }
 


### PR DESCRIPTION
Added more defense checks making sure the bots and players are still active in the map and sharing social instance. The current code can create random crashes here and there with multiple real players.

Not entirely sure this will totally prevent it, but should help.