### PR TITLE
Warlock Soulstone Fixes/Pet Changes

### DIFF
--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -594,18 +594,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
                 nonCombatEngine->addStrategy("dps assist", false);
             break;
         case CLASS_WARLOCK:
-            if (tab == WARLOCK_TAB_AFFLICATION)
-            {
-                nonCombatEngine->addStrategiesNoInit("felhunter", nullptr);
-            }
-            else if (tab == WARLOCK_TAB_DEMONOLOGY)
-            {
-                nonCombatEngine->addStrategiesNoInit("felguard", nullptr);
-            }
-            else if (tab == WARLOCK_TAB_DESTRUCTION)
-            {
-                nonCombatEngine->addStrategiesNoInit("imp", nullptr);
-            }
+            // Pet selection is now handled in GenericWarlockNonCombatStrategy triggers
             nonCombatEngine->addStrategiesNoInit("dps assist", nullptr);
             break;
         case CLASS_DEATH_KNIGHT:

--- a/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
+++ b/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
@@ -89,6 +89,7 @@ void GenericWarlockNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& tr
     Player* bot = botAI->GetBot();
     int tab = AiFactory::GetPlayerSpecTab(bot);
 
+    // Firestone/Spellstone triggers
     if (tab == 2)  // Destruction uses Firestone
     {
         triggers.push_back(
@@ -103,63 +104,23 @@ void GenericWarlockNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& tr
         triggers.push_back(
             new TriggerNode("spellstone", NextAction::array(0, new NextAction("spellstone", 24.0f), nullptr)));
     }
-}
 
-// Non-combat strategy for summoning a Imp
-// Enabled by default for the Destruction spec
-// To enable, type "nc +imp"
-// To disable, type "nc -imp"
-SummonImpStrategy::SummonImpStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
-
-void SummonImpStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
-{
-    triggers.push_back(new TriggerNode("no pet", NextAction::array(0, new NextAction("summon imp", 29.0f), NULL)));
-}
-
-// Non-combat strategy for summoning a Voidwalker
-// Disabled by default
-// To enable, type "nc +voidwalker"
-// To disable, type "nc -voidwalker"
-SummonVoidwalkerStrategy::SummonVoidwalkerStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
-
-void SummonVoidwalkerStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
-{
-    triggers.push_back(
-        new TriggerNode("no pet", NextAction::array(0, new NextAction("summon voidwalker", 29.0f), NULL)));
-}
-
-// Non-combat strategy for summoning a Succubus
-// Disabled by default
-// To enable, type "nc +succubus"
-// To disable, type "nc -succubus"
-SummonSuccubusStrategy::SummonSuccubusStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
-
-void SummonSuccubusStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
-{
-    triggers.push_back(new TriggerNode("no pet", NextAction::array(0, new NextAction("summon succubus", 29.0f), NULL)));
-}
-
-// Non-combat strategy for summoning a Felhunter
-// Enabled by default for the Affliction spec
-// To enable, type "nc +felhunter"
-// To disable, type "nc -felhunter"
-SummonFelhunterStrategy::SummonFelhunterStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
-
-void SummonFelhunterStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
-{
-    triggers.push_back(
-        new TriggerNode("no pet", NextAction::array(0, new NextAction("summon felhunter", 29.0f), NULL)));
-}
-
-// Non-combat strategy for summoning a Felguard
-// Enabled by default for the Demonology spec
-// To enable, type "nc +felguard"
-// To disable, type "nc -felguard"
-SummonFelguardStrategy::SummonFelguardStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
-
-void SummonFelguardStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
-{
-    triggers.push_back(new TriggerNode("no pet", NextAction::array(0, new NextAction("summon felguard", 29.0f), NULL)));
+    // Pet-summoning triggers based on spec
+    if (tab == 0)  // Affliction
+    {
+        triggers.push_back(
+            new TriggerNode("no pet", NextAction::array(0, new NextAction("summon felhunter", 29.0f), nullptr)));
+    }
+    else if (tab == 1)  // Demonology
+    {
+        triggers.push_back(
+            new TriggerNode("no pet", NextAction::array(0, new NextAction("summon felguard", 29.0f), nullptr)));
+    }
+    else if (tab == 2)  // Destruction
+    {
+        triggers.push_back(
+            new TriggerNode("no pet", NextAction::array(0, new NextAction("summon imp", 29.0f), nullptr)));
+    }
 }
 
 // Non-combat strategy for selecting themselves to receive soulstone

--- a/src/strategy/warlock/GenericWarlockNonCombatStrategy.h
+++ b/src/strategy/warlock/GenericWarlockNonCombatStrategy.h
@@ -19,56 +19,6 @@ public:
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
 };
 
-class SummonImpStrategy : public NonCombatStrategy
-{
-public:
-    SummonImpStrategy(PlayerbotAI* ai);
-    virtual std::string const getName() override { return "imp"; }
-
-public:
-    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-};
-
-class SummonVoidwalkerStrategy : public NonCombatStrategy
-{
-public:
-    SummonVoidwalkerStrategy(PlayerbotAI* ai);
-    virtual std::string const getName() override { return "voidwalker"; }
-
-public:
-    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-};
-
-class SummonSuccubusStrategy : public NonCombatStrategy
-{
-public:
-    SummonSuccubusStrategy(PlayerbotAI* ai);
-    virtual std::string const getName() override { return "succubus"; }
-
-public:
-    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-};
-
-class SummonFelhunterStrategy : public NonCombatStrategy
-{
-public:
-    SummonFelhunterStrategy(PlayerbotAI* ai);
-    virtual std::string const getName() override { return "felhunter"; }
-
-public:
-    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-};
-
-class SummonFelguardStrategy : public NonCombatStrategy
-{
-public:
-    SummonFelguardStrategy(PlayerbotAI* ai);
-    virtual std::string const getName() override { return "felguard"; }
-
-public:
-    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-};
-
 class SoulstoneSelfStrategy : public NonCombatStrategy
 {
 public:

--- a/src/strategy/warlock/WarlockAiObjectContext.cpp
+++ b/src/strategy/warlock/WarlockAiObjectContext.cpp
@@ -76,11 +76,6 @@ class NonCombatBuffStrategyFactoryInternal : public NamedObjectContext<Strategy>
 public:
     NonCombatBuffStrategyFactoryInternal() : NamedObjectContext<Strategy>(false, true)
     {
-        creators["imp"] = &NonCombatBuffStrategyFactoryInternal::imp;
-        creators["voidwalker"] = &NonCombatBuffStrategyFactoryInternal::voidwalker;
-        creators["succubus"] = &NonCombatBuffStrategyFactoryInternal::succubus;
-        creators["felhunter"] = &NonCombatBuffStrategyFactoryInternal::felhunter;
-        creators["felguard"] = &NonCombatBuffStrategyFactoryInternal::felguard;
         creators["ss self"] = &NonCombatBuffStrategyFactoryInternal::soulstone_self;
         creators["ss master"] = &NonCombatBuffStrategyFactoryInternal::soulstone_master;
         creators["ss tank"] = &NonCombatBuffStrategyFactoryInternal::soulstone_tank;
@@ -88,11 +83,6 @@ public:
     }
 
 private:
-    static Strategy* imp(PlayerbotAI* ai) { return new SummonImpStrategy(ai); }
-    static Strategy* voidwalker(PlayerbotAI* ai) { return new SummonVoidwalkerStrategy(ai); }
-    static Strategy* succubus(PlayerbotAI* ai) { return new SummonSuccubusStrategy(ai); }
-    static Strategy* felhunter(PlayerbotAI* ai) { return new SummonFelhunterStrategy(ai); }
-    static Strategy* felguard(PlayerbotAI* ai) { return new SummonFelguardStrategy(ai); }
     static Strategy* soulstone_self(PlayerbotAI* ai) { return new SoulstoneSelfStrategy(ai); }
     static Strategy* soulstone_master(PlayerbotAI* ai) { return new SoulstoneMasterStrategy(ai); }
     static Strategy* soulstone_tank(PlayerbotAI* ai) { return new SoulstoneTankStrategy(ai); }


### PR DESCRIPTION
Hello Playerbots community,

I released a PR last night that changed quite a few things, and I got some feedback from the community. Here is a patch to fix some issues that arose.

srt/AiFactory.cpp: Removed the pet-based non-combat strategies entirely. **Why the heck would I do that?!** There is a bug that came to my attention when it comes to adding multiple non-combat strategies from the same header, aka GenericWarlockNonCombatStrategies.h It inherently adds "nc" as a non-combat strategy, and we were asking it to also add a pet that correlates with a spec ("imp" for destruction, "felhunter" for affliction, "felguard" for demonology). When we add ANOTHER non-combat strategy, such as "ss self", or another one of the soulstone non-combat strategies, one of the strategies "falls off"! I implore y'all to recreate the bug for yourself. I received a few discord messages of people saying "when I add the soulstone strategy, my pet strategy goes away". I spent the last 5 hours trying to figure out why, with no such luck. I am a simple thinker, so I ended up migrating all of the summoning logic to the GenericWarlockNonCombatStrategy.cpp, where it checks the player's spec, then summons accordingly. After I made this change, I actually noticed that the Warlock ends up summoning the demon quicker for some reason... Couldn't tell ya why. **TLDR: Changed pet summoning from separate strategies into triggers -> actions based on spec.**

src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp: Added summoning logic based on tab (spec).

src/strategy/warlock/GenericWarlockNonCombatStrategy.h: Gutted pet strategies out of this entirely.

src/strategy/warlock/WarlockActions.cpp: So I was made aware that bots were attempting to soulstone the same healer, or tank. I looked over the code, and the logic for checking for the soulstone aura was already implemented - the issue was, multiple warlocks began using the item at the exact same time. The soulstone resurrection aura was not on the healer when they started, so of course they went to town in all happily casting soulstone on the same damn healer. **The change I am making is to implement something called a "soulstone reservation"**, which means the bot "reserves the right" to soulstone the target for 2 seconds, so other bots can't attempt to soulstone the same target. I also added **line of sight and 30m range requirements**, so they aren't attempting to soulstone something out of range or LoS. I tested this and it seemed to work, but _please_ test this to confirm!

src/strategy/warlock/WarlockAiObjectContext.cpp: Gutted pet strategies out of this entirely.

Last but not least, I wanted to mention something. Tonight I tried to remove the DpsWarlockStrategy.cpp and .h, and clean up their usage in WarlockAiObjectContext, but for some reason the bots performed CONSIDERABLY worse. I have no idea why. On Noth the Plaguebringer, with the DpsWarlockStrategy they were pulling 3.8k-4.7k with ilevel 187 blues. Without, they were pulling 2.9k-3.9k. Same thing on target dummies - they were doing less damage, and they weren't prioritizing the DoTs as well. I will have to look into this further, but for the meantime, the DpsWarlockStrategy.cpp and .h will stay.

P.S. thank all of you for the continued support on this pet project of mine. I highly appreciate the praise, advice, and suggestions.
