### PR TITLE
(#1299) Implement AccountScript override to make sure altbots are logged off when a player logs onto this account.

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -704,8 +704,13 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
 
     if (cmd == "add" || cmd == "addaccount" || cmd == "login")
     {
-        if (ObjectAccessor::FindPlayer(guid))
-            return "player already logged in";
+        if (Player* player = ObjectAccessor::FindPlayer(guid))
+        {
+            if (!player->GetSession()->IsBot())
+                return "Cannot add bot: character is currently being played by a real player.";
+            else
+                return "player already logged in as bot";
+        }
 
         // For addaccount command, verify it's an account name
         if (cmd == "addaccount")

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -417,6 +417,9 @@ void LogoutAltBot(ObjectGuid guid)
                     // Remove from master's PlayerbotMgr map
                     mgr->RemoveFromPlayerbotsMap(guid);
 
+                    // Set AI master pointer to player
+                    botAI->SetMaster(player);
+
                     return;
                 }
             }

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -397,10 +397,10 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
     }
 }
 
-void LogoutAltBot(Player* player)
+void LogoutAltBot(ObjectGuid guid)
 {
     // Try to get the bot object and its master directly
-    if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
+    if (Player* bot = ObjectAccessor::FindPlayer(guid))
     {
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (botAI)
@@ -409,16 +409,16 @@ void LogoutAltBot(Player* player)
             if (master)
             {
                 PlayerbotMgr* mgr = GET_PLAYERBOT_MGR(master);
-                if (mgr && mgr->GetPlayerBot())
+                if (mgr && mgr->GetPlayerBot(guid))
                 {
                     LOG_INFO("playerbots", "Real player logging in, logging out bot for character {}", bot->GetName());
-                    mgr->LogoutPlayerBot(player->GetGUID()id);
+                    mgr->LogoutPlayerBot(guid);
 
                     // Remove from master's PlayerbotMgr map
-                    mgr->RemoveFromPlayerbotsMap(player->GetGUID());
+                    mgr->RemoveFromPlayerbotsMap(guid);
 
-                    // Set AI master pointer to player
-                    botAI->SetMaster(player);
+                    // Set AI master pointer to player (named "bot" in this instance)
+                    botAI->SetMaster(bot);
 
                     return;
                 }

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -397,10 +397,10 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
     }
 }
 
-void LogoutAltBot(ObjectGuid guid)
+void LogoutAltBot(Player* player)
 {
     // Try to get the bot object and its master directly
-    if (Player* bot = ObjectAccessor::FindPlayer(guid))
+    if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
     {
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (botAI)
@@ -409,13 +409,13 @@ void LogoutAltBot(ObjectGuid guid)
             if (master)
             {
                 PlayerbotMgr* mgr = GET_PLAYERBOT_MGR(master);
-                if (mgr && mgr->GetPlayerBot(guid))
+                if (mgr && mgr->GetPlayerBot())
                 {
                     LOG_INFO("playerbots", "Real player logging in, logging out bot for character {}", bot->GetName());
-                    mgr->LogoutPlayerBot(guid);
+                    mgr->LogoutPlayerBot(player->GetGUID()id);
 
                     // Remove from master's PlayerbotMgr map
-                    mgr->RemoveFromPlayerbotsMap(guid);
+                    mgr->RemoveFromPlayerbotsMap(player->GetGUID());
 
                     // Set AI master pointer to player
                     botAI->SetMaster(player);

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -417,13 +417,6 @@ void LogoutAltBot(ObjectGuid guid)
             }
         }
     }
-
-    // Fallback: forcibly kick if still in world
-    if (Player* player = ObjectAccessor::FindPlayer(guid))
-    {
-        LOG_INFO("playerbots", "Bot {} not tracked in any manager, forcing KickPlayer", player->GetName());
-        player->GetSession()->KickPlayer();
-    }
 }
 
 void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -411,7 +411,12 @@ void LogoutAltBot(ObjectGuid guid)
                 PlayerbotMgr* mgr = GET_PLAYERBOT_MGR(master);
                 if (mgr && mgr->GetPlayerBot(guid))
                 {
+                    LOG_INFO("playerbots", "Real player logging in, logging out bot for character {}", bot->GetName());
                     mgr->LogoutPlayerBot(guid);
+
+                    // Remove from master's PlayerbotMgr map
+                    mgr->RemoveFromPlayerbotsMap(guid);
+
                     return;
                 }
             }

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -397,6 +397,35 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
     }
 }
 
+void LogoutAltBot(ObjectGuid guid)
+{
+    // Try to get the bot object and its master directly
+    if (Player* bot = ObjectAccessor::FindPlayer(guid))
+    {
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI)
+        {
+            Player* master = botAI->GetMaster();
+            if (master)
+            {
+                PlayerbotMgr* mgr = GET_PLAYERBOT_MGR(master);
+                if (mgr && mgr->GetPlayerBot(guid))
+                {
+                    mgr->LogoutPlayerBot(guid);
+                    return;
+                }
+            }
+        }
+    }
+
+    // Fallback: forcibly kick if still in world
+    if (Player* player = ObjectAccessor::FindPlayer(guid))
+    {
+        LOG_INFO("playerbots", "Bot {} not tracked in any manager, forcing KickPlayer", player->GetName());
+        player->GetSession()->KickPlayer();
+    }
+}
+
 void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)
 {
     if (Player* bot = GetPlayerBot(guid))

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -122,6 +122,6 @@ private:
 };
 
 #define sPlayerbotsMgr PlayerbotsMgr::instance()
-void LogoutAltBot(Player* player);
+void LogoutAltBot(ObjectGuid guid);
 
 #endif

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -122,6 +122,6 @@ private:
 };
 
 #define sPlayerbotsMgr PlayerbotsMgr::instance()
-void LogoutAltBot(ObjectGuid guid);
+void LogoutAltBot(Player* player);
 
 #endif

--- a/src/PlayerbotMgr.h
+++ b/src/PlayerbotMgr.h
@@ -122,5 +122,6 @@ private:
 };
 
 #define sPlayerbotsMgr PlayerbotsMgr::instance()
+void LogoutAltBot(ObjectGuid guid);
 
 #endif

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -99,11 +99,8 @@ public:
             // If this character is currently online as a bot, log out the bot first
             if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
             {
-                if (bot != player) // should not be the same pointer
-                {
-                    LOG_INFO("playerbots", "Real player logging in, logging out bot for character {}", player->GetName());
-                    LogoutAltBot(player->GetGUID());
-                }
+                LOG_INFO("playerbots", "Real player logging in, logging out bot for character {}", player->GetName());
+                LogoutAltBot(player->GetGUID());
             }
 
             sPlayerbotsMgr->AddPlayerbotData(player, false);

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -99,7 +99,7 @@ public:
             // If this character is currently online as a bot, log out the bot first
             if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
             {
-                LogoutAltBot(Player* player);
+                LogoutAltBot(player->GetGUID());
             }
 
             sPlayerbotsMgr->AddPlayerbotData(player, false);

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -100,6 +100,9 @@ public:
             if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
             {
                 LogoutAltBot(player->GetGUID());
+
+                // Set AI master pointer to player
+                botAI->SetMaster(player);
             }
 
             sPlayerbotsMgr->AddPlayerbotData(player, false);

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -100,9 +100,6 @@ public:
             if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
             {
                 LogoutAltBot(player->GetGUID());
-
-                // Set AI master pointer to player
-                botAI->SetMaster(player);
             }
 
             sPlayerbotsMgr->AddPlayerbotData(player, false);

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -99,7 +99,6 @@ public:
             // If this character is currently online as a bot, log out the bot first
             if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
             {
-                LOG_INFO("playerbots", "Real player logging in, logging out bot for character {}", player->GetName());
                 LogoutAltBot(player->GetGUID());
             }
 

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -99,7 +99,7 @@ public:
             // If this character is currently online as a bot, log out the bot first
             if (Player* bot = ObjectAccessor::FindPlayer(player->GetGUID()))
             {
-                LogoutAltBot(player->GetGUID());
+                LogoutAltBot(Player* player);
             }
 
             sPlayerbotsMgr->AddPlayerbotData(player, false);


### PR DESCRIPTION
# Overview
This PR improves the handling of altbot logouts when a real player logs into an account that has characters currently online as altbots. It ensures that all altbots (which have been manually added by some player) are properly logged out before the real player session takes over, preventing session conflicts and "ghost" bots.

closes: #1299 

# Key Changes

## New Helper Function:
Added `LogoutAltBot(ObjectGuid guid)` to robustly log out a bot by GUID.

- Tries to log out via the bot's master [PlayerbotMgr]if possible.
- Falls back to forcibly kicking the session if the bot is not tracked in any manager.

## Account Login Hook:
The PlayerbotsAccountScript::OnAccountLogin hook now calls `LogoutAltBot` for each character of the logging-in account, ensuring all bots are logged out before the player logs in.

## Efficiency:
Instead of looping over all players, the code uses the bot's AI to directly find its master and the correct PlayerbotMgr.

## Fallback Safety:
If a bot is not tracked in any manager but is still in the world, its session is forcibly kicked to guarantee cleanup.

# Why?
- Fixes issues where bots added via .playerbot bot add were not being logged out on account login.
- Prevents session conflicts and ensures a clean handover from bot to real player.

# Testing
- Log in to an account with characters currently online as bots (both random and manually added).
- Verify that all such bots are logged out before the real player enters the world.
- Check server logs for confirmation of logout actions.