### PR TITLE
Prevents crash when logging in bots whose master disconnected before login

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -98,24 +98,20 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
     Player* masterPlayer = masterSession ? masterSession->GetPlayer() : nullptr;
 
     bool isRndbot = !masterAccountId;
-
-    std::ostringstream out;
     bool allowed = true;
-    time_t currentTime = time(nullptr);
+	std::ostringstream out;
 
-    if (!isRndbot)
-    {
-        time_t& lastAction = lastBotActionTime[masterAccountId];
-        if (lastAction && (currentTime - lastAction) < 5)
-        {
-            allowed = false;
-            out << "Wait " << (5 - (currentTime - lastAction)) << "s to call the next bot";
-        }
-        else
-        {
-            lastAction = currentTime;
-        }
-    }
+	if(!isRndbot)
+	{
+		time_t CurrentTime = time(nullptr);
+		if (DelayBot && (CurrentTime - DelayBot) <= 10)
+		{
+			allowed = false;
+			out << "Wait 10s to call the next bot";
+		}
+
+		DelayBot = CurrentTime;
+	}
 
     bool sameAccount = sPlayerbotAIConfig->allowAccountBots && accountId == masterAccountId;
     Guild* guild = masterPlayer ? sGuildMgr->GetGuildById(masterPlayer->GetGuildId()) : nullptr;
@@ -153,13 +149,6 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
         }
         return;
     }
-
-    // 5 second artificial delay for manual bots (not rndbot)
-    if (!isRndbot)
-    {
-        std::this_thread::sleep_for(std::chrono::seconds(5));
-    }
-
     std::shared_ptr<PlayerbotLoginQueryHolder> holder =
         std::make_shared<PlayerbotLoginQueryHolder>(this, masterAccountId, accountId, playerGuid);
     if (!holder->Initialize())
@@ -318,28 +307,28 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid, uint32 masterAccountId)
 {
     if (Player* bot = GetPlayerBot(guid))
     {
-        time_t currentTime = time(nullptr);
+        //Checks if the bot is in a group and removes it to avoid a possible crash
+		if (ObjectGuid groupId = sCharacterCache->GetCharacterGroupGuidByGuid(guid))
+		{
+			if (Group* group = sGroupMgr->GetGroupByGUID(groupId.GetCounter()))
+			{
+				group->RemoveMember(guid);
+				group = nullptr;
+			}
+		}
 
-        if (masterAccountId)
-        {
-            time_t& lastAction = lastBotActionTime[masterAccountId];
-            if (lastAction && (currentTime - lastAction) < 5)
-                return;
-            else
-                lastAction = currentTime;
-        }
+		uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(guid);
+		
+		if(accountId == masterAccountId)
+		{
+			time_t CurrentTime = time(nullptr);
+			if (DelayBot && (CurrentTime - DelayBot) <= 10)
+			{
+				return;
+			}
 
-        // 5 second artificial delay
-        std::this_thread::sleep_for(std::chrono::seconds(5));
-
-        // Remove from group if necessary
-        if (ObjectGuid groupId = sCharacterCache->GetCharacterGroupGuidByGuid(guid))
-        {
-            if (Group* group = sGroupMgr->GetGroupByGUID(groupId.GetCounter()))
-            {
-                group->RemoveMember(guid);
-            }
-        }
+			DelayBot = CurrentTime;
+		}
 
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (!botAI)

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -98,26 +98,13 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
     Player* masterPlayer = masterSession ? masterSession->GetPlayer() : nullptr;
 
     bool isRndbot = !masterAccountId;
-    bool allowed = true;
-	std::ostringstream out;
-
-	if(!isRndbot)
-	{
-		time_t CurrentTime = time(nullptr);
-		if (DelayBot && (CurrentTime - DelayBot) <= 10)
-		{
-			allowed = false;
-			out << "Wait 10s to call the next bot";
-		}
-
-		DelayBot = CurrentTime;
-	}
-
     bool sameAccount = sPlayerbotAIConfig->allowAccountBots && accountId == masterAccountId;
     Guild* guild = masterPlayer ? sGuildMgr->GetGuildById(masterPlayer->GetGuildId()) : nullptr;
     bool sameGuild = sPlayerbotAIConfig->allowGuildBots && guild && guild->GetMember(playerGuid); 
     bool addClassBot = sRandomPlayerbotMgr->IsAddclassBot(playerGuid.GetCounter());
 
+    bool allowed = true;
+    std::ostringstream out;
     std::string botName;
     sCharacterCache->GetCharacterNameByGuid(playerGuid, botName);
     if (!isRndbot && !sameAccount && !sameGuild && !addClassBot)
@@ -303,33 +290,10 @@ void PlayerbotMgr::CancelLogout()
     }
 }
 
-void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid, uint32 masterAccountId)
+void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
 {
     if (Player* bot = GetPlayerBot(guid))
     {
-        //Checks if the bot is in a group and removes it to avoid a possible crash
-		if (ObjectGuid groupId = sCharacterCache->GetCharacterGroupGuidByGuid(guid))
-		{
-			if (Group* group = sGroupMgr->GetGroupByGUID(groupId.GetCounter()))
-			{
-				group->RemoveMember(guid);
-				group = nullptr;
-			}
-		}
-
-		uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(guid);
-		
-		if(accountId == masterAccountId)
-		{
-			time_t CurrentTime = time(nullptr);
-			if (DelayBot && (CurrentTime - DelayBot) <= 10)
-			{
-				return;
-			}
-
-			DelayBot = CurrentTime;
-		}
-
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (!botAI)
             return;
@@ -725,7 +689,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
         if (!GetPlayerBot(guid))
             return "not your bot";
 
-        LogoutPlayerBot(guid, masterAccountId);
+        LogoutPlayerBot(guid);
         return "ok";
     }
 

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -174,12 +174,17 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
 
     uint32 masterAccount = holder.GetMasterAccountId();
     WorldSession* masterSession = masterAccount ? sWorldSessionMgr->FindSession(masterAccount) : nullptr;
-
-    // Check if masterSession->GetPlayer() is valid
     Player* masterPlayer = masterSession ? masterSession->GetPlayer() : nullptr;
-    if (masterSession && !masterPlayer)
+
+    // If the masterPlayer is no longer online, log the bot out immediately
+    if (masterAccount && (!masterSession || !masterPlayer))
     {
-        LOG_DEBUG("mod-playerbots", "Master session found but no player is associated for master account ID: {}", masterAccount);
+        LOG_DEBUG("mod-playerbots", "Master is no longer online, aborting bot login");
+
+        bot->GetSession()->LogoutPlayer(true);
+        delete botSession;
+        botLoading.erase(holder.GetGuid());
+        return;
     }
     
     sRandomPlayerbotMgr->OnPlayerLogin(bot);

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -48,15 +48,13 @@ public:
     std::vector<std::string> HandlePlayerbotCommand(char const* args, Player* master = nullptr);
     std::string const ProcessBotCommand(std::string const cmd, ObjectGuid guid, ObjectGuid masterguid, bool admin,
                                         uint32 masterAccountId, uint32 masterGuildId);
-
-    std::unordered_map<uint32, time_t> lastBotActionTime; // <masterAccountId, timestamp>
-
     uint32 GetAccountId(std::string const name);
     uint32 GetAccountId(ObjectGuid guid);
     std::string const ListBots(Player* master);
     std::string const LookupBots(Player* master);
     uint32 GetPlayerbotsCount() { return playerBots.size(); }
     uint32 GetPlayerbotsCountByClass(uint32 cls);
+    time_t DelayBot;
 
 protected:
     virtual void OnBotLoginInternal(Player* const bot) = 0;

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -30,7 +30,7 @@ public:
     void AddPlayerBot(ObjectGuid guid, uint32 masterAccountId);
     void HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder const& holder);
 
-    void LogoutPlayerBot(ObjectGuid guid, uint32 masterAccountId = 0);
+    void LogoutPlayerBot(ObjectGuid guid);
     void DisablePlayerBot(ObjectGuid guid);
     void RemoveFromPlayerbotsMap(ObjectGuid guid);
     Player* GetPlayerBot(ObjectGuid guid) const;
@@ -54,7 +54,6 @@ public:
     std::string const LookupBots(Player* master);
     uint32 GetPlayerbotsCount() { return playerBots.size(); }
     uint32 GetPlayerbotsCountByClass(uint32 cls);
-    time_t DelayBot;
 
 protected:
     virtual void OnBotLoginInternal(Player* const bot) = 0;

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -30,7 +30,7 @@ public:
     void AddPlayerBot(ObjectGuid guid, uint32 masterAccountId);
     void HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder const& holder);
 
-    void LogoutPlayerBot(ObjectGuid guid);
+    void LogoutPlayerBot(ObjectGuid guid, uint32 masterAccountId = 0);
     void DisablePlayerBot(ObjectGuid guid);
     void RemoveFromPlayerbotsMap(ObjectGuid guid);
     Player* GetPlayerBot(ObjectGuid guid) const;
@@ -54,6 +54,7 @@ public:
     std::string const LookupBots(Player* master);
     uint32 GetPlayerbotsCount() { return playerBots.size(); }
     uint32 GetPlayerbotsCountByClass(uint32 cls);
+    time_t DelayBot;
 
 protected:
     virtual void OnBotLoginInternal(Player* const bot) = 0;

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -48,13 +48,15 @@ public:
     std::vector<std::string> HandlePlayerbotCommand(char const* args, Player* master = nullptr);
     std::string const ProcessBotCommand(std::string const cmd, ObjectGuid guid, ObjectGuid masterguid, bool admin,
                                         uint32 masterAccountId, uint32 masterGuildId);
+
+    std::unordered_map<uint32, time_t> lastBotActionTime; // <masterAccountId, timestamp>
+
     uint32 GetAccountId(std::string const name);
     uint32 GetAccountId(ObjectGuid guid);
     std::string const ListBots(Player* master);
     std::string const LookupBots(Player* master);
     uint32 GetPlayerbotsCount() { return playerBots.size(); }
     uint32 GetPlayerbotsCountByClass(uint32 cls);
-    time_t DelayBot;
 
 protected:
     virtual void OnBotLoginInternal(Player* const bot) = 0;


### PR DESCRIPTION
This PR adds a check to the HandlePlayerBotLoginCallback function to ensure that the master player is still online before completing the bot login. If the master is no longer present, the bot is safely logged out, preventing invalid pointer access and related crashes. This change resolves a common race condition where the master disconnects shortly after adding a bot to the group.