### PR TITLE
[URGENT Fix] Trinket proc effects are getting cast even if they are not onUse - Leads to big server lags

### DIFF
--- a/src/strategy/actions/GenericSpellActions.cpp
+++ b/src/strategy/actions/GenericSpellActions.cpp
@@ -339,7 +339,7 @@ bool UseTrinketAction::UseTrinket(Item* item)
             // e.g. on Item https://www.wowhead.com/wotlk/item=44074/oracle-talisman-of-ablution leading to
             // constant casting of the proc spell onto themselfes https://www.wowhead.com/wotlk/spell=59787/oracle-ablutions
             // This will lead to multiple hundreds of entries in m_appliedAuras -> Once killing an enemy -> Big diff time spikes
-            if (spellProcFlag == 2) return false;
+            if (spellProcFlag != 0) return false;
 
             if (!botAI->CanCastSpell(spellId, bot, false))
             {

--- a/src/strategy/actions/GenericSpellActions.cpp
+++ b/src/strategy/actions/GenericSpellActions.cpp
@@ -304,7 +304,6 @@ bool UseTrinketAction::Execute(Event event)
         return true;
 
     Item* trinket2 = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_TRINKET2);
-    
     if (trinket2 && UseTrinket(trinket2))
         return true;
     
@@ -333,6 +332,15 @@ bool UseTrinketAction::UseTrinket(Item* item)
         if (item->GetTemplate()->Spells[i].SpellId > 0 && item->GetTemplate()->Spells[i].SpellTrigger == ITEM_SPELLTRIGGER_ON_USE)
         {
             spellId = item->GetTemplate()->Spells[i].SpellId;
+            uint32 spellProcFlag = sSpellMgr->GetSpellInfo(spellId)->ProcFlags;
+
+            // Handle items with procflag "if you kill a target that grants honor or experience"
+            // Bots will "learn" the trinket proc, so CanCastSpell() will be true
+            // e.g. on Item https://www.wowhead.com/wotlk/item=44074/oracle-talisman-of-ablution leading to
+            // constant casting of the proc spell onto themselfes https://www.wowhead.com/wotlk/spell=59787/oracle-ablutions
+            // This will lead to multiple hundreds of entries in m_appliedAuras -> Once killing an enemy -> Big diff time spikes
+            if (spellProcFlag == 2) return false;
+
             if (!botAI->CanCastSpell(spellId, bot, false))
             {
                 return false;


### PR DESCRIPTION
### Description

Bots will "learn" specific trinket procs, so CanCastSpell() at UseTrinketAction::UseTrinket will be true (GenericSpellActions.cpp | Line 315). E.g. on Item https://www.wowhead.com/wotlk/item=44074/oracle-talisman-of-ablution leading to constant casting of the proc spell onto themselfes https://www.wowhead.com/wotlk/spell=59787/oracle-ablutions. This will lead to multiple hundreds of entries in m_appliedAuras -> Once killing an enemy -> Big diff time spikes. See diagnosis

### Diagnosis

I used an function call tracer to trace down weird behavior about abnormal huge server diff times. I noticed, that some bots are using the item https://www.wowhead.com/wotlk/item=44074/oracle-talisman-of-ablution. That item has an unique way to apply the desired effect onto the player wielding the trinket.

I think its a core mechanic, that some procs will get learned by the wielder, so do the bots. There is just one issue with the bots. They are using another way of handling procs, since they will use trinkets on the **boost context action**. If that gets triggered (**which it gets alot**) UseTrinketAction::Execute checks if the wielded Trinkets are useable or not. Since specific trinkets are being cast by "using" a spell, some trinkets will still be used, even if they shouldnt be. Its getting "bypassed" by the HandleUseItemOpcode. Players wont send these Packets, since they cant effectivly click trinkets which are not useable.

This could lead to really weird behavior, overpowered trinket stacks (if you ever noticed bots with absurd amount of haste for example) or like in my case above huge server freezes. Follwing a few Screenshots and Screencasts:

**Freezes in action and m_appliedAuras list of one of the bots wielding the trinket**
https://github.com/user-attachments/assets/c094cc87-d856-4c76-b241-c42f536c9c30
https://github.com/user-attachments/assets/04062909-4a26-4739-8f6c-937c9d4ac7ca

Complexity of the trinket mentioned above
![Screenshot From 2025-06-20 11-36-48](https://github.com/user-attachments/assets/d920a620-185f-482f-90f2-345cb8411581)

One bot already stacked up 100+ of these auras, leading to massive server diffs, since other threads are halting
![Screenshot From 2025-06-20 12-43-33](https://github.com/user-attachments/assets/c1ecc12b-8cc0-4034-a38f-147876ca38e1)

Ingame .list aura -> https://www.wowhead.com/wotlk/spell=59787/oracle-ablutions
![Screenshot From 2025-06-20 16-49-50](https://github.com/user-attachments/assets/f7011a6e-2711-40cc-9bae-5c8db74d06f9)

Trace of the bot calling the _AddAura, leading to the multiplications
![Screenshot From 2025-06-20 18-28-15](https://github.com/user-attachments/assets/a4e075c2-caf3-4c3e-95d5-005a8164875e)

Callstack of the _AddAura calls
![image](https://github.com/user-attachments/assets/a585417a-72aa-4e56-a19f-ddea698db6b1)

Spell ID of Trinket gets checked here. Once learned, it will pass the "Can i use that trinket" expression
![Screenshot From 2025-06-20 17-45-41](https://github.com/user-attachments/assets/75e36045-7c76-4d59-8fbe-d7828d8ac354)

### Synopsis

~~This system needs a huge refactor in my eye. Forbidding trinkets like this with spellProcFlag = 2 for example is not a final solution. It seems like that the Bots somehow learn the "proc spells" via the boost context, dont know why they wouldnt on login in that case. Could be the case for all trinkets, could be the case for only special cases like the Oracle Talisman of Ablution. Havent tested this yet. With this example, bots using that trinket wont benefit of the onKill-Effect. This could also be the case for all other trinkets, being forbidden there.~~

~~I will keep testing to see, if it really applies to all or just some trinkets. Noticed some weird behavior here and there, but havent thought that fat at that time. For the time beeing this one should drastically reduce the server freeze issues, many people talking about, especially with higher rndbot counts.~~

Checking against spellProcFlag != 0 is a valid option in my opinion now, after i noticed, that all other trinkets still work as expected. Special Trinket cases need to be handled somewhere else, not by the boost context to make them work.

This would also explain why the server diffs suffer, the longer the server runs. If it applies to all trinkets, executions of the boost strategy, which the bots are using, will take longer and longer.

If anyone has a great idea to fix that issue, go ahead!

### This commit should reduce big server halts by a huge margin, especially on longer runtimes

~~Like i said im not sure how many other trinkets behave the same, but atleast onKill-Trinkets would now be disabled for the time being.~~


### First quick suggestion

Apply Auras of Trinkets or learn their "spell procs" on login. Change the UseTrinketAction::UseTrinket to explicitly check for onUse only trinkets, if that makes sense, could be wrong there. 

**Getting the trinket to work, isn't the job of the boost context anyway. That needs to be handled somewhere else.**

EDIT:

Just for proof. The bot which caused the spikes, now wont trigger the onKill-Effects anymore, since its not being pushed into m_ownedAuras nor m_appliedAuras. Dont know how real players **and altbots** are handled differently then rndbots. If you as a Player equip and trinket with such procs, you will recieve the Aura. Even after logging in without doing anything else. Altbots will also correctly use that aura.

![image](https://github.com/user-attachments/assets/cba8f26f-e392-4664-8922-47cc9a311333)

~~By the way, i dont know why the trinket above doesnt fail here already:~~

~~`if (item->GetTemplate()->Spells[i].SpellId > 0 && item->GetTemplate()->Spells[i].SpellTrigger == ITEM_SPELLTRIGGER_ON_USE)`~~

~~since its 100% not usable, so i cant imagine an DB-Issue or something.~~

I think in the case of this specific trinket, the responsible spell there is marked as an onUse Spell, thats why the iterator finds and allows it.
