### PR TITLE
Autogear override items

### DIFF
--- a/src/strategy/actions/TrainerAction.cpp
+++ b/src/strategy/actions/TrainerAction.cpp
@@ -227,7 +227,7 @@ bool AutoGearAction::Execute(Event event)
                     : PlayerbotFactory::CalcMixedGearScore(sPlayerbotAIConfig->autoGearScoreLimit,
                                                            sPlayerbotAIConfig->autoGearQualityLimit);
     PlayerbotFactory factory(bot, bot->GetLevel(), sPlayerbotAIConfig->autoGearQualityLimit, gs);
-    factory.InitEquipment(true);
+    factory.InitEquipment(true, true);
     factory.InitAmmo();
     if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
     {


### PR DESCRIPTION
- Added autogear action possibility to override items without ilvl condition

Example:
AiPlayerbot.AutoGearQualityLimit = 4
AiPlayerbot.AutoGearScoreLimit = 213
AiPlayerbot.RandomGearLoweringChance = 0.5

![obraz](https://github.com/user-attachments/assets/822244c2-45f2-44b5-ae7e-d6233ed83760)
