### PR TITLE
Convert PlayerbotsXPRate to RandomBotXPRate

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -375,11 +375,6 @@ AiPlayerbot.AggroDistance = 22
 #
 #
 
-# Set XP rate for bots
-# Default: 1.0
-# Actual XP Rate will be = Server XP Rate * AiPlayerbot.PlayerbotsXPRate
-AiPlayerbot.PlayerbotsXPRate = 1.0
-
 # Health/Mana levels
 AiPlayerbot.CriticalHealth = 25
 AiPlayerbot.LowHealth = 45
@@ -604,6 +599,10 @@ AiPlayerbot.RandomBotFixedLevel = 0
 # Set RandomBotMaxLevel bots to RandomBotMinLevel
 # Default: 0 (disabled)
 AiPlayerbot.DowngradeMaxLevelBot = 0
+
+# Set XP rate for random bots (Default: 1.0)
+# Server XP Rate * AiPlayerbot.RandomBotXPRate
+AiPlayerbot.RandomBotXPRate = 1.0
 
 #
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -489,7 +489,7 @@ bool PlayerbotAIConfig::Initialize()
     autoGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearQualityLimit", 3);
     autoGearScoreLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearScoreLimit", 0);
 
-    playerbotsXPrate = sConfigMgr->GetOption<float>("AiPlayerbot.PlayerbotsXPRate", 1.0);
+    randomBotXPRate = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotXPRate", 1.0);
     randomBotAllianceRatio = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAllianceRatio", 50);
     randomBotHordeRatio = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotHordeRatio", 50);
     disableDeathKnightLogin = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableDeathKnightLogin", 0);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -275,7 +275,7 @@ public:
     bool randomBotShowCloak;
     bool randomBotFixedLevel;
     bool disableRandomLevels;
-    float playerbotsXPrate;
+    float randomBotXPRate;
     uint32 randomBotAllianceRatio;
     uint32 randomBotHordeRatio;
     bool disableDeathKnightLogin;

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -219,9 +219,12 @@ public:
         if (!player->GetSession()->IsBot())
             return;
         
-        if (sPlayerbotAIConfig->playerbotsXPrate != 1.0)
+        if (!sRandomPlayerbotMgr->IsRandomBot(player))
+            return;
+
+        if (sPlayerbotAIConfig->randomBotXPRate != 1.0)
         {
-            amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->playerbotsXPrate));
+            amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->randomBotXPRate));
         }
     }
 };

--- a/src/strategy/actions/XpGainAction.cpp
+++ b/src/strategy/actions/XpGainAction.cpp
@@ -40,15 +40,15 @@ bool XpGainAction::Execute(Event event)
         BroadcastHelper::BroadcastKill(botAI, bot, creature);
     }
 
-    // playerbotsXPrate is now implemented in OnPlayerGiveXP script
-    // if (!sRandomPlayerbotMgr->IsRandomBot(bot) || sPlayerbotAIConfig->playerbotsXPrate == 1)
+    // randomBotXPRate is now implemented in OnPlayerGiveXP script
+    // if (!sRandomPlayerbotMgr->IsRandomBot(bot) || sPlayerbotAIConfig->randomBotXPRate == 1)
     //     return true;
     
     // Unit* victim = nullptr;
     // if (guid)
     //     victim = botAI->GetUnit(guid);
 
-    // xpgain = xpgain * (sPlayerbotAIConfig->playerbotsXPrate - 1);
+    // xpgain = xpgain * (sPlayerbotAIConfig->randomBotXPRate - 1);
     // GiveXP(xpgain, victim);
 
     return true;


### PR DESCRIPTION
Make xp rate config only apply to random bots, skipping altbots. Keep consistent with its original implementation.