### PR TITLE
Clarify EnableNewRpgStrategy relation to RandomBotTeleLowerLevel and RandomBotTeleHigherLevel, and making them more intuitive

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -718,7 +718,7 @@ AiPlayerbot.RandomBotGroupNearby = 0
 AiPlayerbot.AutoDoQuests = 1
 
 # Random Bots will behave more like real players (exprimental)
-# This option will override AutoDoQuests
+# This option will override AutoDoQuests, RandomBotTeleLowerLevel, and RandomBotTeleHigherLevel
 # Default: 1 (enabled)
 AiPlayerbot.EnableNewRpgStrategy = 1
 
@@ -787,9 +787,11 @@ AiPlayerbot.ProbTeleToBankers = 0.25
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 
-# Level diff between random bots and nearby creatures for random teleports
-AiPlayerbot.RandomBotTeleLowerLevel = 3
-AiPlayerbot.RandomBotTeleHigherLevel = 1
+# How many levels below the lowest level creature in a zone, can a bot be
+AiPlayerbot.RandomBotTeleLowerLevel = 1
+
+# How many levels above the highest level creature in a zone, can a bot be
+AiPlayerbot.RandomBotTeleHigherLevel = 3
 
 # Bots automatically teleport to another place for leveling on levelup
 # Default: 1 (enabled)

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -674,7 +674,7 @@ AiPlayerbot.HunterWolfPet = 0
 #
 #
 # Specify percent of active bots
-# The Default is 100% but will be automatically adjusted if botActiveAloneSmartScale
+# The default is 100% but will be automatically adjusted if botActiveAloneSmartScale
 # is enabled. Regardless, this value is only applied to inactive areas where no real players
 # are detected. When real players are nearby, the value is always enforced to 100%
 AiPlayerbot.BotActiveAlone = 100
@@ -687,7 +687,7 @@ AiPlayerbot.BotActiveAloneForceWhenIsFriend = 1
 AiPlayerbot.BotActiveAloneForceWhenInGuild = 1
 
 # SmartScale (automatic scaling of percentage of active bots based on latency)
-# The Default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
+# The default is 1. When enabled (smart) scales the 'BotActiveAlone' value.
 # (The scaling will be overruled by the BotActiveAloneForceWhen...rules)
 #
 #   Limitfloor - when DIFF (latency) above floor, activity scaling is applied starting with 90%
@@ -765,7 +765,7 @@ AiPlayerbot.RandomBotSpellIds = "54197"
 #
 #
 
-# Random bot Default strategies (applied after Defaults)
+# Random bot default strategies (applied after defaults)
 AiPlayerbot.RandomBotCombatStrategies = "+dps,+dps assist,-threat"
 # AiPlayerbot.RandomBotNonCombatStrategies = "+grind,+loot,+rpg,+custom::say"
 AiPlayerbot.RandomBotNonCombatStrategies = ""
@@ -841,7 +841,7 @@ AiPlayerbot.RandomBotAutoJoinBG = 0
 # - Ensure there are enough eligible bots to meet the specified counts.
 #
 # Arena Considerations:
-# - Rated arena brackets Default to level 80-84 (bracket 14).
+# - Rated arena brackets default to level 80-84 (bracket 14).
 # - Custom code changes are required for lower-level arena brackets to function properly.
 #
 # Battleground bracket range possibilities:

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -118,7 +118,6 @@ AiPlayerbot.DeleteRandomBotAccounts = 0
 # The maximum number of bots that a player can control simultaneously
 AiPlayerbot.MaxAddedBots = 40
 
-
 # Enable/Disable creating bots by addclass command (0 = GM only, 1 = enabled)
 # Default: 1 (enabled)
 AiPlayerbot.AddClassCommand = 1
@@ -169,7 +168,6 @@ AiPlayerbot.SelfBotLevel = 1
 # Give free food to bots
 # Default: 1 (enabled)
 AiPlayerbot.FreeFood = 1
-
 
 # Non-GM player can only use init=auto to initialize bots based on their own level and gearscore
 # Default: 0 (non-GM player can use any intialization commands)
@@ -800,7 +798,7 @@ AiPlayerbot.RandomBotTeleportDistance = 100
 AiPlayerbot.RandomBotTeleLowerLevel = 1
 
 # How many levels above the highest level creature in a zone, can a bot be
-# Default: 3 (randombot will leave if they are more than 3 level3 higher)
+# Default: 3 (randombot will leave if they are more than 3 levels higher)
 AiPlayerbot.RandomBotTeleHigherLevel = 3
 
 # Bots automatically teleport to another place for leveling on levelup

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -792,12 +792,12 @@ AiPlayerbot.ProbTeleToBankers = 0.25
 # How far randombots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 
-# How many levels below the lowest level creature in a zone, can a bot be
+# How many levels below the lowest-level creature in a zone, can a bot be
 # This will have no effect if AiPlayerbot.EnableNewRpgStrategy is enabled
 # Default: 1 (randombot will leave if they are more than 1 level lower)
 AiPlayerbot.RandomBotTeleLowerLevel = 1
 
-# How many levels above the highest level creature in a zone, can a bot be
+# How many levels above the highest-level creature in a zone, can a bot be
 # Default: 3 (randombot will leave if they are more than 3 levels higher)
 AiPlayerbot.RandomBotTeleHigherLevel = 3
 

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -89,7 +89,7 @@ AiPlayerbot.MaxRandomBots = 500
 # Random bot accounts
 # If you are not using any expansion at all, you may have to set this manually, then
 # please ensure that RandomBotAccountCount is at least greater than (MaxRandomBots / 10 + AddClassAccountPoolSize)
-# default: 0 - Automatic
+# Default: 0 - Automatic
 AiPlayerbot.RandomBotAccountCount = 0
 
 # Delete all random bot accounts (reset randombots)
@@ -114,14 +114,14 @@ AiPlayerbot.DeleteRandomBotAccounts = 0
 AiPlayerbot.MaxAddedBots = 40
 
 # Enable/Disable create bot by addclass command (0 = GM only, 1 = enable)
-# default: 1 (enable)
+# Default: 1 (enable)
 AiPlayerbot.AddClassCommand = 1
 
 # Set the addclass command account pool size
 AiPlayerbot.AddClassAccountPoolSize = 50
 
 # Bot group invitation permission level (0 = GM only, 1 = accept based on level, 2 = always accept)
-# default: 1 (accept based on level)
+# Default: 1 (accept based on level)
 AiPlayerbot.GroupInvitationPermission = 1
 
 # auto-login all player alts as bots on player login
@@ -163,11 +163,11 @@ AiPlayerbot.SelfBotLevel = 1
 AiPlayerbot.FreeFood = 1
 
 # Non-GM player can only use init=auto to initialize bots based on their own level and gear score
-# default: 0 (non-gm player can use any intialization commands)
+# Default: 0 (non-gm player can use any intialization commands)
 AiPlayerbot.AutoInitOnly = 0
 
 # The upper limit ratio of bot equipment level for init=auto
-# default: 1.0 (same with the player)
+# Default: 1.0 (same with the player)
 AiPlayerbot.AutoInitEquipLevelLimitRatio = 1.0
 
 # Bot automatically trains spells when talking to trainer (yes = train all available spells as long as the bot has the money, free = auto trains with no money cost, no = only list spells)
@@ -184,23 +184,23 @@ AiPlayerbot.AutoTrainSpells = yes
 #
 
 # Enable/Disable summoning bots when the master is in combat
-# default: 1 (enabled)
+# Default: 1 (enabled)
 AiPlayerbot.AllowSummonInCombat = 1
 
 # Enable/Disable summoning bots when the master is dead
-# default: 1 (enabled)
+# Default: 1 (enabled)
 AiPlayerbot.AllowSummonWhenMasterIsDead = 1
 
 # Enable/Disable summoning bots when they are dead (0 = only when the bots are ghosts, 1 = always)
-# default: 1 (always)
+# Default: 1 (always)
 AiPlayerbot.AllowSummonWhenBotIsDead = 1
 
 # Enable/Disable reviving the bots when summoning them (0 = disable, 1 = disable in combat, 2 = enable)
-# default: 1 (disable in combat)
+# Default: 1 (disable in combat)
 AiPlayerbot.ReviveBotWhenSummoned = 1
 
 # Enable/Disable bot repair gear when summon (0 = no, 1 = yes)
-# default: 1
+# Default: 1
 AiPlayerbot.BotRepairWhenSummon = 1
 
 #
@@ -215,22 +215,22 @@ AiPlayerbot.BotRepairWhenSummon = 1
 
 # Defines at what level a bot will naturally use its 60% ground mount
 # note: was level 20 during WotLK, 30 during TBC, 40 during Vanilla
-# default: 20
+# Default: 20
 AiPlayerbot.UseGroundMountAtMinLevel = 20
 
 # Defines at what level a bot will naturally use its 100% fast ground mount
 # note: was level 40 during WotLK, 60 during Vanilla
-# default: 40
+# Default: 40
 AiPlayerbot.UseFastGroundMountAtMinLevel = 40
 
 # Defines at what level a bot will naturally use its 150% fly mount
 # note: was level 60 during WotLK, 70 during TBC
-# default: 60
+# Default: 60
 AiPlayerbot.UseFlyMountAtMinLevel = 60
 
 # Defines at what level a bot will naturally use its 280% fast fly mount
 # note: was level 70 during WotLK and TBC
-# default: 70
+# Default: 70
 AiPlayerbot.UseFastFlyMountAtMinLevel = 70
 
 #
@@ -306,7 +306,7 @@ AiPlayerbot.MaxWaitForMove = 5000
 AiPlayerbot.DisableMoveSplinePath = 0
 
 # Max search time for movement (higher for better movement on slopes)
-# default: 3
+# Default: 3
 AiPlayerbot.MaxMovementSearchTime = 3
 
 # Action expiration time
@@ -456,11 +456,11 @@ AiPlayerbot.FleeingEnabled = 1
 #
 
 # Enable/Disable maintenance command, learn all available spells and skills, supplement consumables, repair, etc.
-# default: 1 (enable)
+# Default: 1 (enable)
 AiPlayerbot.MaintenanceCommand = 1
 
 # Enable/Disable autogear command, auto upgrade player bots gears, the quality is limited by AutoGearQualityLimit and AutoGearScoreLimit
-# default: 1 (enable)
+# Default: 1 (enable)
 AiPlayerbot.AutoGearCommand = 1
 
 # Enable/Disable autogear command on player alt bots
@@ -468,11 +468,11 @@ AiPlayerbot.AutoGearCommand = 1
 AiPlayerbot.AutoGearCommandAltBots = 1
 
 # Equips quality limitation for auto gear command (1 = normal, 2 = uncommon, 3 = rare, 4 = epic, 5 = legendary)
-# default: 3 (rare)
+# Default: 3 (rare)
 AiPlayerbot.AutoGearQualityLimit = 3
 
 # Equips item level (not gearScore) limitation for auto gear command (0 = no limit)
-# default: 0 (no limit)
+# Default: 0 (no limit)
 AiPlayerbot.AutoGearScoreLimit = 0
 
 # Enables/Disables bot cheating
@@ -614,11 +614,11 @@ AiPlayerbot.DowngradeMaxLevelBot = 0
 #
 
 # Equips quality limitation for random bots (1 = normal, 2 = uncommon, 3 = rare, 4 = epic, 5 = legendary)
-# default: 3 (rare)
+# Default: 3 (rare)
 AiPlayerbot.RandomGearQualityLimit = 3
 
 # Equips gear score limitation for random bots (0 = no limit)
-# default: 0 (no limit)
+# Default: 0 (no limit)
 AiPlayerbot.RandomGearScoreLimit = 0
 
 # Set minimum level of randombots where gets enchants on items (Maxlevel + 1 to disable)
@@ -643,10 +643,10 @@ AiPlayerbot.RandomGearLoweringChance = 0
 AiPlayerbot.GearScoreCheck = 0
 
 # Enable/Disable bot equipments persistence (stop random initialization) after certain level (EquipmentPersistenceLevel)
-# default: 0 (disable)
+# Default: 0 (disable)
 AiPlayerbot.EquipmentPersistence = 0
 
-# default: 80
+# Default: 80
 AiPlayerbot.EquipmentPersistenceLevel = 80
 
 # Randombots automatically upgrade equipments on levelup
@@ -781,16 +781,18 @@ AiPlayerbot.NonCombatStrategies = ""
 AiPlayerbot.RandomBotMaps = 0,1,530,571
 
 # Probabilty bots teleport to banker (city)
-# default: 0.25
+# Default: 0.25
 AiPlayerbot.ProbTeleToBankers = 0.25
 
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 
 # How many levels below the lowest level creature in a zone, can a bot be
+# Default: 1
 AiPlayerbot.RandomBotTeleLowerLevel = 1
 
 # How many levels above the highest level creature in a zone, can a bot be
+# Default: 3
 AiPlayerbot.RandomBotTeleHigherLevel = 3
 
 # Bots automatically teleport to another place for leveling on levelup

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -798,6 +798,7 @@ AiPlayerbot.RandomBotTeleportDistance = 100
 AiPlayerbot.RandomBotTeleLowerLevel = 1
 
 # How many levels above the highest-level creature in a zone, can a bot be
+# This will have no effect if AiPlayerbot.EnableNewRpgStrategy is enabled
 # Default: 3 (randombot will leave if they are more than 3 levels higher)
 AiPlayerbot.RandomBotTeleHigherLevel = 3
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -308,8 +308,8 @@ bool PlayerbotAIConfig::Initialize()
     randomBotMinLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotMinLevel", 1);
     randomBotMaxLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotMaxLevel", 80);
     randomBotLoginAtStartup = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotLoginAtStartup", true);
-    randomBotTeleLowerLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleLowerLevel", 3);
-    randomBotTeleHigherLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleHigherLevel", 1);
+    randomBotTeleLowerLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleLowerLevel", 1);
+    randomBotTeleHigherLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleHigherLevel", 3);
     openGoSpell = sConfigMgr->GetOption<int32>("AiPlayerbot.OpenGoSpell", 6477);
 
     randomChangeMultiplier = sConfigMgr->GetOption<float>("AiPlayerbot.RandomChangeMultiplier", 1.0);

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1627,8 +1627,8 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
             uint32 level = (min_level + max_level + 1) / 2;
             WorldLocation loc(mapId, x, y, z, 0);
             collected_locs++;
-            for (int32 l = (int32)level - (int32)sPlayerbotAIConfig->randomBotTeleHigherLevel;
-                 l <= (int32)level + (int32)sPlayerbotAIConfig->randomBotTeleLowerLevel; l++)
+            for (int32 l = (int32)level - (int32)sPlayerbotAIConfig->randomBotTeleLowerLevel;
+                 l <= (int32)level + (int32)sPlayerbotAIConfig->randomBotTeleHigherLevel; l++)
             {
                 if (l < 1 || l > maxLevel)
                 {


### PR DESCRIPTION
**Changes:**
1. Clarifying in conf.dist that EnableNewRpgStrategy RandomBotTeleLowerLevel and RandomBotTeleHigherLevel (it would instead use the ranges in [PrepareZone2LevelBracket](https://github.com/liyunfan1223/mod-playerbots/blob/f17ec36cdecc908b7b51a3b161a1136462ba6348/src/RandomPlayerbotMgr.cpp#L1494))

2. Clarifying in conf.dist what RandomBotTeleLowerLevel and RandomBotTeleHigherLevel do.

3. Switching around the names of the variables to make them actually intuitive to their function. Example, consider Borean Tundra, a zone with creatures from level 68 to 72. With these default values
```
AiPlayerbot.RandomBotTeleLowerLevel = 1
AiPlayerbot.RandomBotTeleHigherLevel = 3
```
now the zone is open to teleporting bots from level 67 (68-1) to 75 (72+3), whereas before the numbers were switched to do the same function.

~~4. Capitalized every mention of the word "default" in playerbots.conf.dist that should've been capitalized, because it bothered me that some weren't -_-~~ Addressed by https://github.com/liyunfan1223/mod-playerbots/pull/1296

**Closes issue:** https://github.com/liyunfan1223/mod-playerbots/issues/1288

**Next step:** 
As stated, RandomBotTeleLowerLevel and RandomBotTeleHigherLevel are overridden by EnableNewRpgStrategy anyway, and since EnableNewRpgStrategy is enabled by default now, I am thinking of making the zones brackets in [PrepareZone2LevelBracket](https://github.com/liyunfan1223/mod-playerbots/blob/f17ec36cdecc908b7b51a3b161a1136462ba6348/src/RandomPlayerbotMgr.cpp#L1494) user facing, so they can be updated in the conf if someone wants to change them. Would like thoughts and opinions on that.