### PR TITLE
Update playerbots.conf.dist with DisabledWithoutRealPlayer context

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -96,7 +96,9 @@ AiPlayerbot.RandomBotAccountCount = 0
 # To apply this, set the number to 1 and run the Worldserver. Once deletion is complete, if you would like to recreate randombots, set the number back to 0 and rerun the Worldserver.
 AiPlayerbot.DeleteRandomBotAccounts = 0
 
-# Disabled without real player
+# Disable randombots when no real players are logged in
+# Default: 0 (randombots will login when server starts)
+# If enabled, randombots will only login 30 seconds (default) after a real player logs in, and will logout 300 seconds (default) after all real players logout
 AiPlayerbot.DisabledWithoutRealPlayer = 0
 AiPlayerbot.DisabledWithoutRealPlayerLoginDelay = 30
 AiPlayerbot.DisabledWithoutRealPlayerLogoutDelay = 300

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -98,7 +98,7 @@ AiPlayerbot.DeleteRandomBotAccounts = 0
 
 # Disable randombots when no real players are logged in
 # Default: 0 (randombots will login when server starts)
-# If enabled, randombots will only login 30 seconds (default) after a real player logs in, and will logout 300 seconds (default) after all real players logout
+# If enabled, randombots will only log in 30 seconds (default) after a real player logs in, and will log out 300 seconds (default) after all real players log out
 AiPlayerbot.DisabledWithoutRealPlayer = 0
 AiPlayerbot.DisabledWithoutRealPlayerLoginDelay = 30
 AiPlayerbot.DisabledWithoutRealPlayerLogoutDelay = 300


### PR DESCRIPTION
Just saw @kadeshar PR https://github.com/liyunfan1223/mod-playerbots/pull/1335 that introduces a great requested feature to logout bots if no one is around. Gave it a bit more comment context.

And just a little heads up to anyone editing playerbots.conf.dist (or even worldserver.conf.dist in the AC repo) please make sure to properly document your additions. Not every person using AC/PB is well versed to understand what a thing does by just reading the variable. Also please document what the default value of the variable is. Thanks.