### PR TITLE
fix(#1250): Fix movement animation desync after CC effects This fixes…

### DIFF
--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -1027,6 +1027,20 @@ void MovementAction::UpdateMovementState()
         bot->SendMovementFlagUpdate();
     }
 
+    // See if the bot is currently slowed, rooted, or otherwise unable to move
+    bool isCurrentlyRestricted = bot->isFrozen() || bot->IsPolymorphed() || bot->HasRootAura() || bot->HasStunAura() ||
+                                 bot->HasConfuseAura() || bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
+
+    // Detect if movement restrictions have been lifted
+    if (wasMovementRestricted && !isCurrentlyRestricted && bot->IsAlive())
+    {
+        // CC just ended - refresh movement state to ensure animations play correctly
+        bot->SendMovementFlagUpdate();
+    }
+
+    // Save current state for the next check
+    wasMovementRestricted = isCurrentlyRestricted;
+    
     // Temporary speed increase in group
     // if (botAI->HasRealPlayerMaster()) {
     //     bot->SetSpeedRate(MOVE_RUN, 1.1f);

--- a/src/strategy/actions/MovementActions.h
+++ b/src/strategy/actions/MovementActions.h
@@ -73,6 +73,7 @@ private:
     // normal_only = false, float step = 8.0f);
     const Movement::PointsArray SearchForBestPath(float x, float y, float z, float& modified_z, int maxSearchCount = 5,
                                                   bool normal_only = false, float step = 8.0f);
+    bool wasMovementRestricted = false;
 };
 
 class FleeAction : public MovementAction


### PR DESCRIPTION
… a bug where playerbots fail to display proper movement animations after crowd control effects wear off. When affected by movement-restricting abilities (e.g., Net-o-Matic Projector), bots would abruptly snap between positions instead of transitioning smoothly with walking or running animations.

Fix: Better handling of CC state transitions in bot movement:
    - Added wasMovementRestricted to track CC status
    - Enhanced UpdateMovementState() to detect and react to CC ending
    - Triggered movement flag update to fix animation desync

This ensures proper client-server movement synchronization and resolves the visual bug where bots appeared to jump or skip positions. The fix restores the correct movement animation state, replicating the effect previously achieved with the reset or summon commands.