### PR TITLE
Fix inventory clear on init quests

### DIFF
--- a/src/factory/PlayerbotFactory.h
+++ b/src/factory/PlayerbotFactory.h
@@ -156,7 +156,7 @@ private:
     void ClearSkills();
     void InitTalents(uint32 specNo);
     void InitTalentsByTemplate(uint32 specNo);
-    void InitQuests(std::list<uint32>& questMap);
+    void InitQuests(std::list<uint32>& questMap, bool withRewardItem = true);
     void ClearInventory();
     void ClearAllItems();
     void ResetQuests();


### PR DESCRIPTION
InitQuests no longer clear inventory but instead destroy the corresponding reward items. 

Fix issues that sometimes cause inventory to be incorrectly cleared, (e.g. maintenance https://github.com/liyunfan1223/mod-playerbots/issues/1244).

