### PR TITLE
Introduction of the SafeLearn(spellId) lambda that checks if the bot …

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2206,27 +2206,27 @@ void PlayerbotFactory::InitSkills()
             bot->learnSpell(spellId, false, true); // Avoid duplicate attempts in DB
     };
 
-// Define Riding skill according to level
-if (bot->GetLevel() >= 70)
-    bot->SetSkill(SKILL_RIDING, 300, 300);
-else if (bot->GetLevel() >= 60)
-    bot->SetSkill(SKILL_RIDING, 225, 225);
-else if (bot->GetLevel() >= 40)
-    bot->SetSkill(SKILL_RIDING, 150, 150);
-else if (bot->GetLevel() >= 20)
-    bot->SetSkill(SKILL_RIDING, 75, 75);
-else
-    bot->SetSkill(SKILL_RIDING, 0, 0);
-
-// Safe learning of mount spells
-if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)
-    SafeLearn(33388); // Apprentice
-if (bot->GetLevel() >= sPlayerbotAIConfig->useFastGroundMountAtMinLevel)
-    SafeLearn(33391); // Journeyman
-if (bot->GetLevel() >= sPlayerbotAIConfig->useFlyMountAtMinLevel)
-    SafeLearn(34090); // Expert
-if (bot->GetLevel() >= sPlayerbotAIConfig->useFastFlyMountAtMinLevel)
-    SafeLearn(34091); // Artisan
+    // Define Riding skill according to level
+    if (bot->GetLevel() >= 70)
+        bot->SetSkill(SKILL_RIDING, 300, 300, 300);
+    else if (bot->GetLevel() >= 60)
+        bot->SetSkill(SKILL_RIDING, 225, 225, 225);
+    else if (bot->GetLevel() >= 40)
+        bot->SetSkill(SKILL_RIDING, 150, 150, 150);
+    else if (bot->GetLevel() >= 20)
+        bot->SetSkill(SKILL_RIDING, 75, 75, 75);
+    else
+        bot->SetSkill(SKILL_RIDING, 0, 0, 0);
+    
+    // Safe learning of mount spells
+    if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)
+        SafeLearn(33388); // Apprentice
+    if (bot->GetLevel() >= sPlayerbotAIConfig->useFastGroundMountAtMinLevel)
+        SafeLearn(33391); // Journeyman
+    if (bot->GetLevel() >= sPlayerbotAIConfig->useFlyMountAtMinLevel)
+        SafeLearn(34090); // Expert
+    if (bot->GetLevel() >= sPlayerbotAIConfig->useFastFlyMountAtMinLevel)
+        SafeLearn(34091); // Artisan
 
     uint32 skillLevel = bot->GetLevel() < 40 ? 0 : 1;
     uint32 dualWieldLevel = bot->GetLevel() < 20 ? 0 : 1;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2201,14 +2201,20 @@ void PlayerbotFactory::InitSkills()
     bot->UpdateSkillsForLevel();
 
     bot->SetSkill(SKILL_RIDING, 0, 0, 0);
+    auto SafeLearn = [this](uint32 spellId)
+    {
+        if (!bot->HasSpell(spellId))
+            bot->learnSpell(spellId);
+    };
+
     if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)
-        bot->learnSpell(33388);
+        SafeLearn(33388);
     if (bot->GetLevel() >= sPlayerbotAIConfig->useFastGroundMountAtMinLevel)
-        bot->learnSpell(33391);
+        SafeLearn(33391);
     if (bot->GetLevel() >= sPlayerbotAIConfig->useFlyMountAtMinLevel)
-        bot->learnSpell(34090);
+        SafeLearn(34090);
     if (bot->GetLevel() >= sPlayerbotAIConfig->useFastFlyMountAtMinLevel)
-        bot->learnSpell(34091);
+        SafeLearn(34091);
 
     uint32 skillLevel = bot->GetLevel() < 40 ? 0 : 1;
     uint32 dualWieldLevel = bot->GetLevel() < 20 ? 0 : 1;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2200,21 +2200,33 @@ void PlayerbotFactory::InitSkills()
     //uint32 maxValue = level * 5; //not used, line marked for removal.
     bot->UpdateSkillsForLevel();
 
-    bot->SetSkill(SKILL_RIDING, 0, 0, 0);
     auto SafeLearn = [this](uint32 spellId)
     {
-        if (bot->GetSpellMap().find(spellId) == bot->GetSpellMap().end())
-            bot->learnSpell(spellId, false, true);
+        if (!bot->HasSpell(spellId))
+            bot->learnSpell(spellId, false, true); // Avoid duplicate attempts in DB
     };
 
-    if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)
-        SafeLearn(33388);
-    if (bot->GetLevel() >= sPlayerbotAIConfig->useFastGroundMountAtMinLevel)
-        SafeLearn(33391);
-    if (bot->GetLevel() >= sPlayerbotAIConfig->useFlyMountAtMinLevel)
-        SafeLearn(34090);
-    if (bot->GetLevel() >= sPlayerbotAIConfig->useFastFlyMountAtMinLevel)
-        SafeLearn(34091);
+// Define Riding skill according to level
+if (bot->GetLevel() >= 70)
+    bot->SetSkill(SKILL_RIDING, 300, 300);
+else if (bot->GetLevel() >= 60)
+    bot->SetSkill(SKILL_RIDING, 225, 225);
+else if (bot->GetLevel() >= 40)
+    bot->SetSkill(SKILL_RIDING, 150, 150);
+else if (bot->GetLevel() >= 20)
+    bot->SetSkill(SKILL_RIDING, 75, 75);
+else
+    bot->SetSkill(SKILL_RIDING, 0, 0);
+
+// Safe learning of mount spells
+if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)
+    SafeLearn(33388); // Apprentice
+if (bot->GetLevel() >= sPlayerbotAIConfig->useFastGroundMountAtMinLevel)
+    SafeLearn(33391); // Journeyman
+if (bot->GetLevel() >= sPlayerbotAIConfig->useFlyMountAtMinLevel)
+    SafeLearn(34090); // Expert
+if (bot->GetLevel() >= sPlayerbotAIConfig->useFastFlyMountAtMinLevel)
+    SafeLearn(34091); // Artisan
 
     uint32 skillLevel = bot->GetLevel() < 40 ? 0 : 1;
     uint32 dualWieldLevel = bot->GetLevel() < 20 ? 0 : 1;

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2203,8 +2203,8 @@ void PlayerbotFactory::InitSkills()
     bot->SetSkill(SKILL_RIDING, 0, 0, 0);
     auto SafeLearn = [this](uint32 spellId)
     {
-        if (!bot->HasSpell(spellId))
-            bot->learnSpell(spellId);
+        if (bot->GetSpellMap().find(spellId) == bot->GetSpellMap().end())
+            bot->learnSpell(spellId, false, true);
     };
 
     if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)


### PR DESCRIPTION
…already knows the spell before learning it.

Updates all bot skills with UpdateSkillsForLevel()

Sets the appropriate level of the Riding skill based on the bot's level

Uses learnSpell(spellId, false, true) correctly to avoid duplicates in the database (avoids Duplicate entry error)

Uses SafeLearn lambda safely

Uses sPlayerbotAIConfig minimum levels to build flexible logic