### PR TITLE
Fixes #1093 (Hunter's stuck in Auto shot pose and Can't equip gear)

### DIFF
--- a/src/strategy/actions/ChooseTargetActions.cpp
+++ b/src/strategy/actions/ChooseTargetActions.cpp
@@ -83,7 +83,12 @@ bool DropTargetAction::Execute(Event event)
     bot->SetTarget(ObjectGuid::Empty);
     bot->SetSelection(ObjectGuid());
     botAI->ChangeEngine(BOT_STATE_NON_COMBAT);
-    // botAI->InterruptSpell();
+    if (bot->getClass() == CLASS_HUNTER && 
+        (bot->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL)->m_spellInfo->Id == 75))
+            //Is bot a hunter and is Auto Shot Active?
+        {
+            bot->InterruptSpell(CURRENT_AUTOREPEAT_SPELL); // Interrupt Auto Shot
+        }
     bot->AttackStop();
 
     // if (Pet* pet = bot->GetPet())


### PR DESCRIPTION
This addresses #1093 

Auto Shot is part of the default hunter combat strategy and I don't understand exactly how the AI actions work, this seems to be the safest place to add this.  

Adds a simple check to DropTargetAction to see if the bot is a hunter, and the current auto repeating spell is 75, then clears it. (This usually is Id 75, aka Auto Shot) 

This ensures the AOE channeled spells aren't interrupted, including any channeled hunter spells. 

Edit: If you're still in combat, it instantly picks back up Auto Shot. You may miss a single auto shot with this method, I don't think this would effect overall DPS from hunters enough to worry about it, and it keeps the changes out of the main Azerothcore-wotlk fork. 