### PR TITLE
Warlock Soul Shard Hotfix

### DIFF
--- a/src/strategy/warlock/WarlockActions.cpp
+++ b/src/strategy/warlock/WarlockActions.cpp
@@ -19,8 +19,8 @@
 #include <unordered_map>
 #include <mutex>
 
-// Checks if the bot has less than 32 soul shards, and if so, allows casting Drain Soul
-bool CastDrainSoulAction::isUseful() { return AI_VALUE2(uint32, "item count", "soul shard") < 32; }
+// Checks if the bot has less than 20 soul shards, and if so, allows casting Drain Soul
+bool CastDrainSoulAction::isUseful() { return AI_VALUE2(uint32, "item count", "soul shard") < 20; }
 
 // Checks if the bot's health is above a certain threshold, and if so, allows casting Life Tap
 bool CastLifeTapAction::isUseful() { return AI_VALUE2(uint8, "health", "self target") > sPlayerbotAIConfig->lowHealth; }
@@ -133,6 +133,20 @@ bool CreateSoulShardAction::Execute(Event event)
         return true;
     }
     return false;
+}
+
+// Checks if the bot has less than 6 soul shards, allowing the creation of a new one
+bool CreateSoulShardAction::isUseful()
+{
+    Player* bot = botAI->GetBot();
+    if (!bot)
+        return false;
+
+    uint32 soulShardId = 6265;
+    uint32 currentShards = bot->GetItemCount(soulShardId, false);  // false = only bags
+    const uint32 SHARD_CAP = 6;                                    // adjust as needed
+
+    return currentShards < SHARD_CAP;
 }
 
 

--- a/src/strategy/warlock/WarlockActions.h
+++ b/src/strategy/warlock/WarlockActions.h
@@ -46,6 +46,7 @@ class CreateSoulShardAction : public Action
 public:
     CreateSoulShardAction(PlayerbotAI* botAI) : Action(botAI, "create soul shard") {}
     bool Execute(Event event) override;
+    bool isUseful() override;
 };
 
 class DestroySoulShardAction : public InventoryAction


### PR DESCRIPTION
Hello everyone,

This PR is to address an issue that was posted recently - a player has shown that soul shards are being created in excess, spamming the player's chat log. I am adding an isuseful() check to the createsoulshard action, so it will never be executed if they have more than 5 soul shards.

Also, out of an abundance of caution, I am lowering the cap for CastDrainSoulAction::isUseful() to 20 from 32. That way, if for some reason the warlock has 20+ shards, it won't attempt to collect any more / use drain soul.