### PR TITLE
Typo fix in AcceptBgInvitationAction

### DIFF
--- a/src/strategy/actions/AcceptBattlegroundInvitationAction.h
+++ b/src/strategy/actions/AcceptBattlegroundInvitationAction.h
@@ -13,7 +13,7 @@ class PlayerbotAI;
 class AcceptBgInvitationAction : public Action
 {
 public:
-    AcceptBgInvitationAction(PlayerbotAI* botAI) : Action(botAI, "accept bg invitatio") {}
+    AcceptBgInvitationAction(PlayerbotAI* botAI) : Action(botAI, "accept bg invitation") {}
 
     bool Execute(Event event) override;
 };


### PR DESCRIPTION
Fix obvious typo "accept bg invitatio" -->"accept bg invitation"