### PR TITLE
fix: ⚡ added missing guildTaskEnabled checks for GuildTaskMgr

### DIFF
--- a/src/GuildTaskMgr.cpp
+++ b/src/GuildTaskMgr.cpp
@@ -525,6 +525,11 @@ uint32 GuildTaskMgr::GetMaxItemTaskCount(uint32 itemId)
 
 bool GuildTaskMgr::IsGuildTaskItem(uint32 itemId, uint32 guildId)
 {
+    if (!sPlayerbotAIConfig->guildTaskEnabled)
+    {
+        return 0;
+    }
+
     uint32 value = 0;
 
     PlayerbotsDatabasePreparedStatement* stmt =
@@ -548,6 +553,11 @@ bool GuildTaskMgr::IsGuildTaskItem(uint32 itemId, uint32 guildId)
 std::map<uint32, uint32> GuildTaskMgr::GetTaskValues(uint32 owner, std::string const type,
                                                      [[maybe_unused]] uint32* validIn /* = nullptr */)
 {
+    if (!sPlayerbotAIConfig->guildTaskEnabled)
+    {
+        return std::map<uint32, uint32>();
+    }
+
     std::map<uint32, uint32> results;
 
     PlayerbotsDatabasePreparedStatement* stmt =
@@ -576,6 +586,11 @@ std::map<uint32, uint32> GuildTaskMgr::GetTaskValues(uint32 owner, std::string c
 
 uint32 GuildTaskMgr::GetTaskValue(uint32 owner, uint32 guildId, std::string const type, [[maybe_unused]] uint32* validIn /* = nullptr */)
 {
+    if (!sPlayerbotAIConfig->guildTaskEnabled)
+    {
+        return 0;
+    }
+    
     uint32 value = 0;
 
     PlayerbotsDatabasePreparedStatement* stmt =


### PR DESCRIPTION
## Description

Even if guildTaskEnabled was set to 0 in the configuration file, a massive amount of queries like PLAYERBOTS_SEL_GUILD_TASKS_BY_VALUE, PLAYERBOTS_SEL_GUILD_TASKS_BY_OWNER were executed, which lead to unnecessary database load.

## Analysis

Based on https://github.com/liyunfan1223/mod-playerbots/issues/1373#issuecomment-2963659554. Unnecessary query/executions onto an empty playerbots_guild_tasks table dominated the executions on the db by far.

## Synopsis

I hope this could lead in the right direction, finding the issue discussed at #1373. This change should improve performance, by reducing the load on the database by a fair amount.

## Result

**Before**
```
[2025-06-11 21:04:23] --------------------------
[2025-06-11 21:04:23] Lines with 'playerbots_guild_tasks': 557486
[2025-06-11 21:04:24] Lines with 'pet_spell': 146427
[2025-06-11 21:04:24] Lines with 'character_pet': 145867
[2025-06-11 21:04:24] Lines with 'pet_spell_cooldown': 69873
[2025-06-11 21:04:24] Lines with 'playerbots_random_bots': 124261
[2025-06-11 21:04:24] Lines with 'character_skills': 151771
[2025-06-11 21:04:25] Lines with 'item_instance': 166261
[2025-06-11 21:04:25] Lines with 'character_inventory': 159896
[2025-06-11 21:04:25] Lines with 'character_aura': 78384
[2025-06-11 21:04:26] --------------------------
[2025-06-11 21:04:26] Total number of lines: 2433363
[2025-06-11 21:04:26] Lines without search strings: 909127
[2025-06-11 21:04:26] Server running for 2 hrs 31 mins 29 secs 0 millisecs
```

**After**
```
[2025-06-12 02:45:56] --------------------------
[2025-06-12 02:45:56] Lines with 'playerbots_guild_tasks': 0
[2025-06-12 02:45:56] Lines with 'pet_spell': 25593
[2025-06-12 02:45:56] Lines with 'character_pet': 30101
[2025-06-12 02:45:56] Lines with 'pet_spell_cooldown': 11692
[2025-06-12 02:45:56] Lines with 'playerbots_random_bots': 25293
[2025-06-12 02:45:56] Lines with 'character_skills': 13771
[2025-06-12 02:45:56] Lines with 'item_instance': 21702
[2025-06-12 02:45:56] Lines with 'character_inventory': 21252
[2025-06-12 02:45:56] Lines with 'character_aura': 5823
[2025-06-12 02:45:56] --------------------------
[2025-06-12 02:45:56] Total number of lines: 246562
[2025-06-12 02:45:56] Lines without search strings: 103455
[2025-06-12 02:45:56] Server running for 0 hrs 17 mins 25 secs 0 millisecs
```