### PR TITLE
Added config to make rndbots only get gear from looting/quests

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -656,6 +656,11 @@ AiPlayerbot.RandomGearQualityLimit = 3
 # Default: 0 (no limit)
 AiPlayerbot.RandomGearScoreLimit = 0
 
+# Equipment quality limitation for randombots (0 = disabled, 1 = enabled)
+# If disabled, random bots can only upgrade equipment through looting and quests
+# Default: 1 (enabled)
+AiPlayerbot.IncrementalGearInit = 1
+
 # Set minimum level of bots that will enchant their equipment (Maxlevel + 1 to disable)
 # Default: 60
 AiPlayerbot.MinEnchantingBotLevel = 60

--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -80,13 +80,13 @@ uint8 AiFactory::GetPlayerSpecTab(Player* bot)
         switch (bot->getClass())
         {
             case CLASS_MAGE:
-                tab = 1;
+                tab = MAGE_TAB_FROST;
                 break;
             case CLASS_PALADIN:
-                tab = 2;
+                tab = PALADIN_TAB_RETRIBUTION;
                 break;
             case CLASS_PRIEST:
-                tab = 1;
+                tab = PRIEST_TAB_HOLY;
                 break;
         }
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -117,6 +117,8 @@ bool PlayerbotAIConfig::Initialize()
     tellWhenAvoidAoe = sConfigMgr->GetOption<bool>("AiPlayerbot.TellWhenAvoidAoe", false);
 
     randomGearLoweringChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomGearLoweringChance", 0.0f);
+    
+    incrementalGearInit = sConfigMgr->GetOption<bool>("AiPlayerbot.IncrementalGearInit", true);
     randomGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearQualityLimit", 3);
     randomGearScoreLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearScoreLimit", 0);
 

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -87,6 +87,7 @@ public:
     std::vector<uint32> randomBotQuestIds;
     uint32 randomBotTeleportDistance;
     float randomGearLoweringChance;
+    bool incrementalGearInit;
     int32 randomGearQualityLimit;
     int32 randomGearScoreLimit;
     float randomBotMinLevelChance, randomBotMaxLevelChance;

--- a/src/factory/StatsCollector.cpp
+++ b/src/factory/StatsCollector.cpp
@@ -29,12 +29,12 @@ void StatsCollector::CollectItemStats(ItemTemplate const* proto)
 {
     if (proto->IsRangedWeapon())
     {
-        uint32 val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
+        float val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
         stats[STATS_TYPE_RANGED_DPS] += val;
     }
     else if (proto->IsWeapon())
     {
-        uint32 val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
+        float val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
         stats[STATS_TYPE_MELEE_DPS] += val;
     }
     stats[STATS_TYPE_ARMOR] += proto->Armor;
@@ -436,10 +436,10 @@ void StatsCollector::CollectByItemStatType(uint32 itemStatType, int32 val)
     switch (itemStatType)
     {
         case ITEM_MOD_MANA:
-            stats[STATS_TYPE_MANA_REGENERATION] += val / 10;
+            stats[STATS_TYPE_MANA_REGENERATION] += (float)val / 10;
             break;
         case ITEM_MOD_HEALTH:
-            stats[STATS_TYPE_STAMINA] += val / 15;
+            stats[STATS_TYPE_STAMINA] += (float)val / 15;
             break;
         case ITEM_MOD_AGILITY:
             stats[STATS_TYPE_AGILITY] += val;
@@ -747,11 +747,11 @@ void StatsCollector::HandleApplyAura(const SpellEffectInfo& effectInfo, float mu
     }
 }
 
-int32 StatsCollector::AverageValue(const SpellEffectInfo& effectInfo)
+float StatsCollector::AverageValue(const SpellEffectInfo& effectInfo)
 {
     // float basePointsPerLevel = effectInfo.RealPointsPerLevel; //not used, line marked for removal.
-    int32 basePoints = effectInfo.BasePoints;
-    int32 randomPoints = int32(effectInfo.DieSides);
+    float basePoints = effectInfo.BasePoints;
+    int32 randomPoints = effectInfo.DieSides;
 
     switch (randomPoints)
     {
@@ -761,7 +761,7 @@ int32 StatsCollector::AverageValue(const SpellEffectInfo& effectInfo)
             basePoints += 1;
             break;
         default:
-            int32 randvalue = (1 + randomPoints) / 2;
+            float randvalue = (1 + randomPoints) / 2.0f;
             basePoints += randvalue;
             break;
     }

--- a/src/factory/StatsCollector.h
+++ b/src/factory/StatsCollector.h
@@ -71,7 +71,7 @@ public:
     bool CheckSpellValidation(uint32 spellFamilyName, flag96 spelFalimyFlags, bool strict = true);
 
 public:
-    int32 stats[STATS_TYPE_MAX];
+    float stats[STATS_TYPE_MAX];
 
 private:
     void CollectByItemStatType(uint32 itemStatType, int32 val);
@@ -80,7 +80,7 @@ private:
 
     void HandleApplyAura(const SpellEffectInfo& effectInfo, float multiplier, bool canNextTrigger,
                          uint32 triggerCooldown);
-    int32 AverageValue(const SpellEffectInfo& effectInfo);
+    float AverageValue(const SpellEffectInfo& effectInfo);
 
 private:
     CollectorType type_;

--- a/src/factory/StatsWeightCalculator.h
+++ b/src/factory/StatsWeightCalculator.h
@@ -57,6 +57,7 @@ private:
     CollectorType hitOverflowType_;
     std::unique_ptr<StatsCollector> collector_;
     uint8 cls;
+    uint8 lvl;
     int tab;
     bool enable_overflow_penalty_;
     bool enable_item_set_bonus_;

--- a/src/strategy/actions/AutoMaintenanceOnLevelupAction.cpp
+++ b/src/strategy/actions/AutoMaintenanceOnLevelupAction.cpp
@@ -163,7 +163,8 @@ void AutoMaintenanceOnLevelupAction::AutoUpgradeEquip()
     PlayerbotFactory factory(bot, bot->GetLevel());
     if (!sPlayerbotAIConfig->equipmentPersistence || bot->GetLevel() < sPlayerbotAIConfig->equipmentPersistenceLevel)
     {
-        factory.InitEquipment(true);
+        if (sPlayerbotAIConfig->incrementalGearInit)
+            factory.InitEquipment(true);
     }
     factory.InitAmmo();
     return;

--- a/src/strategy/actions/EquipAction.cpp
+++ b/src/strategy/actions/EquipAction.cpp
@@ -187,7 +187,8 @@ void EquipAction::EquipItem(Item* item)
             // Priority 1: Replace main hand if the new weapon is strictly better
             // and if conditions allow (e.g. no conflicting 2H logic)
             bool betterThanMH = (newItemScore > mainHandScore);
-            bool mhConditionOK = ((invType != INVTYPE_2HWEAPON && !have2HWeaponEquipped) ||
+            // If a one-handed weapon is better, we can still use it instead of a two-handed weapon
+            bool mhConditionOK = (invType != INVTYPE_2HWEAPON ||
                       (isTwoHander && !canTitanGrip) ||
                       (canTitanGrip && isValidTGWeapon));
 

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -1801,7 +1801,6 @@ const Movement::PointsArray MovementAction::SearchForBestPath(float x, float y, 
 
 bool FleeAction::Execute(Event event)
 {
-    // return Flee(AI_VALUE(Unit*, "current target"));
     return MoveAway(AI_VALUE(Unit*, "current target"), sPlayerbotAIConfig->fleeDistance, true);
 }
 
@@ -1811,6 +1810,10 @@ bool FleeAction::isUseful()
     {
         return false;
     }
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (target && target->IsInWorld() && !bot->IsWithinMeleeRange(target))
+        return false;
+
     return true;
 }
 

--- a/src/strategy/mage/ArcaneMageStrategy.cpp
+++ b/src/strategy/mage/ArcaneMageStrategy.cpp
@@ -60,7 +60,7 @@ ArcaneMageStrategy::ArcaneMageStrategy(PlayerbotAI* botAI) : GenericMageStrategy
 NextAction** ArcaneMageStrategy::getDefaultActions()
 {
     return NextAction::array(0, new NextAction("arcane blast", ACTION_DEFAULT + 0.3f),
-                             // new NextAction("arcane barrage", ACTION_DEFAULT + 0.2f), // cast during movement
+                             new NextAction("frostbolt", ACTION_DEFAULT + 0.2f), // arcane immune target
                              new NextAction("fire blast", ACTION_DEFAULT + 0.1f), // cast during movement
                              new NextAction("shoot", ACTION_DEFAULT), nullptr);
 }

--- a/src/strategy/mage/FireMageStrategy.cpp
+++ b/src/strategy/mage/FireMageStrategy.cpp
@@ -10,7 +10,8 @@
 
 NextAction** FireMageStrategy::getDefaultActions()
 {
-    return NextAction::array(0, new NextAction("fireball", ACTION_DEFAULT + 0.2f),
+    return NextAction::array(0, new NextAction("fireball", ACTION_DEFAULT + 0.3f),
+                             new NextAction("frostbolt", ACTION_DEFAULT + 0.2f), // fire immune target
                              new NextAction("fire blast", ACTION_DEFAULT + 0.1f), // cast during movement
                              new NextAction("shoot", ACTION_DEFAULT), NULL);
 }

--- a/src/strategy/values/GrindTargetValue.cpp
+++ b/src/strategy/values/GrindTargetValue.cpp
@@ -116,12 +116,11 @@ Unit* GrindTargetValue::FindTargetForGrinding(uint32 assistCount)
             botAI->rpgInfo.status == RPG_GO_INNKEEPER ||
             botAI->rpgInfo.status == RPG_DO_QUEST;
 
-        bool notHostile = !bot->IsHostileTo(unit); /*|| (unit->ToCreature() && unit->ToCreature()->IsCivilian());*/
         float aggroRange = 30.0f;
         if (unit->ToCreature())
             aggroRange = std::min(30.0f, unit->ToCreature()->GetAggroRange(bot) + 10.0f);
         bool outOfAggro = unit->ToCreature() && bot->GetDistance(unit) > aggroRange;
-        if (inactiveGrindStatus && (outOfAggro || notHostile))
+        if (inactiveGrindStatus && outOfAggro)
         {
             if (needForQuestMap.find(unit->GetEntry()) == needForQuestMap.end())
                 needForQuestMap[unit->GetEntry()] = needForQuest(unit);


### PR DESCRIPTION
- Added `IncrementalGearInit` config. With this option disabled, rndbots gear will be obtained entirely from looting/quests except for first initialization.
- For bots with level < 5, initialization with start out items.
- Enhance RPG movement and reduce stuck.
- Fixed https://github.com/liyunfan1223/mod-playerbots/issues/1203