### PR TITLE
Add index on playerbots_random_bots to reduce deadlocks

### DIFF
--- a/data/sql/playerbots/updates/db_playerbots/2025_04_26.sql
+++ b/data/sql/playerbots/updates/db_playerbots/2025_04_26.sql
@@ -1,0 +1,9 @@
+-- ##########################################################
+-- # Playerbots RandomBots Performance Update
+-- # Add missing index to reduce Deadlocks
+-- # Author: Raz0r1337 aka St0ny
+-- # Date: 2025-04-26
+-- ##########################################################
+
+ALTER TABLE `playerbots_random_bots`
+ADD INDEX `idx_owner_bot_event` (`owner`, `bot`, `event`);


### PR DESCRIPTION
## Summary

Adds a missing composite index to the `playerbots_random_bots` table (`owner`, `bot`, `event`)
to reduce the likelihood of deadlocks during high concurrent activity.

## Changes

- Added a composite index `idx_owner_bot_event`.
- SQL update provided in `data/sql/playerbots/updates/db_playerbots`.
- No change to the table structure or playerbot functionality.