### PR TITLE
Replace sprintf with snprintf to address macOS security warning

### DIFF
--- a/src/ChatHelper.cpp
+++ b/src/ChatHelper.cpp
@@ -382,7 +382,7 @@ std::string const ChatHelper::FormatSpell(SpellInfo const* spellInfo)
 std::string const ChatHelper::FormatItem(ItemTemplate const* proto, uint32 count, uint32 total)
 {
     char color[32];
-    sprintf(color, "%x", ItemQualityColors[proto->Quality]);
+    snprintf(color, sizeof(color), "%x", ItemQualityColors[proto->Quality]);
 
     std::string itemName;
     const ItemLocale* locale = sObjectMgr->GetItemLocale(proto->ItemId);
@@ -409,7 +409,7 @@ std::string const ChatHelper::FormatItem(ItemTemplate const* proto, uint32 count
 std::string const ChatHelper::FormatQItem(uint32 itemId)
 {
     char color[32];
-    sprintf(color, "%x", ItemQualityColors[0]);
+    snprintf(color, sizeof(color), "%x", ItemQualityColors[0]);
 
     std::ostringstream out;
     out << "|c" << color << "|Hitem:" << itemId << ":0:0:0:0:0:0:0"


### PR DESCRIPTION
This PR replaces sprintf with snprintf in ChatHelper::FormatItem and ChatHelper::FormatQItem to resolve 
security warnings issued by macOS regarding potential buffer overflows.

snprintf is used to safely format item quality color codes while enforcing buffer boundaries. This change 
follows modern best practices for secure string formatting and aligns with macOS's stricter security checks.

The change is fully portable and should not affect builds or behavior on Windows or Linux, as snprintf is 
widely supported across standard C++ runtimes.

