### PR TITLE
Active loot roll

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -157,7 +157,7 @@ PlayerbotAI::PlayerbotAI(Player* bot)
     masterIncomingPacketHandlers.AddHandler(CMSG_GAMEOBJ_USE, "use game object");
     masterIncomingPacketHandlers.AddHandler(CMSG_AREATRIGGER, "area trigger");
     // masterIncomingPacketHandlers.AddHandler(CMSG_GAMEOBJ_USE, "use game object");
-    masterIncomingPacketHandlers.AddHandler(CMSG_LOOT_ROLL, "loot roll");
+    // masterIncomingPacketHandlers.AddHandler(CMSG_LOOT_ROLL, "loot roll");
     masterIncomingPacketHandlers.AddHandler(CMSG_GOSSIP_HELLO, "gossip hello");
     masterIncomingPacketHandlers.AddHandler(CMSG_QUESTGIVER_HELLO, "gossip hello");
     masterIncomingPacketHandlers.AddHandler(CMSG_ACTIVATETAXI, "activate taxi");

--- a/src/strategy/actions/LootRollAction.cpp
+++ b/src/strategy/actions/LootRollAction.cpp
@@ -15,8 +15,6 @@
 
 bool LootRollAction::Execute(Event event)
 {
-    Player* bot = QueryItemUsageAction::botAI->GetBot();
-
     Group* group = bot->GetGroup();
     if (!group)
         return false;
@@ -108,61 +106,11 @@ bool LootRollAction::Execute(Event event)
                 group->CountRollVote(bot->GetGUID(), guid, vote);
                 break;
         }
+        // One item at a time
+        return true;
     }
-	
-    // WorldPacket p(event.getPacket()); //WorldPacket packet for CMSG_LOOT_ROLL, (8+4+1)
-    // p.rpos(0); //reset packet pointer
-    // p >> guid; //guid of the item rolled
-    // p >> slot; //number of players invited to roll
-    // p >> rollType; //need,greed or pass on roll
 
-    // std::vector<Roll*> rolls = group->GetRolls();
-    // bot->Say("guid:" + std::to_string(guid.GetCounter()) +
-    //     "item entry:" + std::to_string(guid.GetEntry()), LANG_UNIVERSAL);
-    // for (std::vector<Roll*>::iterator i = rolls.begin(); i != rolls.end(); ++i)
-    // {
-    //     if ((*i)->isValid() && (*i)->itemGUID == guid && (*i)->itemSlot == slot)
-    //     {
-    //         uint32 itemId = (*i)->itemid;
-    //         bot->Say("item entry2:" + std::to_string(itemId), LANG_UNIVERSAL);
-    //         ItemTemplate const *proto = sObjectMgr->GetItemTemplate(itemId);
-    //         if (!proto)
-    //             continue;
-
-    //         switch (proto->Class)
-    //         {
-    //         case ITEM_CLASS_WEAPON:
-    //         case ITEM_CLASS_ARMOR:
-    //             if (!QueryItemUsage(proto).empty())
-    //                 vote = NEED;
-    //             else if (bot->HasSkill(SKILL_ENCHANTING))
-    //                 vote = DISENCHANT;
-    //             break;
-    //         default:
-    //             if (StoreLootAction::IsLootAllowed(itemId, botAI))
-    //                 vote = NEED;
-    //             break;
-    //         }
-    //         break;
-    //     }
-    // }
-
-    // if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(guid.GetEntry()))
-    // {
-    //     switch (proto->Class)
-    //     {
-    //         case ITEM_CLASS_WEAPON:
-    //         case ITEM_CLASS_ARMOR:
-    //             if (!QueryItemUsage(proto).empty())
-    //                 vote = NEED;
-    //             break;
-    //         default:
-    //             if (StoreLootAction::IsLootAllowed(guid.GetEntry(), botAI))
-    //                 vote = NEED;
-    //             break;
-    //     }
-    // }
-    return true;
+    return false;
 }
 
 

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -67,6 +67,9 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     // quest ?
     //triggers.push_back(new TriggerNode("quest confirm", NextAction::array(0, new NextAction("quest confirm", relevance), nullptr)));
     triggers.push_back(new TriggerNode("questgiver quest details", NextAction::array(0, new NextAction("turn in query quest", relevance), nullptr)));
+
+    // loot roll
+    triggers.push_back(new TriggerNode("very often", NextAction::array(0, new NextAction("loot roll", 10.0f), nullptr)));
 }
 
 WorldPacketHandlerStrategy::WorldPacketHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)

--- a/src/strategy/triggers/TriggerContext.h
+++ b/src/strategy/triggers/TriggerContext.h
@@ -37,6 +37,7 @@ public:
         creators["random"] = &TriggerContext::Random;
         creators["seldom"] = &TriggerContext::seldom;
         creators["often"] = &TriggerContext::often;
+        creators["very often"] = &TriggerContext::very_often;
 
         creators["target critical health"] = &TriggerContext::TargetCriticalHealth;
 
@@ -314,6 +315,7 @@ private:
     static Trigger* Random(PlayerbotAI* botAI) { return new RandomTrigger(botAI, "random", 20); }
     static Trigger* seldom(PlayerbotAI* botAI) { return new RandomTrigger(botAI, "seldom", 300); }
     static Trigger* often(PlayerbotAI* botAI) { return new RandomTrigger(botAI, "often", 5); }
+    static Trigger* very_often(PlayerbotAI* botAI) { return new RandomTrigger(botAI, "often", 3); }
     static Trigger* EnemyOutOfMelee(PlayerbotAI* botAI) { return new EnemyOutOfMeleeTrigger(botAI); }
     static Trigger* EnemyOutOfSpell(PlayerbotAI* botAI) { return new EnemyOutOfSpellRangeTrigger(botAI); }
     static Trigger* enemy_too_close_for_spell(PlayerbotAI* botAI) { return new EnemyTooCloseForSpellTrigger(botAI); }


### PR DESCRIPTION
Let the bot do loot roll actively. They used to wait for their master to do loot roll before reacting.

This is an immersion improvement and a preparation for a possible feature that random bots form groups without real player.