### PR TITLE
Update Pvp Prohibited Zone Id's (addresses #513)

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1062,7 +1062,7 @@ AiPlayerbot.DeleteRandomBotArenaTeams = 0
 AiPlayerbot.PvpProhibitedZoneIds = "2255,656,2361,2362,2363,976,35,2268,3425,392,541,1446,3828,3712,3738,3565,3539,3623,4152,3988,4658,4284,4418,4436,4275,4323,4395,3703,4298,139"
 
 # PvP Restricted Areas (bots don't pvp)
-AiPlayerbot.PvpProhibitedAreaIds = "976,35,392,2268,4161,4010,4317,4312"
+AiPlayerbot.PvpProhibitedAreaIds = "976,35,392,2268,4161,4010,4317,4312,3649,3887,3958,3724,4080"
 
 # Improve reaction speeds in battlegrounds and arenas (may cause lag)
 AiPlayerbot.FastReactInBG = 1


### PR DESCRIPTION
3649 = Sporeggar (Zangarmarsh)
3887 = Refugee Caravan (Terokkar Forest)
3958 = Sha'tari Base Camp (Terokkar Forest)
3724 = Cosmowrench (Netherstorm)
4080 = Isle of Quel'Danas

As referenced in Issue #513 

