### PR TITLE
Calculation of the power of items with random properties

### DIFF
--- a/src/ChatHelper.cpp
+++ b/src/ChatHelper.cpp
@@ -305,6 +305,49 @@ ItemIds ChatHelper::parseItems(std::string const text)
     return itemIds;
 }
 
+ItemWithRandomProperty ChatHelper::parseItemWithRandomProperty(std::string const text)
+{
+    ItemWithRandomProperty res;
+    
+    size_t itemStart = text.find("Hitem:");
+    if (itemStart == std::string::npos)
+        return res;
+    
+    itemStart += 6;
+    if (itemStart >= text.length())
+        return res;
+    
+    size_t colonPos = text.find(':', itemStart);
+    if (colonPos == std::string::npos)
+        return res;
+    
+    std::string itemIdStr = text.substr(itemStart, colonPos - itemStart);
+    res.itemId = atoi(itemIdStr.c_str());
+    
+    std::vector<std::string> params;
+    size_t currentPos = colonPos + 1;
+    
+    while (currentPos < text.length()) {
+        size_t nextColon = text.find(':', currentPos);
+        if (nextColon == std::string::npos) {
+            size_t hTag = text.find("|h", currentPos);
+            if (hTag != std::string::npos) {
+                params.push_back(text.substr(currentPos, hTag - currentPos));
+            }
+            break;
+        }
+        
+        params.push_back(text.substr(currentPos, nextColon - currentPos));
+        currentPos = nextColon + 1;
+    }
+    
+    if (params.size() >= 6) {
+        res.randomPropertyId = atoi(params[5].c_str());
+    }
+    
+    return res;
+}
+
 std::string const ChatHelper::FormatQuest(Quest const* quest)
 {
     if (!quest)

--- a/src/ChatHelper.h
+++ b/src/ChatHelper.h
@@ -25,6 +25,11 @@ struct ItemTemplate;
 typedef std::set<uint32> ItemIds;
 typedef std::set<uint32> SpellIds;
 
+struct ItemWithRandomProperty {
+    uint32 itemId{0};
+    int32 randomPropertyId{0};
+};
+
 class ChatHelper : public PlayerbotAIAware
 {
 public:
@@ -33,6 +38,7 @@ public:
     static std::string const formatMoney(uint32 copper);
     static uint32 parseMoney(std::string const text);
     static ItemIds parseItems(std::string const text);
+    static ItemWithRandomProperty parseItemWithRandomProperty(std::string const text);
     uint32 parseSpell(std::string const text);
     static std::string parseValue(const std::string& type, const std::string& text);
 

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1742,9 +1742,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
         if (incremental && oldItem)
         {
-            float old_score = calculator.CalculateItem(oldItem->GetEntry());
-            if (oldItem->GetItemRandomPropertyId())
-                old_score += calculator.CalculateRandomProperty(oldItem->GetItemRandomPropertyId(), oldItem->GetEntry());
+            float old_score = calculator.CalculateItem(oldItem->GetEntry(), oldItem->GetItemRandomPropertyId());
             if (bestScoreForSlot < 1.2f * old_score)
                 continue;
         }

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1743,6 +1743,8 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         if (incremental && oldItem)
         {
             float old_score = calculator.CalculateItem(oldItem->GetEntry());
+            if (oldItem->GetItemRandomPropertyId())
+                old_score += calculator.CalculateRandomProperty(oldItem->GetItemRandomPropertyId(), oldItem->GetEntry());
             if (bestScoreForSlot < 1.2f * old_score)
                 continue;
         }

--- a/src/factory/StatsCollector.cpp
+++ b/src/factory/StatsCollector.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "DBCStores.h"
+#include "ItemEnchantmentMgr.h"
 #include "ItemTemplate.h"
 #include "ObjectMgr.h"
 #include "PlayerbotAI.h"
@@ -205,7 +206,7 @@ void StatsCollector::CollectSpellStats(uint32 spellId, float multiplier, int32 s
     }
 }
 
-void StatsCollector::CollectEnchantStats(SpellItemEnchantmentEntry const* enchant)
+void StatsCollector::CollectEnchantStats(SpellItemEnchantmentEntry const* enchant, uint32 default_enchant_amount)
 {
     for (int s = 0; s < MAX_SPELL_ITEM_ENCHANTMENT_EFFECTS; ++s)
     {
@@ -231,6 +232,10 @@ void StatsCollector::CollectEnchantStats(SpellItemEnchantmentEntry const* enchan
             }
             case ITEM_ENCHANTMENT_TYPE_STAT:
             {
+                // for item random suffix
+                if (!enchant_amount)
+                    enchant_amount = default_enchant_amount;
+
                 if (!enchant_amount)
                 {
                     break;
@@ -250,7 +255,7 @@ bool StatsCollector::SpecialSpellFilter(uint32 spellId)
     // trinket
     switch (spellId)
     {
-        case 60764: // Totem of Splintering
+        case 60764:  // Totem of Splintering
             if (type_ & (CollectorType::SPELL))
                 return true;
             break;
@@ -744,7 +749,7 @@ void StatsCollector::HandleApplyAura(const SpellEffectInfo& effectInfo, float mu
 
 int32 StatsCollector::AverageValue(const SpellEffectInfo& effectInfo)
 {
-    //float basePointsPerLevel = effectInfo.RealPointsPerLevel; //not used, line marked for removal.
+    // float basePointsPerLevel = effectInfo.RealPointsPerLevel; //not used, line marked for removal.
     int32 basePoints = effectInfo.BasePoints;
     int32 randomPoints = int32(effectInfo.DieSides);
 
@@ -767,7 +772,7 @@ bool StatsCollector::CheckSpellValidation(uint32 spellFamilyName, flag96 spelFal
 {
     if (PlayerbotAI::Class2SpellFamilyName(cls_) != spellFamilyName)
         return false;
-    
+
     bool isHealingSpell = PlayerbotAI::IsHealingSpell(spellFamilyName, spelFalimyFlags);
     // strict to healer
     if (strict && (type_ & CollectorType::SPELL_HEAL))

--- a/src/factory/StatsCollector.h
+++ b/src/factory/StatsCollector.h
@@ -66,7 +66,7 @@ public:
     void Reset();
     void CollectItemStats(ItemTemplate const* proto);
     void CollectSpellStats(uint32 spellId, float multiplier = 1.0f, int32 spellCooldown = -1);
-    void CollectEnchantStats(SpellItemEnchantmentEntry const* enchant);
+    void CollectEnchantStats(SpellItemEnchantmentEntry const* enchant, uint32 default_enchant_amount = 0);
     bool CanBeTriggeredByType(SpellInfo const* spellInfo, uint32 procFlags, bool strict = true);
     bool CheckSpellValidation(uint32 spellFamilyName, flag96 spelFalimyFlags, bool strict = true);
 

--- a/src/factory/StatsWeightCalculator.cpp
+++ b/src/factory/StatsWeightCalculator.cpp
@@ -525,9 +525,9 @@ void StatsWeightCalculator::CalculateItemTypePenalty(ItemTemplate const* proto)
     // {
     //     weight_ *= 1.0;
     // }
-    // double hand
     if (proto->Class == ITEM_CLASS_WEAPON)
     {
+        // double hand
         bool isDoubleHand = proto->Class == ITEM_CLASS_WEAPON &&
                             !(ITEM_SUBCLASS_MASK_SINGLE_HAND & (1 << proto->SubClass)) &&
                             !(ITEM_SUBCLASS_MASK_WEAPON_RANGED & (1 << proto->SubClass));
@@ -535,29 +535,41 @@ void StatsWeightCalculator::CalculateItemTypePenalty(ItemTemplate const* proto)
         if (isDoubleHand)
         {
             weight_ *= 0.5;
-        }
-        // spec without double hand
-        // enhancement, rogue, ice dk, unholy dk, shield tank, fury warrior without titan's grip but with duel wield
-        if (isDoubleHand &&
-            ((cls == CLASS_SHAMAN && tab == SHAMAN_TAB_ENHANCEMENT && player_->CanDualWield()) ||
-             (cls == CLASS_ROGUE) || (cls == CLASS_DEATH_KNIGHT && tab == DEATHKNIGHT_TAB_FROST) ||
-             (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_FURY && !player_->CanTitanGrip() && player_->CanDualWield()) ||
-             (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_PROTECTION) ||
-             (cls == CLASS_PALADIN && tab == PALADIN_TAB_PROTECTION)))
-        {
-            weight_ *= 0.1;
+            // spec without double hand
+            // enhancement, rogue, ice dk, unholy dk, shield tank, fury warrior without titan's grip but with duel wield
+            if (((cls == CLASS_SHAMAN && tab == SHAMAN_TAB_ENHANCEMENT && player_->CanDualWield()) ||
+                 (cls == CLASS_ROGUE) || (cls == CLASS_DEATH_KNIGHT && tab == DEATHKNIGHT_TAB_FROST) ||
+                 (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_FURY && !player_->CanTitanGrip() && player_->CanDualWield()) ||
+                 (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_PROTECTION) ||
+                 (cls == CLASS_PALADIN && tab == PALADIN_TAB_PROTECTION)))
+            {
+                weight_ *= 0.1;
+            }
+
         }
         // spec with double hand
         // fury without duel wield, arms, bear, retribution, blood dk
-        if (!isDoubleHand &&
-            ((cls == CLASS_HUNTER && !player_->CanDualWield()) ||
-             (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_FURY && !player_->CanDualWield()) ||
-             (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_ARMS) || (cls == CLASS_DRUID && tab == DRUID_TAB_FERAL) ||
-             (cls == CLASS_PALADIN && tab == PALADIN_TAB_RETRIBUTION) ||
-             (cls == CLASS_DEATH_KNIGHT && tab == DEATHKNIGHT_TAB_BLOOD) ||
-             (cls == CLASS_SHAMAN && tab == SHAMAN_TAB_ENHANCEMENT && !player_->CanDualWield())))
+        if (!isDoubleHand)
         {
-            weight_ *= 0.1;
+            if ((cls == CLASS_HUNTER && !player_->CanDualWield()) ||
+                (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_FURY && !player_->CanDualWield()) ||
+                (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_ARMS) || (cls == CLASS_DRUID && tab == DRUID_TAB_FERAL) ||
+                (cls == CLASS_PALADIN && tab == PALADIN_TAB_RETRIBUTION) ||
+                (cls == CLASS_DEATH_KNIGHT && tab == DEATHKNIGHT_TAB_BLOOD) ||
+                (cls == CLASS_SHAMAN && tab == SHAMAN_TAB_ENHANCEMENT && !player_->CanDualWield()))
+            {
+                weight_ *= 0.1;
+            }
+            // caster's main hand (cannot duel weapon but can equip two-hands stuff)
+            if (cls == CLASS_MAGE ||
+                cls == CLASS_PRIEST ||
+                cls == CLASS_WARLOCK ||
+                cls == CLASS_DRUID ||
+                (cls == CLASS_SHAMAN && !player_->CanDualWield()))
+            {
+                weight_ *= 0.65;
+            }
+            
         }
         // fury with titan's grip
         if ((!isDoubleHand || proto->SubClass == ITEM_SUBCLASS_WEAPON_POLEARM ||
@@ -566,15 +578,18 @@ void StatsWeightCalculator::CalculateItemTypePenalty(ItemTemplate const* proto)
         {
             weight_ *= 0.1;
         }
+        
         if (cls == CLASS_HUNTER && proto->SubClass == ITEM_SUBCLASS_WEAPON_THROWN)
         {
             weight_ *= 0.1;
         }
+        
         if (cls == CLASS_ROGUE && (tab == ROGUE_TAB_ASSASSINATION || tab == ROGUE_TAB_SUBTLETY) &&
             proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER)
         {
             weight_ *= 0.5;
         }
+
         if (cls == CLASS_ROGUE && player_->HasAura(13964) &&
             (proto->SubClass == ITEM_SUBCLASS_WEAPON_SWORD || proto->SubClass == ITEM_SUBCLASS_WEAPON_AXE))
         {

--- a/src/factory/StatsWeightCalculator.h
+++ b/src/factory/StatsWeightCalculator.h
@@ -30,6 +30,7 @@ public:
     void Reset();
     float CalculateItem(uint32 itemId);
     float CalculateEnchant(uint32 enchantId);
+    float CalculateRandomProperty(int32 randomPropertyId, uint32 itemId);
 
     void SetOverflowPenalty(bool apply) { enable_overflow_penalty_ = apply; }
     void SetItemSetBonus(bool apply) { enable_item_set_bonus_ = apply; }

--- a/src/factory/StatsWeightCalculator.h
+++ b/src/factory/StatsWeightCalculator.h
@@ -28,19 +28,19 @@ class StatsWeightCalculator
 public:
     StatsWeightCalculator(Player* player);
     void Reset();
-    float CalculateItem(uint32 itemId);
+    float CalculateItem(uint32 itemId, int32 randomPropertyId = 0);
     float CalculateEnchant(uint32 enchantId);
-    float CalculateRandomProperty(int32 randomPropertyId, uint32 itemId);
-
+    
     void SetOverflowPenalty(bool apply) { enable_overflow_penalty_ = apply; }
     void SetItemSetBonus(bool apply) { enable_item_set_bonus_ = apply; }
     void SetQualityBlend(bool apply) { enable_quality_blend_ = apply; }
-
-private:
+    
+    private:
     void GenerateWeights(Player* player);
     void GenerateBasicWeights(Player* player);
     void GenerateAdditionalWeights(Player* player);
-
+    
+    void CalculateRandomProperty(int32 randomPropertyId, uint32 itemId);
     void CalculateItemSetMod(Player* player, ItemTemplate const* proto);
     void CalculateSocketBonus(Player* player, ItemTemplate const* proto);
 

--- a/src/strategy/ItemVisitors.h
+++ b/src/strategy/ItemVisitors.h
@@ -232,6 +232,20 @@ public:
     }
 };
 
+class CollectItemsVisitor : public IterateItemsVisitor
+{
+public:
+    CollectItemsVisitor() : IterateItemsVisitor() {}
+
+    std::vector<Item*> items;
+
+    bool Visit(Item* item) override
+    {
+        items.push_back(item);
+        return true;
+    }
+};
+
 class ItemCountByQuality : public IterateItemsVisitor
 {
 public:

--- a/src/strategy/actions/EquipAction.cpp
+++ b/src/strategy/actions/EquipAction.cpp
@@ -8,6 +8,7 @@
 #include "Event.h"
 #include "ItemCountValue.h"
 #include "ItemUsageValue.h"
+#include "ItemVisitors.h"
 #include "Playerbots.h"
 #include "StatsWeightCalculator.h"
 
@@ -311,19 +312,28 @@ bool EquipUpgradesAction::Execute(Event event)
             return false;
     }
 
-    ListItemsVisitor visitor;
+    CollectItemsVisitor visitor;
     IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
 
     ItemIds items;
-    for (std::map<uint32, uint32>::iterator i = visitor.items.begin(); i != visitor.items.end(); ++i)
+    for (auto i = visitor.items.begin(); i != visitor.items.end(); ++i)
     {
-        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", i->first);
+        Item* item = *i;
+        if (!item)
+            break;
+        int32 randomProperty = item->GetItemRandomPropertyId();
+        uint32 itemId = item->GetTemplate()->ItemId;
+        std::string itemUsageParam;
+        if (randomProperty != 0) {
+            itemUsageParam = std::to_string(itemId) + "," + std::to_string(randomProperty);
+        } else {
+            itemUsageParam = std::to_string(itemId);
+        }
+        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
+
         if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
         {
-            // LOG_INFO("playerbots", "Bot {} <{}> EquipUpgradesAction {} ({})", bot->GetGUID().ToString().c_str(),
-            //    bot->GetName().c_str(), i->first, usage == 1 ? "no item in slot" : usage == 2 ? "replace" : usage == 3 ?
-            //    "wrong item but empty slot" : "");
-            items.insert(i->first);
+            items.insert(itemId);
         }
     }
 
@@ -333,21 +343,31 @@ bool EquipUpgradesAction::Execute(Event event)
 
 bool EquipUpgradeAction::Execute(Event event)
 {
-    ListItemsVisitor visitor;
+    CollectItemsVisitor visitor;
     IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
 
     ItemIds items;
-    for (std::map<uint32, uint32>::iterator i = visitor.items.begin(); i != visitor.items.end(); ++i)
+    for (auto i = visitor.items.begin(); i != visitor.items.end(); ++i)
     {
-        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", i->first);
+        Item* item = *i;
+        if (!item)
+            break;
+        int32 randomProperty = item->GetItemRandomPropertyId();
+        uint32 itemId = item->GetTemplate()->ItemId;
+        std::string itemUsageParam;
+        if (randomProperty != 0) {
+            itemUsageParam = std::to_string(itemId) + "," + std::to_string(randomProperty);
+        } else {
+            itemUsageParam = std::to_string(itemId);
+        }
+        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
+
         if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
         {
-            // LOG_INFO("playerbots", "Bot {} <{}> EquipUpgradeAction item {} ({})", bot->GetGUID().ToString().c_str(),
-            //    bot->GetName().c_str(), i->first, usage == 1 ? "no item in slot" : usage == 2 ? "replace" : usage == 3 ?
-            //    "wrong item but empty slot" : "");
-            items.insert(i->first);
+            items.insert(itemId);
         }
     }
+
     EquipItems(items);
     return true;
 }

--- a/src/strategy/actions/LootRollAction.cpp
+++ b/src/strategy/actions/LootRollAction.cpp
@@ -9,6 +9,7 @@
 #include "Group.h"
 #include "ItemUsageValue.h"
 #include "LootAction.h"
+#include "ObjectMgr.h"
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
 
@@ -30,12 +31,24 @@ bool LootRollAction::Execute(Event event)
         ObjectGuid guid = roll->itemGUID;
         uint32 slot = roll->itemSlot;
         uint32 itemId = roll->itemid;
+        int32 randomProperty = 0;
+        if (roll->itemRandomPropId)
+            randomProperty = roll->itemRandomPropId;
+        else if (roll->itemRandomSuffix)
+            randomProperty = -((int)roll->itemRandomSuffix);
 
         RollVote vote = PASS;
         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
         if (!proto)
             continue;
-        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemId);
+        
+        std::string itemUsageParam;
+        if (randomProperty != 0) {
+            itemUsageParam = std::to_string(itemId) + "," + std::to_string(randomProperty);
+        } else {
+            itemUsageParam = std::to_string(itemId);
+        }
+        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
         
         // Armor Tokens are classed as MISC JUNK (Class 15, Subclass 0), luckily no other items I found have class bits and epic quality.
         if (proto->Class == ITEM_CLASS_MISC && proto->SubClass == ITEM_SUBCLASS_JUNK && proto->Quality == ITEM_QUALITY_EPIC)

--- a/src/strategy/actions/OutfitAction.cpp
+++ b/src/strategy/actions/OutfitAction.cpp
@@ -183,7 +183,7 @@ void OutfitAction::Update(std::string const name)
 {
     ListItemsVisitor visitor;
     IterateItems(&visitor, ITERATE_ITEMS_IN_EQUIP);
-
+    
     ItemIds items;
     for (std::map<uint32, uint32>::iterator i = visitor.items.begin(); i != visitor.items.end(); ++i)
         items.insert(i->first);

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -43,6 +43,7 @@ bool ReleaseSpiritAction::Execute(Event event)
     botAI->TellMasterNoFacing(message);
 
     IncrementDeathCount();
+    bot->DurabilityRepairAll(false, 1.0f, false);
     LogRelease("released");
 
     WorldPacket releasePacket(CMSG_REPOP_REQUEST);
@@ -79,6 +80,7 @@ void ReleaseSpiritAction::LogRelease(const std::string& releaseMsg, bool isAutoR
 bool AutoReleaseSpiritAction::Execute(Event event)
 {
     IncrementDeathCount();
+    bot->DurabilityRepairAll(false, 1.0f, false);
     LogRelease("auto released", true);
 
     WorldPacket packet(CMSG_REPOP_REQUEST);

--- a/src/strategy/actions/TellLosAction.cpp
+++ b/src/strategy/actions/TellLosAction.cpp
@@ -146,9 +146,7 @@ bool TellCalculateItemAction::Execute(Event event)
     const ItemTemplate* proto = sObjectMgr->GetItemTemplate(item.itemId);
     if (!proto)
         return false;
-    float score = calculator.CalculateItem(item.itemId);
-    if (item.randomPropertyId)
-        score += calculator.CalculateRandomProperty(item.randomPropertyId, item.itemId);
+    float score = calculator.CalculateItem(item.itemId, item.randomPropertyId);
 
     std::ostringstream out;
     out << "Calculated score of " << chat->FormatItem(proto) << " : " << score;

--- a/src/strategy/actions/TellLosAction.cpp
+++ b/src/strategy/actions/TellLosAction.cpp
@@ -140,17 +140,18 @@ bool TellEstimatedDpsAction::Execute(Event event)
 bool TellCalculateItemAction::Execute(Event event)
 {
     std::string const text = event.getParam();
-    ItemIds ids = chat->parseItems(text);
+    ItemWithRandomProperty item = chat->parseItemWithRandomProperty(text);
     StatsWeightCalculator calculator(bot);
-    for (const uint32 &id : ids)
-    {
-        const ItemTemplate* proto = sObjectMgr->GetItemTemplate(id);
-        if (!proto)
-            continue;
-        float score = calculator.CalculateItem(id);
-        std::ostringstream out;
-        out << "Calculated score of " << chat->FormatItem(proto) << " : " << score;
-        botAI->TellMasterNoFacing(out.str());
-    }
+
+    const ItemTemplate* proto = sObjectMgr->GetItemTemplate(item.itemId);
+    if (!proto)
+        return false;
+    float score = calculator.CalculateItem(item.itemId);
+    if (item.randomPropertyId)
+        score += calculator.CalculateRandomProperty(item.randomPropertyId, item.itemId);
+
+    std::ostringstream out;
+    out << "Calculated score of " << chat->FormatItem(proto) << " : " << score;
+    botAI->TellMasterNoFacing(out.str());
     return true;
 }

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -8,6 +8,7 @@
 #include "AiFactory.h"
 #include "ChatHelper.h"
 #include "GuildTaskMgr.h"
+#include "Item.h"
 #include "LootObjectStack.h"
 #include "PlayerbotAIConfig.h"
 #include "PlayerbotFactory.h"
@@ -18,7 +19,16 @@
 
 ItemUsage ItemUsageValue::Calculate()
 {
-    uint32 itemId = atoi(qualifier.c_str());
+    uint32 itemId = 0;
+    uint32 randomPropertyId = 0;
+    size_t pos = qualifier.find(",");
+    if (pos != std::string::npos) {
+        itemId = atoi(qualifier.substr(0, pos).c_str());
+        randomPropertyId = atoi(qualifier.substr(pos + 1).c_str());
+    } else {
+        itemId = atoi(qualifier.c_str());
+    }
+
     if (!itemId)
         return ITEM_USAGE_NONE;
 
@@ -89,7 +99,7 @@ ItemUsage ItemUsageValue::Calculate()
     if (bot->GetGuildId() && sGuildTaskMgr->IsGuildTaskItem(itemId, bot->GetGuildId()))
         return ITEM_USAGE_GUILD_TASK;
 
-    ItemUsage equip = QueryItemUsageForEquip(proto);
+    ItemUsage equip = QueryItemUsageForEquip(proto, randomPropertyId);
     if (equip != ITEM_USAGE_NONE)
         return equip;
 
@@ -224,7 +234,7 @@ ItemUsage ItemUsageValue::Calculate()
     return ITEM_USAGE_NONE;
 }
 
-ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto)
+ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto, int32 randomPropertyId)
 {
     if (bot->CanUseItem(itemProto) != EQUIP_ERR_OK)
         return ITEM_USAGE_NONE;
@@ -297,6 +307,9 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto)
     calculator.SetOverflowPenalty(false);
     
     float itemScore = calculator.CalculateItem(itemProto->ItemId);
+    if (randomPropertyId)
+        itemScore += calculator.CalculateRandomProperty(randomPropertyId, itemProto->ItemId);
+
     if (itemScore)
         shouldEquip = true;
 
@@ -383,6 +396,10 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto)
         float oldScore = calculator.CalculateItem(oldItemProto->ItemId);
         if (oldItem)
         {
+            if (oldItem->GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID))
+            {
+                oldScore += calculator.CalculateRandomProperty(oldItem->GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID), itemProto->ItemId);
+            }
             // uint32 oldStatWeight = sRandomItemMgr->GetLiveStatWeight(bot, oldItemProto->ItemId);
             if (itemScore || oldScore)
             {

--- a/src/strategy/values/ItemUsageValue.cpp
+++ b/src/strategy/values/ItemUsageValue.cpp
@@ -306,10 +306,8 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto, 
     calculator.SetItemSetBonus(false);
     calculator.SetOverflowPenalty(false);
     
-    float itemScore = calculator.CalculateItem(itemProto->ItemId);
-    if (randomPropertyId)
-        itemScore += calculator.CalculateRandomProperty(randomPropertyId, itemProto->ItemId);
-
+    float itemScore = calculator.CalculateItem(itemProto->ItemId, randomPropertyId);
+    
     if (itemScore)
         shouldEquip = true;
 
@@ -393,13 +391,9 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto, 
         }
 
         ItemTemplate const* oldItemProto = oldItem->GetTemplate();
-        float oldScore = calculator.CalculateItem(oldItemProto->ItemId);
+        float oldScore = calculator.CalculateItem(oldItemProto->ItemId, oldItem->GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID));
         if (oldItem)
         {
-            if (oldItem->GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID))
-            {
-                oldScore += calculator.CalculateRandomProperty(oldItem->GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID), itemProto->ItemId);
-            }
             // uint32 oldStatWeight = sRandomItemMgr->GetLiveStatWeight(bot, oldItemProto->ItemId);
             if (itemScore || oldScore)
             {

--- a/src/strategy/values/ItemUsageValue.h
+++ b/src/strategy/values/ItemUsageValue.h
@@ -43,7 +43,7 @@ public:
     ItemUsage Calculate() override;
 
 private:
-    ItemUsage QueryItemUsageForEquip(ItemTemplate const* proto);
+    ItemUsage QueryItemUsageForEquip(ItemTemplate const* proto, int32 randomPropertyId = 0);
     uint32 GetSmallestBagSize();
     bool IsItemUsefulForQuest(Player* player, ItemTemplate const* proto);
     bool IsItemNeededForSkill(ItemTemplate const* proto);


### PR DESCRIPTION
Improved calculation of the power of items with random properties to correctly perform loot roll and equip upgrade. Allow ramdom bots to better increase gear power by grind loot (with gear initialization disabled)

Added automatic repair of gears during repop to prevent better gear from being replaced due to broken.

Close https://github.com/liyunfan1223/mod-playerbots/issues/1183