### PR TITLE
fix: ⚡ added missing checks for PetIsDeadValue

### DIFF
--- a/src/GuildTaskMgr.cpp
+++ b/src/GuildTaskMgr.cpp
@@ -525,6 +525,11 @@ uint32 GuildTaskMgr::GetMaxItemTaskCount(uint32 itemId)
 
 bool GuildTaskMgr::IsGuildTaskItem(uint32 itemId, uint32 guildId)
 {
+    if (!sPlayerbotAIConfig->guildTaskEnabled)
+    {
+        return 0;
+    }
+
     uint32 value = 0;
 
     PlayerbotsDatabasePreparedStatement* stmt =
@@ -548,6 +553,11 @@ bool GuildTaskMgr::IsGuildTaskItem(uint32 itemId, uint32 guildId)
 std::map<uint32, uint32> GuildTaskMgr::GetTaskValues(uint32 owner, std::string const type,
                                                      [[maybe_unused]] uint32* validIn /* = nullptr */)
 {
+    if (!sPlayerbotAIConfig->guildTaskEnabled)
+    {
+        return std::map<uint32, uint32>();
+    }
+
     std::map<uint32, uint32> results;
 
     PlayerbotsDatabasePreparedStatement* stmt =
@@ -576,6 +586,11 @@ std::map<uint32, uint32> GuildTaskMgr::GetTaskValues(uint32 owner, std::string c
 
 uint32 GuildTaskMgr::GetTaskValue(uint32 owner, uint32 guildId, std::string const type, [[maybe_unused]] uint32* validIn /* = nullptr */)
 {
+    if (!sPlayerbotAIConfig->guildTaskEnabled)
+    {
+        return 0;
+    }
+    
     uint32 value = 0;
 
     PlayerbotsDatabasePreparedStatement* stmt =

--- a/src/strategy/values/StatsValues.cpp
+++ b/src/strategy/values/StatsValues.cpp
@@ -40,6 +40,11 @@ bool IsDeadValue::Calculate()
 
 bool PetIsDeadValue::Calculate()
 {
+    if ((bot->GetLevel() < 10 && bot->getClass() == CLASS_HUNTER) || bot->IsMounted())
+    {
+        return false;
+    }
+
     if (!bot->GetPet())
     {
         uint32 ownerid = bot->GetGUID().GetCounter();


### PR DESCRIPTION
## Description

Hunter under level 10, which are not able to summon their pets defined in the database spammed SELECT id FROM character_pet WHERE owner = {}, since the result of the query was true. Bots under level 10 already have pets in their stables. Also the same thing applied to Bots on mounts, because, while mounted, pets get despawned. This should drastically improve server performance.

## Analysis

Based on https://github.com/liyunfan1223/mod-playerbots/issues/1373#issuecomment-2963659554. Massive amounts of queries based on the issue under onto the character_pet table.

## Synopsis

I hope this could lead in the right direction, finding the issue discussed at #1373. This change should improve performance, by reducing the load on the database by a fair amount.

## Result

**Before**
```
[2025-06-11 21:04:23] --------------------------
[2025-06-11 21:04:23] Lines with 'playerbots_guild_tasks': 557486
[2025-06-11 21:04:24] Lines with 'pet_spell': 146427
[2025-06-11 21:04:24] Lines with 'character_pet': 145867
[2025-06-11 21:04:24] Lines with 'pet_spell_cooldown': 69873
[2025-06-11 21:04:24] Lines with 'playerbots_random_bots': 124261
[2025-06-11 21:04:24] Lines with 'character_skills': 151771
[2025-06-11 21:04:25] Lines with 'item_instance': 166261
[2025-06-11 21:04:25] Lines with 'character_inventory': 159896
[2025-06-11 21:04:25] Lines with 'character_aura': 78384
[2025-06-11 21:04:26] --------------------------
[2025-06-11 21:04:26] Total number of lines: 2433363
[2025-06-11 21:04:26] Lines without search strings: 909127
[2025-06-11 21:04:26] Server running for 2 hrs 31 mins 29 secs 0 millisecs
```

**After**
```
[2025-06-12 13:35:16] --------------------------
[2025-06-12 13:35:16] Lines with 'playerbots_guild_tasks': 0
[2025-06-12 13:35:16] Lines with 'pet_spell': 8389
[2025-06-12 13:35:16] Lines with 'character_pet': 2620
[2025-06-12 13:35:16] Lines with 'pet_spell_cooldown': 3659
[2025-06-12 13:35:16] Lines with 'playerbots_random_bots': 7970
[2025-06-12 13:35:16] Lines with 'character_skills': 526
[2025-06-12 13:35:16] Lines with 'item_instance': 1100
[2025-06-12 13:35:16] Lines with 'character_inventory': 1099
[2025-06-12 13:35:16] Lines with 'character_aura': 282
[2025-06-12 13:35:16] --------------------------
[2025-06-12 13:35:16] Total number of lines: 41445
[2025-06-12 13:35:16] Lines without search strings: 19459
[2025-06-12 13:35:16] Server running for 0 hrs 6 mins 5 secs 0 millisecs
```