### PR TITLE
feat(playerbots): staggered taxi take-off for bots

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -18,6 +18,7 @@
 #        COMBAT
 #        CHEATS
 #        SPELLS
+#        FLIGHTPATH
 #    PLAYERBOT RNDBOT SPECIFIC SETTINGS
 #        GENERAL
 #        LEVELS
@@ -489,6 +490,28 @@ AiPlayerbot.BotCheats = "taxi"
 
 # ID of spell to open lootable chests
 AiPlayerbot.OpenGoSpell = 6477
+
+#
+#
+#
+###################################################################################################
+
+####################################################################################################
+# FLIGHTPATH
+#
+#
+
+# Min random delay before the 1st follower bot clicks the flight-master (ms)
+AiPlayerbot.BotTaxiDelayMinMs = 350
+
+# Upper bound for the overall taxi delay window (ms) – larger spreads big raids
+AiPlayerbot.BotTaxiDelayMaxMs = 5000
+
+# Fixed gap added per group-slot so bots never take off together (ms)
+AiPlayerbot.BotTaxiGapMs = 200
+
+# Extra small randomness added to each gap so launches don’t look robotic (ms)
+AiPlayerbot.BotTaxiGapJitterMs = 100
 
 #
 #

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -590,6 +590,9 @@ public:
     NewRpgStatistic rpgStatistic;
     std::unordered_set<uint32> lowPriorityQuest;
 
+    // Schedules a callback to run once after <delayMs> milliseconds.
+    void AddTimedEvent(std::function<void()> callback, uint32 delayMs);
+
 private:
     static void _fillGearScoreData(Player* player, Item* item, std::vector<uint32>* gearScore, uint32& twoHandScore,
                                    bool mixed = false);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -331,6 +331,12 @@ bool PlayerbotAIConfig::Initialize()
     useFlyMountAtMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.UseFlyMountAtMinLevel", 60);
     useFastFlyMountAtMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.UseFastFlyMountAtMinLevel", 70);
 
+    // stagger bot flightpath takeoff
+    delayMin = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiDelayMinMs", 350u);
+    delayMax = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiDelayMaxMs", 5000u);
+    gapMs = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiGapMs", 200u);
+    gapJitterMs = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiGapJitterMs", 100u);
+
     LOG_INFO("server.loading", "Loading TalentSpecs...");
 
     for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -348,6 +348,12 @@ public:
     uint32 useFlyMountAtMinLevel;
     uint32 useFastFlyMountAtMinLevel;
 
+    // stagger flightpath takeoff
+    uint32 delayMin;
+    uint32 delayMax;
+    uint32 gapMs;
+    uint32 gapJitterMs;
+
     std::string const GetTimestampStr();
     bool hasLog(std::string const fileName)
     {

--- a/src/strategy/actions/TaxiAction.cpp
+++ b/src/strategy/actions/TaxiAction.cpp
@@ -9,7 +9,7 @@
 #include "LastMovementValue.h"
 #include "Playerbots.h"
 #include "PlayerbotAIConfig.h"
-
+#include "Config.h"
 
 bool TaxiAction::Execute(Event event)
 {
@@ -49,6 +49,12 @@ bool TaxiAction::Execute(Event event)
                         nodes.push_back(i);
                 }
         }
+
+        // stagger bot takeoff
+        uint32 delayMin = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiDelayMinMs", 350u, false);
+        uint32 delayMax = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiDelayMaxMs", 5000u, false);
+        uint32 gapMs = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiGapMs", 200u, false);
+        uint32 gapJitterMs = sConfigMgr->GetOption<uint32>("AiPlayerbot.BotTaxiGapJitterMs", 100u, false);
 
         // Only for follower bots
         if (botAI->HasRealPlayerMaster())


### PR DESCRIPTION
Adds four new configurable settings to playerbots.conf:

- AiPlayerbot.BotTaxiDelayMinMs:   Min random delay before the 1st follower bot clicks the flight-master
- AiPlayerbot.BotTaxiDelayMaxMs:   Upper bound for the overall taxi delay window – larger spreads big raids
- AiPlayerbot.BotTaxiGapMs:        Fixed gap added per group-slot so bots never take off together
- AiPlayerbot.BotTaxiGapJitterMs:  Extra small randomness added to each gap so launches don’t look robotic

These options allow server owners to fine-tune how bots queue up and take off from flight masters, making their behavior appear more natural.

Closes #1017 : Bots use Flight master nearly the same time.