### PR TITLE
Add Fishing action and fish with master. 

### DIFF
--- a/src/strategy/actions/ActionContext.h
+++ b/src/strategy/actions/ActionContext.h
@@ -63,6 +63,7 @@
 #include "WorldBuffAction.h"
 #include "XpGainAction.h"
 #include "NewRpgAction.h"
+#include "FishingAction.h"
 
 class PlayerbotAI;
 
@@ -189,6 +190,7 @@ public:
         creators["buy tabard"] = &ActionContext::buy_tabard;
         creators["guild manage nearby"] = &ActionContext::guild_manage_nearby;
         creators["clean quest log"] = &ActionContext::clean_quest_log;
+        creators["fishing action"] = &ActionContext::fishing_action;    
 
         // BG Tactics
         creators["bg tactics"] = &ActionContext::bg_tactics;
@@ -372,6 +374,7 @@ private:
     static Action* buy_tabard(PlayerbotAI* botAI) { return new BuyTabardAction(botAI); }
     static Action* guild_manage_nearby(PlayerbotAI* botAI) { return new GuildManageNearbyAction(botAI); }
     static Action* clean_quest_log(PlayerbotAI* botAI) { return new CleanQuestLogAction(botAI); }
+    static Action* fishing_action(PlayerbotAI* botAI) { return new FishingAction(botAI); }
 
     // BG Tactics
     static Action* bg_tactics(PlayerbotAI* botAI) { return new BGTactics(botAI); }

--- a/src/strategy/actions/FishWithMasterAction.cpp
+++ b/src/strategy/actions/FishWithMasterAction.cpp
@@ -3,7 +3,7 @@
  * and/or modify it under version 2 of the License, or (at your option), any later version.
  */
 #include "FishWithMasterAction.h"
-
+#include "FishingAction.h"
 #include "Event.h"
 #include "Playerbots.h"
 
@@ -16,59 +16,5 @@ bool FishWithMasterAction::Execute(Event event)
     uint8 castCount = 0, castFlags = 0;
     uint32 spellId = 0;
     p >> castCount >> spellId >> castFlags;
-
-    if (spellId != FISHING_SPELL)
-        return false;
-
-    auto isFishingPole = [](Item* item) -> bool
-    {
-        if (!item)
-            return false;
-        ItemTemplate const* proto = item->GetTemplate();
-        return proto && proto->Class == ITEM_CLASS_WEAPON && proto->SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE;
-    };
-
-    Item* pole = nullptr;
-    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END && !pole; ++slot)
-    {
-        pole = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
-        if (!isFishingPole(pole))
-            pole = nullptr;
-    }
-    if (!pole)
-    {
-        for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END && !pole; ++slot)
-        {
-            Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
-            if (isFishingPole(item))
-                pole = item;
-        }
-        for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END && !pole; ++bag)
-        {
-            Bag* pBag = (Bag*)bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag);
-            if (!pBag)
-                continue;
-            for (uint32 j = 0; j < pBag->GetBagSize() && !pole; ++j)
-            {
-                Item* item = pBag->GetItemByPos(j);
-                if (isFishingPole(item))
-                    pole = item;
-            }
-        }
-    }
-
-    if (!pole)
-    {
-        botAI->TellError("I don't have a fishing pole");
-        return false;
-    }
-
-    if (pole->GetSlot() != EQUIPMENT_SLOT_MAINHAND)
-    {
-        WorldPacket eqPacket(CMSG_AUTOEQUIP_ITEM_SLOT, 2);
-        eqPacket << pole->GetGUID() << uint8(EQUIPMENT_SLOT_MAINHAND);
-        bot->GetSession()->HandleAutoEquipItemSlotOpcode(eqPacket);
-    }
-
-    return botAI->CastSpell(FISHING_SPELL, bot);
+    return FishingAction(botAI).Execute(event);
 }

--- a/src/strategy/actions/FishWithMasterAction.cpp
+++ b/src/strategy/actions/FishWithMasterAction.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+#include "FishWithMasterAction.h"
+
+#include "Event.h"
+#include "Playerbots.h"
+
+static constexpr uint32 FISHING_SPELL = 7620;
+
+bool FishWithMasterAction::Execute(Event event)
+{
+    WorldPacket p(event.getPacket());
+    p.rpos(0);
+    uint8 castCount = 0, castFlags = 0;
+    uint32 spellId = 0;
+    p >> castCount >> spellId >> castFlags;
+
+    if (spellId != FISHING_SPELL)
+        return false;
+
+    auto isFishingPole = [](Item* item) -> bool
+    {
+        if (!item)
+            return false;
+        ItemTemplate const* proto = item->GetTemplate();
+        return proto && proto->Class == ITEM_CLASS_WEAPON && proto->SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE;
+    };
+
+    Item* pole = nullptr;
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END && !pole; ++slot)
+    {
+        pole = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (!isFishingPole(pole))
+            pole = nullptr;
+    }
+    if (!pole)
+    {
+        for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END && !pole; ++slot)
+        {
+            Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+            if (isFishingPole(item))
+                pole = item;
+        }
+        for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END && !pole; ++bag)
+        {
+            Bag* pBag = (Bag*)bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag);
+            if (!pBag)
+                continue;
+            for (uint32 j = 0; j < pBag->GetBagSize() && !pole; ++j)
+            {
+                Item* item = pBag->GetItemByPos(j);
+                if (isFishingPole(item))
+                    pole = item;
+            }
+        }
+    }
+
+    if (!pole)
+    {
+        botAI->TellError("I don't have a fishing pole");
+        return false;
+    }
+
+    if (pole->GetSlot() != EQUIPMENT_SLOT_MAINHAND)
+    {
+        WorldPacket eqPacket(CMSG_AUTOEQUIP_ITEM_SLOT, 2);
+        eqPacket << pole->GetGUID() << uint8(EQUIPMENT_SLOT_MAINHAND);
+        bot->GetSession()->HandleAutoEquipItemSlotOpcode(eqPacket);
+    }
+
+    return botAI->CastSpell(FISHING_SPELL, bot);
+}

--- a/src/strategy/actions/FishWithMasterAction.h
+++ b/src/strategy/actions/FishWithMasterAction.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_FISHWITHMASTERACTION_H
+#define _PLAYERBOT_FISHWITHMASTERACTION_H
+
+#include "Action.h"
+
+class PlayerbotAI;
+
+class FishWithMasterAction : public Action
+{
+public:
+    FishWithMasterAction(PlayerbotAI* botAI) : Action(botAI, "fish with master") {}
+
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/strategy/actions/FishWithMasterAction.h
+++ b/src/strategy/actions/FishWithMasterAction.h
@@ -6,7 +6,7 @@
 #ifndef _PLAYERBOT_FISHWITHMASTERACTION_H
 #define _PLAYERBOT_FISHWITHMASTERACTION_H
 
-#include "Action.h"
+#include "FishingAction.h"
 
 class PlayerbotAI;
 

--- a/src/strategy/actions/FishingAction.cpp
+++ b/src/strategy/actions/FishingAction.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */ 
+#include "FishingAction.h"
+#include "Event.h"
+#include "Playerbots.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+
+
+static constexpr uint32 FISHING_SPELL = 7620;
+
+WorldPosition FishingAction::FindWater(Player* bot, float distance)
+{
+    float x = bot->GetPositionX();
+    float y = bot->GetPositionY();
+    float z = bot->GetPositionZ();
+    uint32 mapId = bot->GetMapId();
+    for (float checkX = x - distance; checkX <= x + distance; checkX += 5.0f)
+    {
+        for (float checkY = y - distance; checkY <= y + distance; checkY += 5.0f)
+        {
+            if (mapId, checkX, checkY, z, DEFAULT_COLLISION_HEIGHT)
+                {
+                WorldPosition FishSpot = WorldPosition(checkX, checkY, z);   
+                return FishSpot;
+                }
+        }
+    }
+    return nullptr;
+};
+
+bool FishingAction::Execute(Event event)
+{
+    if (!AI_VALUE(bool, "can fish"))  // verify spell and fishing pole. Adds pole to Rndbot if missing.
+        return false;
+
+    if (qualifier == "travel")
+    {
+        TravelTarget* target = AI_VALUE(TravelTarget*, "travel target");
+
+        if (target->getStatus() != TravelStatus::TRAVEL_STATUS_TRAVEL)
+            return false;
+    }
+    WorldPosition FishSpot = FindWater(bot, 5.0f);
+    if (FishSpot)
+    {
+        bot->SetFacingTo(FishSpot);
+    }
+
+    else
+    {
+   //     botAI->RpgTaxiAction(FindWater(bot, 100.0f));
+        bot->SetFacingTo(FindWater(bot, 100.0f));
+    }
+
+    Item* pole = nullptr;
+    if (pole->GetSlot() != EQUIPMENT_SLOT_MAINHAND)
+    {
+        WorldPacket eqPacket(CMSG_AUTOEQUIP_ITEM_SLOT, 2);
+        eqPacket << pole->GetGUID() << uint8(EQUIPMENT_SLOT_MAINHAND);
+        bot->GetSession()->HandleAutoEquipItemSlotOpcode(eqPacket);
+    }
+
+    return botAI->CastSpell(FISHING_SPELL, bot);
+};
+
+bool UseFishingBobberAction::Execute(Event event)
+{
+    // Find the fishing bobber (fishing node) owned by the bot
+    GameObject* bobber = nullptr;
+    std::list<GameObject*> objects;
+    GuidVector gos = AI_VALUE(GuidVector, "nearest game objects");
+    for (ObjectGuid const guid : gos)
+    {
+        if (GameObject* go = botAI->GetGameObject(guid))
+            objects.push_back(go);
+    }
+
+    for (auto& obj : objects)
+    {
+        if (obj->GetEntry() != 35591)
+            continue;
+
+        if (obj->GetOwnerGUID() != bot->GetGUID())
+            continue;
+
+        if (obj->getLootState() != GO_READY)
+        {
+            time_t bobberActiveTime = obj->GetRespawnTime() - FISHING_BOBBER_READY_TIME;
+            if (bobberActiveTime > time(0))
+                botAI->SetNextCheckDelay((bobberActiveTime - time(0)) * IN_MILLISECONDS + 500);
+            else
+                botAI->SetNextCheckDelay(1000);
+            return true;
+        }
+
+        std::unique_ptr<WorldPacket> packet(new WorldPacket(CMSG_GAMEOBJ_USE));
+        *packet << obj->GetGUID();
+        bot->GetSession()->QueuePacket(packet.get());
+
+        return true;
+    }
+
+    return false;
+};

--- a/src/strategy/actions/FishingAction.h
+++ b/src/strategy/actions/FishingAction.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_FISHINGACTION_H
+#define _PLAYERBOT_FISHINGACTION_H
+
+#include "Action.h"
+#include "Event.h"
+#include "Playerbots.h"
+
+class PlayerbotAI;
+
+class FishingAction : public Action, public Qualified
+{
+public:
+    FishingAction(PlayerbotAI* botAI) : Action(botAI, "fishing action"){}
+    bool Execute(Event event) override;
+
+private:
+    WorldPosition FindWater(Player* bot, float distance = 5.0f);
+};
+
+class UseFishingBobberAction : public Action
+{
+public:
+    UseFishingBobberAction(PlayerbotAI* botAI) : Action(botAI, "use fishing bobber") {}
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/strategy/actions/WorldPacketActionContext.h
+++ b/src/strategy/actions/WorldPacketActionContext.h
@@ -41,6 +41,7 @@
 #include "UseMeetingStoneAction.h"
 #include "NamedObjectContext.h"
 #include "ReleaseSpiritAction.h"
+#include "FishWithMasterAction.h"
 
 class PlayerbotAI;
 
@@ -107,6 +108,7 @@ public:
         creators["lfg leave"] = &WorldPacketActionContext::lfg_leave;
         creators["lfg teleport"] = &WorldPacketActionContext::lfg_teleport;
         creators["see spell"] = &WorldPacketActionContext::see_spell;
+        creators["fish with master"] = &WorldPacketActionContext::fish_with_master;
         creators["arena team accept"] = &WorldPacketActionContext::arena_team_accept;
     }
 
@@ -171,6 +173,7 @@ private:
     static Action* lfg_role_check(PlayerbotAI* botAI) { return new LfgRoleCheckAction(botAI); }
     static Action* lfg_join(PlayerbotAI* botAI) { return new LfgJoinAction(botAI); }
     static Action* see_spell(PlayerbotAI* botAI) { return new SeeSpellAction(botAI); }
+    static Action* fish_with_master(PlayerbotAI* botAI) { return new FishWithMasterAction(botAI); }
     static Action* arena_team_accept(PlayerbotAI* botAI) { return new ArenaTeamAcceptAction(botAI); }
 };
 

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -59,7 +59,8 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     // triggers.push_back(new TriggerNode("group destroyed", NextAction::array(0, new NextAction("reset botAI",
     // relevance), nullptr)));
     triggers.push_back(new TriggerNode("group list", NextAction::array(0, new NextAction("reset botAI", relevance), nullptr)));
-    triggers.push_back(new TriggerNode("see spell", NextAction::array(0, new NextAction("see spell", relevance), nullptr)));
+    triggers.push_back(new TriggerNode("see spell", NextAction::array(0, new NextAction("see spell", relevance), new NextAction("fish with master", relevance), nullptr)));
+    
     triggers.push_back(new TriggerNode("release spirit", NextAction::array(0, new NextAction("release", relevance), nullptr)));
     triggers.push_back(new TriggerNode("revive from corpse", NextAction::array(0, new NextAction("revive from corpse", relevance), nullptr)));
     triggers.push_back(new TriggerNode("master loot roll", NextAction::array(0, new NextAction("master loot roll", relevance), nullptr)));

--- a/src/strategy/values/FishValues.h
+++ b/src/strategy/values/FishValues.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_FISHVALUES_H
+#define _PLAYERBOT_FISHVALUES_H
+
+#include "Value.h"
+#include "NamedObjectContext.h"
+
+
+class PlayerbotAI;
+
+class CanFishValue : public BoolCalculatedValue
+{
+    public:
+        CanFishValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "can fish", 1) {};
+        bool Calculate() override;
+};
+class CanOpenBobberValue : public BoolCalculatedValue
+    {
+    public:
+        CanOpenBobberValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "can open bobber") {};
+            bool Calculate() override;
+    };
+
+#endif


### PR DESCRIPTION
With @notOrrytrout I started working on enabling bot fishing with master, but also on their own. 
The first commit didnt crash, showing that it was possible to have a bot cast when master does. Currently it compiles but crashes when you try to fish with a bot in the group, whether the bot has fishing or not. It makes me think that the check in FishingValues is broken somehow, but I cant figure out how. 