### PR TITLE
Prevents recreating the tamed pet in InitPet() for hunter bots

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -812,6 +812,9 @@ void PlayerbotFactory::InitPetTalents()
 
 void PlayerbotFactory::InitPet()
 {
+    if (bot->GetPetId() != 0)
+    return;
+
     Pet* pet = bot->GetPet();
     if (!pet)
     {


### PR DESCRIPTION
This update adds a check to prevent the InitPet() method from re-creating a pet for hunter bots that already have a tamed pet (GetPetId() != 0). This prevents pets that have already been trained and have talents set from being lost, especially after login or teleportation. Responsibility for re-summoning an existing pet can be handled separately via LoadPetFromDB.