### PR TITLE
fixing multiple 'unused variable' warnings

### DIFF
--- a/src/strategy/AiObject.h
+++ b/src/strategy/AiObject.h
@@ -488,7 +488,7 @@ protected:
 
 // node_name , action, prerequisite
 #define ACTION_NODE_P(name, spell, pre)                                                                       \
-    static ActionNode* name(PlayerbotAI* botAI)                                                               \
+    static ActionNode* name([[maybe_unused]] PlayerbotAI* botAI)                                                               \
     {                                                                                                         \
         return new ActionNode(spell, /*P*/ NextAction::array(0, new NextAction(pre), nullptr), /*A*/ nullptr, \
                               /*C*/ nullptr);                                                                 \
@@ -496,7 +496,7 @@ protected:
 
 // node_name , action, alternative
 #define ACTION_NODE_A(name, spell, alt)                                                                       \
-    static ActionNode* name(PlayerbotAI* botAI)                                                               \
+    static ActionNode* name([[maybe_unused]] PlayerbotAI* botAI)                                                               \
     {                                                                                                         \
         return new ActionNode(spell, /*P*/ nullptr, /*A*/ NextAction::array(0, new NextAction(alt), nullptr), \
                               /*C*/ nullptr);                                                                 \
@@ -504,7 +504,7 @@ protected:
 
 // node_name , action, continuer
 #define ACTION_NODE_C(name, spell, con)                                                  \
-    static ActionNode* name(PlayerbotAI* botAI)                                          \
+    static ActionNode* name([[maybe_unused]] PlayerbotAI* botAI)                                          \
     {                                                                                    \
         return new ActionNode(spell, /*P*/ nullptr, /*A*/ nullptr,                       \
                               /*C*/ NextAction::array(0, new NextAction(con), nullptr)); \

--- a/src/strategy/druid/FeralDruidStrategy.h
+++ b/src/strategy/druid/FeralDruidStrategy.h
@@ -24,7 +24,7 @@ public:
     }
 
 private:
-    static ActionNode* regrowth(PlayerbotAI* botAI)
+    static ActionNode* regrowth([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("regrowth",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
@@ -32,7 +32,7 @@ private:
                               /*C*/ NextAction::array(0, new NextAction("melee", 10.0f), nullptr));
     }
 
-    static ActionNode* rejuvenation(PlayerbotAI* botAI)
+    static ActionNode* rejuvenation([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("rejuvenation",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
@@ -40,7 +40,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* healing_touch(PlayerbotAI* botAI)
+    static ActionNode* healing_touch([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("healing touch",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
@@ -48,7 +48,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* regrowth_on_party(PlayerbotAI* botAI)
+    static ActionNode* regrowth_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("regrowth on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
@@ -56,7 +56,7 @@ private:
                               /*C*/ NextAction::array(0, new NextAction("melee", 10.0f), nullptr));
     }
 
-    static ActionNode* rejuvenation_on_party(PlayerbotAI* botAI)
+    static ActionNode* rejuvenation_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("rejuvenation on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
@@ -64,7 +64,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* healing_touch_on_party(PlayerbotAI* botAI)
+    static ActionNode* healing_touch_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("healing touch on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),

--- a/src/strategy/druid/GenericDruidNonCombatStrategy.cpp
+++ b/src/strategy/druid/GenericDruidNonCombatStrategy.cpp
@@ -56,35 +56,35 @@ private:
                               /*A*/ nullptr,
                               /*C*/ nullptr);
     }
-    static ActionNode* regrowth_on_party(PlayerbotAI* ai)
+    static ActionNode* regrowth_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("regrowth on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* rejuvenation_on_party(PlayerbotAI* ai)
+    static ActionNode* rejuvenation_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("rejuvenation on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* remove_curse_on_party(PlayerbotAI* ai)
+    static ActionNode* remove_curse_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("remove curse on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* abolish_poison_on_party(PlayerbotAI* ai)
+    static ActionNode* abolish_poison_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("abolish poison on party",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* revive(PlayerbotAI* ai)
+    static ActionNode* revive([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("revive",
                               /*P*/ NextAction::array(0, new NextAction("caster form"), nullptr),

--- a/src/strategy/paladin/GenericPaladinStrategyActionNodeFactory.h
+++ b/src/strategy/paladin/GenericPaladinStrategyActionNodeFactory.h
@@ -105,7 +105,7 @@ private:
                               /*A*/ nullptr,  // NextAction::array(0, new NextAction("flash of light"), NULL),
                               /*C*/ nullptr);
     }
-    // static ActionNode* seal_of_light(PlayerbotAI* ai)
+    // static ActionNode* seal_of_light(PlayerbotAI* /* ai */)
     // {
     //     return new ActionNode ("seal of light",
     //         /*P*/ NULL,

--- a/src/strategy/priest/GenericPriestStrategyActionNodeFactory.h
+++ b/src/strategy/priest/GenericPriestStrategyActionNodeFactory.h
@@ -38,49 +38,49 @@ public:
     }
 
 private:
-    static ActionNode* inner_fire(PlayerbotAI* ai)
+    static ActionNode* inner_fire([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("inner fire",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* holy_nova(PlayerbotAI* ai)
+    static ActionNode* holy_nova([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("holy nova",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* power_word_fortitude(PlayerbotAI* ai)
+    static ActionNode* power_word_fortitude([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("power word: fortitude",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* power_word_fortitude_on_party(PlayerbotAI* ai)
+    static ActionNode* power_word_fortitude_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("power word: fortitude on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* divine_spirit(PlayerbotAI* ai)
+    static ActionNode* divine_spirit([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("divine spirit",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* divine_spirit_on_party(PlayerbotAI* ai)
+    static ActionNode* divine_spirit_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("divine spirit on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* power_word_shield(PlayerbotAI* ai)
+    static ActionNode* power_word_shield([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("power word: shield",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
@@ -88,7 +88,7 @@ private:
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* power_word_shield_on_party(PlayerbotAI* ai)
+    static ActionNode* power_word_shield_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("power word: shield on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
@@ -96,91 +96,91 @@ private:
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* renew(PlayerbotAI* ai)
+    static ActionNode* renew([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("renew",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* renew_on_party(PlayerbotAI* ai)
+    static ActionNode* renew_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("renew on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* greater_heal(PlayerbotAI* ai)
+    static ActionNode* greater_heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("greater heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("heal"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* greater_heal_on_party(PlayerbotAI* ai)
+    static ActionNode* greater_heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("greater heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("heal on party"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* heal(PlayerbotAI* ai)
+    static ActionNode* heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("lesser heal"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* heal_on_party(PlayerbotAI* ai)
+    static ActionNode* heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("lesser heal on party"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* lesser_heal(PlayerbotAI* ai)
+    static ActionNode* lesser_heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("lesser heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* lesser_heal_on_party(PlayerbotAI* ai)
+    static ActionNode* lesser_heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("lesser heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* flash_heal(PlayerbotAI* ai)
+    static ActionNode* flash_heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("flash heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("greater heal"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* flash_heal_on_party(PlayerbotAI* ai)
+    static ActionNode* flash_heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("flash heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("greater heal on party"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* psychic_scream(PlayerbotAI* ai)
+    static ActionNode* psychic_scream([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("psychic scream",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("fade"), NULL),
                               /*C*/ NULL);
     }
-    // static ActionNode* fade(PlayerbotAI* ai)
+    // static ActionNode* fade([[maybe_unused]] PlayerbotAI* botAI)
     // {
     //     return new ActionNode ("fade",
     //         /*P*/ NULL,
     //         /*A*/ NextAction::array(0, new NextAction("flee"), NULL),
     //         /*C*/ NULL);
     // }
-    static ActionNode* shadowfiend(PlayerbotAI* ai)
+    static ActionNode* shadowfiend([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("shadowfiend",
                               /*P*/ NULL,

--- a/src/strategy/priest/PriestNonCombatStrategyActionNodeFactory.h
+++ b/src/strategy/priest/PriestNonCombatStrategyActionNodeFactory.h
@@ -35,98 +35,98 @@ public:
     }
 
 private:
-    static ActionNode* holy_nova(PlayerbotAI* ai)
+    static ActionNode* holy_nova([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("holy nova",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* power_word_shield(PlayerbotAI* ai)
+    static ActionNode* power_word_shield([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("power word: shield",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("renew", 50.0f), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* power_word_shield_on_party(PlayerbotAI* ai)
+    static ActionNode* power_word_shield_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("power word: shield on party",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("renew on party", 50.0f), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* renew(PlayerbotAI* ai)
+    static ActionNode* renew([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("renew",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* renew_on_party(PlayerbotAI* ai)
+    static ActionNode* renew_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("renew on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* greater_heal(PlayerbotAI* ai)
+    static ActionNode* greater_heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("greater heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("heal"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* greater_heal_on_party(PlayerbotAI* ai)
+    static ActionNode* greater_heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("greater heal on party",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("heal on party"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* heal(PlayerbotAI* ai)
+    static ActionNode* heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("lesser heal"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* heal_on_party(PlayerbotAI* ai)
+    static ActionNode* heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("lesser heal on party"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* lesser_heal(PlayerbotAI* ai)
+    static ActionNode* lesser_heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("lesser heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* lesser_heal_on_party(PlayerbotAI* ai)
+    static ActionNode* lesser_heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("lesser heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* flash_heal(PlayerbotAI* ai)
+    static ActionNode* flash_heal([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("flash heal",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* flash_heal_on_party(PlayerbotAI* ai)
+    static ActionNode* flash_heal_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("flash heal on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* circle_of_healing(PlayerbotAI* ai)
+    static ActionNode* circle_of_healing([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("circle of healing on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
@@ -134,14 +134,14 @@ private:
                               /*A*/ NULL,
                               /*C*/ NULL);
     }
-    static ActionNode* prayer_of_fortitude_on_party(PlayerbotAI* ai)
+    static ActionNode* prayer_of_fortitude_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("prayer of fortitude on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                               /*A*/ NextAction::array(0, new NextAction("power word: fortitude on party"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* prayer_of_spirit_on_party(PlayerbotAI* ai)
+    static ActionNode* prayer_of_spirit_on_party([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("prayer of spirit on party",
                               /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),

--- a/src/strategy/priest/ShadowPriestStrategyActionNodeFactory.h
+++ b/src/strategy/priest/ShadowPriestStrategyActionNodeFactory.h
@@ -23,7 +23,7 @@ public:
     }
 
 private:
-    static ActionNode* mind_blast(PlayerbotAI* botAI)
+    static ActionNode* mind_blast([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("mind blast",
                               /*P*/ nullptr,
@@ -31,7 +31,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* mind_flay(PlayerbotAI* botAI)
+    static ActionNode* mind_flay([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("mind flay",
                               /*P*/ nullptr,
@@ -39,7 +39,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* smite(PlayerbotAI* botAI)
+    static ActionNode* smite([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("smite",
                               /*P*/ nullptr,
@@ -47,7 +47,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* dispersion(PlayerbotAI* botAI)
+    static ActionNode* dispersion([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("dispersion",
                               /*P*/ nullptr,

--- a/src/strategy/rogue/AssassinationRogueStrategy.cpp
+++ b/src/strategy/rogue/AssassinationRogueStrategy.cpp
@@ -15,28 +15,28 @@ public:
     }
 
 private:
-    static ActionNode* mutilate(PlayerbotAI* ai)
+    static ActionNode* mutilate([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("mutilate",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("backstab"), nullptr),
                               /*C*/ NULL);
     }
-    static ActionNode* envenom(PlayerbotAI* ai)
+    static ActionNode* envenom([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("envenom",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("rupture"), nullptr),
                               /*C*/ NULL);
     }
-    static ActionNode* backstab(PlayerbotAI* ai)
+    static ActionNode* backstab([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("backstab",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("sinister strike"), nullptr),
                               /*C*/ NULL);
     }
-    static ActionNode* rupture(PlayerbotAI* botAI)
+    static ActionNode* rupture([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("rupture",
                               /*P*/ nullptr,

--- a/src/strategy/rogue/DpsRogueStrategy.cpp
+++ b/src/strategy/rogue/DpsRogueStrategy.cpp
@@ -22,49 +22,49 @@ public:
     }
 
 private:
-    static ActionNode* melee(PlayerbotAI* botAI)
+    static ActionNode* melee([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("melee",
                               /*P*/ nullptr,
                               /*A*/ NextAction::array(0, new NextAction("mutilate"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* mutilate(PlayerbotAI* botAI)
+    static ActionNode* mutilate([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("mutilate",
                               /*P*/ nullptr,
                               /*A*/ NextAction::array(0, new NextAction("sinister strike"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* sinister_strike(PlayerbotAI* botAI)
+    static ActionNode* sinister_strike([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("sinister strike",
                               /*P*/ nullptr,
                               /*A*/ NextAction::array(0, new NextAction("melee"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* kick(PlayerbotAI* botAI)
+    static ActionNode* kick([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("kick",
                               /*P*/ nullptr,
                               /*A*/ NextAction::array(0, new NextAction("kidney shot"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* kidney_shot(PlayerbotAI* botAI)
+    static ActionNode* kidney_shot([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("kidney shot",
                               /*P*/ nullptr,
                               /*A*/ nullptr,
                               /*C*/ nullptr);
     }
-    static ActionNode* backstab(PlayerbotAI* botAI)
+    static ActionNode* backstab([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("backstab",
                               /*P*/ nullptr,
                               /*A*/ NextAction::array(0, new NextAction("mutilate"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* rupture(PlayerbotAI* botAI)
+    static ActionNode* rupture([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("rupture",
                               /*P*/ nullptr,
@@ -158,7 +158,7 @@ public:
     }
 
 private:
-    static ActionNode* ambush(PlayerbotAI* botAI)
+    static ActionNode* ambush([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("ambush",
                               /*P*/ nullptr,
@@ -166,7 +166,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* cheap_shot(PlayerbotAI* botAI)
+    static ActionNode* cheap_shot([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("cheap shot",
                               /*P*/ nullptr,
@@ -174,7 +174,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* garrote(PlayerbotAI* botAI)
+    static ActionNode* garrote([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("garrote",
                               /*P*/ nullptr,
@@ -182,7 +182,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* sap(PlayerbotAI* botAI)
+    static ActionNode* sap([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("sap",
                               /*P*/ nullptr,
@@ -190,7 +190,7 @@ private:
                               /*C*/ nullptr);
     }
 
-    static ActionNode* sinister_strike(PlayerbotAI* botAI)
+    static ActionNode* sinister_strike([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("sinister strike",
                               /*P*/ nullptr,

--- a/src/strategy/rogue/GenericRogueNonCombatStrategy.cpp
+++ b/src/strategy/rogue/GenericRogueNonCombatStrategy.cpp
@@ -16,7 +16,7 @@ public:
     }
 
 private:
-    static ActionNode* use_deadly_poison_on_off_hand(PlayerbotAI* botAI)
+    static ActionNode* use_deadly_poison_on_off_hand([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("use deadly poison on off hand",
                               /*P*/ nullptr,

--- a/src/strategy/shaman/CasterShamanStrategy.cpp
+++ b/src/strategy/shaman/CasterShamanStrategy.cpp
@@ -24,7 +24,7 @@ private:
                               /*A*/ nullptr,
                               /*C*/ NextAction::array(0, new NextAction("fire nova"), nullptr));
     }
-    static ActionNode* totem_of_wrath(PlayerbotAI* botAI)
+    static ActionNode* totem_of_wrath([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("totem of wrath",
                               /*P*/ nullptr,

--- a/src/strategy/warlock/DpsWarlockStrategy.cpp
+++ b/src/strategy/warlock/DpsWarlockStrategy.cpp
@@ -25,14 +25,14 @@ private:
                               /*A*/ NextAction::array(0, new NextAction("shoot"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* unstable_affliction(PlayerbotAI* ai)
+    static ActionNode* unstable_affliction([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("unstable affliction",
                               /*P*/ NULL,
                               /*A*/ NextAction::array(0, new NextAction("immolate"), NULL),
                               /*C*/ NULL);
     }
-    static ActionNode* unstable_affliction_on_attacker(PlayerbotAI* ai)
+    static ActionNode* unstable_affliction_on_attacker([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("unstable affliction on attacker",
                               /*P*/ NULL,

--- a/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
+++ b/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
@@ -44,7 +44,7 @@ private:
                               /*A*/ NextAction::array(0, new NextAction("summon imp"), nullptr),
                               /*C*/ nullptr);
     }
-    static ActionNode* summon_succubus(PlayerbotAI* botAI)
+    static ActionNode* summon_succubus([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode("summon succubus",
                               /*P*/ nullptr,


### PR DESCRIPTION
Implementing C++17 best practices toward unused variable.
Details :
The class NamedObjectFactory needs the "playerbot* ai" parameter, which is used in the inherited class NamedObjectContext, in charge of managing the objects (creation, update and reset).

Various function (named after character spells) are assigned to the ActionCreator map. This map requiring the parameter to work, it can't be quitted from these functions, despite the fact they (the functions) are not using this parameter (playerbot*) themselves.

Good practice in this case is to replace :
`PlayerbotAI* botAI`
by
`[[maybe_unused]] PlayerbotAI* botAI`

Warning solved in debian (using clang++ 14.0.6) : 272 / 1135