### PR TITLE
Fix: Prevents bots from learning spells twice

### DIFF
--- a/src/strategy/actions/TrainerAction.cpp
+++ b/src/strategy/actions/TrainerAction.cpp
@@ -33,12 +33,15 @@ void TrainerAction::Learn(uint32 cost, TrainerSpell const* tSpell, std::ostrings
         if (spellInfo->Effects[j].Effect == SPELL_EFFECT_LEARN_SPELL)
         {
             uint32 learnedSpell = spellInfo->Effects[j].TriggerSpell;
-            bot->learnSpell(learnedSpell);
-            learned = true;
+            if (!bot->HasSpell(learnedSpell))
+            {
+                bot->learnSpell(learnedSpell);
+                learned = true;
+            }
         }
     }
 
-    if (!learned)
+    if (!learned && !bot->HasSpell(tSpell->spell))
         bot->learnSpell(tSpell->spell);
 
     msg << " - learned";

--- a/src/strategy/actions/TrainerAction.cpp
+++ b/src/strategy/actions/TrainerAction.cpp
@@ -42,7 +42,9 @@ void TrainerAction::Learn(uint32 cost, TrainerSpell const* tSpell, std::ostrings
     }
 
     if (!learned && !bot->HasSpell(tSpell->spell))
+    {
         bot->learnSpell(tSpell->spell);
+    }
 
     msg << " - learned";
 }


### PR DESCRIPTION
Added bot->HasSpell() check before calling bot->learnSpell() to ensure the bot does not learn spells it already has.

This avoids redundant behavior, possible unnecessary logging, and inconsistencies in learning spells trained with SPELL_EFFECT_LEARN_SPELL.

Closse https://github.com/liyunfan1223/mod-playerbots/issues/1208