### PR TITLE
Added GameObject IDs that bots ignore

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1954,9 +1954,15 @@ AiPlayerbot.AllowedLogFiles = ""
 
 ####################################################################################################
 # A list of gameObject GUID's that are not allowed for bots to interact with.
-# Example: 176213 = Blood of Heroes
-# Example: 17155 = Defias Gunpowder
-AiPlayerbot.DisallowedGameObjects = 176213,17155
+#
+AiPlayerbot.DisallowedGameObjects = 176213,17155,2656,74448,19020,3719,3658,3705,3706,105579,75293,17155
+#
+# List of GUID's:
+# QuestItems:
+# 176213 = Blood of Heroes, 17155 = Defias Gunpowder, 2656 = Waterlogged Envelope
+# Chests:
+# Large Solid Chest = 74448, Box of Assorted Parts = 19020, Food Crate = 3719, Water Barrel = 3658, Barrel of Milk = 3705, Barrel of sweet Nectar = 3706, Tattered Chest = 105579, Large bettered Chest = 75293
+# Feel free to edit and help to complete.
 #
 ####################################################################################################
 


### PR DESCRIPTION
Added some GameObject ID's to stop Bots from stealing it.

Quests:
2656 = Waterlogged Envelope (Starts a quest)

Chests:
Large Solid Chest = 74448, Box of Assorted Parts = 19020, Food Crate = 3719, Water Barrel = 3658, Barrel of Milk = 3705, Barrel of sweet Nectar = 3706, Tattered Chest = 105579, Large bettered Chest = 75293

These GO's should now be ignored by Bots.

Closes #1417