### PR TITLE
Addresses #1360 

### DIFF
--- a/src/strategy/actions/LootRollAction.cpp
+++ b/src/strategy/actions/LootRollAction.cpp
@@ -65,7 +65,7 @@ bool LootRollAction::Execute(Event event)
             switch (proto->Class)
             {
                 case ITEM_CLASS_WEAPON:
-                case ITEM_CLASS_ARMOR:
+                case ITEM_CLASS_ARMOR:   
                     if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
                     {
                         vote = NEED;
@@ -89,7 +89,14 @@ bool LootRollAction::Execute(Event event)
         {
             if (vote == NEED)
             {
-                vote = GREED;
+                if (RollUniqueCheck(proto, bot))
+                    {
+                        vote = PASS;
+                    }
+                else 
+                    {
+                        vote = GREED;
+                    }
             }
             else if (vote == GREED)
             {
@@ -195,4 +202,26 @@ bool CanBotUseToken(ItemTemplate const* proto, Player* bot)
     }
 
     return false; // Bot's class cannot use this token
+}
+
+bool RollUniqueCheck(ItemTemplate const* proto, Player* bot)
+{
+    // Count the total number of the item (equipped + in bags)
+    uint32 totalItemCount = bot->GetItemCount(proto->ItemId, true);
+
+    // Count the number of the item in bags only
+    uint32 bagItemCount = bot->GetItemCount(proto->ItemId, false);
+
+    // Determine if the unique item is already equipped
+    bool isEquipped = (totalItemCount > bagItemCount);
+    if (isEquipped && proto->HasFlag(ITEM_FLAG_UNIQUE_EQUIPPABLE))
+    {
+        return true;  // Unique Item is already equipped
+    }
+    else if (proto->HasFlag(ITEM_FLAG_UNIQUE_EQUIPPABLE) && (bagItemCount > 1))
+    {
+        return true; // Unique item already in bag, don't roll for it
+    }
+    return false; // Item is not equipped or in bags, roll for it
+
 }

--- a/src/strategy/actions/LootRollAction.h
+++ b/src/strategy/actions/LootRollAction.h
@@ -26,6 +26,7 @@ protected:
 };
 
 bool CanBotUseToken(ItemTemplate const* proto, Player* bot);
+bool RollUniqueCheck(ItemTemplate const* proto, Player* bot);
 
 class MasterLootRollAction : public LootRollAction
 {


### PR DESCRIPTION
This PR addresses unique equipped items.
Rolls are calculated as usual, however if a bot determines it needs an item, an additional check before passing the vote is done. 

If the bot has the unique item it's rolling on already equipped or in its bags, it will pass. Otherwise it will roll Need (Greed)

Only check for items that have the ITEM_FLAG_UNIQUE_EQUIPPABLE flag. This should not interfere with other types of loot. 