### PR TITLE
fix(strategy): Revert InitTriggers to previous implementation

### DIFF
--- a/src/strategy/generic/DpsAssistStrategy.cpp
+++ b/src/strategy/generic/DpsAssistStrategy.cpp
@@ -7,11 +7,10 @@
 
 #include "Playerbots.h"
 
-NextAction** DpsAssistStrategy::getDefaultActions()
+void DpsAssistStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    return NextAction::array(
-        0, new NextAction("dps assist", 50.0f),
-        nullptr);
+    triggers.push_back(
+        new TriggerNode("not dps target active", NextAction::array(0, new NextAction("dps assist", 50.0f), nullptr)));
 }
 
 void DpsAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/strategy/generic/DpsAssistStrategy.h
+++ b/src/strategy/generic/DpsAssistStrategy.h
@@ -16,7 +16,7 @@ public:
     DpsAssistStrategy(PlayerbotAI* botAI) : NonCombatStrategy(botAI) {}
 
     std::string const getName() override { return "dps assist"; }
-    NextAction** getDefaultActions() override;
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
 };
 
 class DpsAoeStrategy : public NonCombatStrategy

--- a/src/strategy/generic/TankAssistStrategy.cpp
+++ b/src/strategy/generic/TankAssistStrategy.cpp
@@ -7,15 +7,8 @@
 
 #include "Playerbots.h"
 
-NextAction** TankAssistStrategy::getDefaultActions()
+void TankAssistStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    return NextAction::array(
-        0, new NextAction("tank assist", 50.0f),
-        nullptr);
+    triggers.push_back(
+        new TriggerNode("tank assist", NextAction::array(0, new NextAction("tank assist", 50.0f), nullptr)));
 }
-
-// void TankAssistStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
-// {
-//     triggers.push_back(
-//         new TriggerNode("tank assist", NextAction::array(0, new NextAction("tank assist", 50.0f), nullptr)));
-// }

--- a/src/strategy/generic/TankAssistStrategy.h
+++ b/src/strategy/generic/TankAssistStrategy.h
@@ -17,8 +17,7 @@ public:
 
     std::string const getName() override { return "tank assist"; }
     uint32 GetType() const override { return STRATEGY_TYPE_TANK; }
-    NextAction** getDefaultActions() override;
-    // void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
 };
 
 #endif


### PR DESCRIPTION
Fixes #1169

Reverts TankAssistStrategy and DpsAssistStrategy InitTriggers implementations to their previous versions. The changes from commit 24efa7e appeared to be optimizations without fixing any documented bugs, but were causing issues.