### PR TITLE
Add ability to configure bot level range for worldbuff strategy

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1521,43 +1521,48 @@ AiPlayerbot.PremadeSpecLink.11.6.80 = 05320021--230033312031500531353013251
 #
 #
 
-# Applies a permanent buff to all bots simulating effects of spells, flasks, food, runes, etc.
+# Applies a permanent buff to bots simulating effects of spells, flasks, food, runes, etc.
 # Requires sending the command "nc +worldbuff" in chat to a bot (or a group of bots) to enable
+
+# Minimum and maximum levels for bots that will apply buffs with the worldbuff strategy (enter 0 for no level limit)
+AiPlayerbot.WorldBuffMinLevel = 80
+AiPlayerbot.WorldBuffMaxLevel = 80
+
 # Numbers after the equal signs are spell IDs and may be customized
 # See Randombots Default Talent Specs for more info on each spec; they are listed in that section by the names in the parentheticals (e.g., arms pve, fury pve)
 
-AiPlayerbot.WorldBuff.0.1.0.80.80 = 53760,57358                    #WARRIOR ARMS (arms pve)
-AiPlayerbot.WorldBuff.0.1.1.80.80 = 53760,57358                    #WARRIOR FURY (fury pve)
-AiPlayerbot.WorldBuff.0.1.2.80.80 = 53758,57356                    #WARRIOR PROTECTION (prot pve)
-AiPlayerbot.WorldBuff.0.2.0.80.80 = 60347,53749,57332              #PALADIN HOLY (holy pve)
-AiPlayerbot.WorldBuff.0.2.1.80.80 = 53758,57356                    #PALADIN PROTECTION (prot pve)
-AiPlayerbot.WorldBuff.0.2.2.80.80 = 53760,57371                    #PALADIN RETRIBUTION (ret pve)
-AiPlayerbot.WorldBuff.0.3.0.80.80 = 53760,57325                    #HUNTER BEAST (bm pve)
-AiPlayerbot.WorldBuff.0.3.1.80.80 = 53760,57358                    #HUNTER MARKSMANSHIP (mm pve)
-AiPlayerbot.WorldBuff.0.3.2.80.80 = 53760,57367                    #HUNTER SURVIVAL (surv pve)
-AiPlayerbot.WorldBuff.0.4.0.80.80 = 53760,57325                    #ROGUE ASSASINATION (as pve)
-AiPlayerbot.WorldBuff.0.4.1.80.80 = 53760,57358                    #ROGUE COMBAT (combat pve)
-AiPlayerbot.WorldBuff.0.4.2.80.80 = 53760,57367                    #ROGUE SUBTLETY (subtlety pve)
-AiPlayerbot.WorldBuff.0.5.0.80.80 = 53755,57327                    #PRIEST DISCIPLINE (disc pve)
-AiPlayerbot.WorldBuff.0.5.1.80.80 = 53755,57327                    #PRIEST HOLY (holy pve)
-AiPlayerbot.WorldBuff.0.5.2.80.80 = 53755,57327                    #PRIEST SHADOW (shadow pve)
-AiPlayerbot.WorldBuff.0.6.0.80.80 = 53758,57356                    #DEATH KNIGHT BLOOD (blood pve)
-AiPlayerbot.WorldBuff.0.6.1.80.80 = 53760,57358                    #DEATH KNIGHT FROST (frost pve)
-AiPlayerbot.WorldBuff.0.6.2.80.80 = 53760,57358                    #DEATH KNIGHT UNHOLY (unholy pve)
-AiPlayerbot.WorldBuff.0.6.3.80.80 = 53760,57371                    #DEATH KNIGHT BLOOD DPS (double aura blood pve)
-AiPlayerbot.WorldBuff.0.7.0.80.80 = 53755,57327                    #SHAMAN ELEMENTAL (ele pve)
-AiPlayerbot.WorldBuff.0.7.1.80.80 = 53760,57325                    #SHAMAN ENHANCEMENT (enh pve)
-AiPlayerbot.WorldBuff.0.7.2.80.80 = 53755,57327                    #SHAMAN RESTORATION (resto pve)
-AiPlayerbot.WorldBuff.0.8.0.80.80 = 53755,57327                    #MAGE ARCANE (arcane pve)
-AiPlayerbot.WorldBuff.0.8.1.80.80 = 53755,57327                    #MAGE FIRE (fire pve)
-AiPlayerbot.WorldBuff.0.8.2.80.80 = 53755,57327                    #MAGE FROST (frost pve)
-AiPlayerbot.WorldBuff.0.9.0.80.80 = 53755,57327                    #WARLOCK AFFLICTION (affli pve)
-AiPlayerbot.WorldBuff.0.9.1.80.80 = 53755,57327                    #WARLOCK DEMONOLOGY (demo pve)
-AiPlayerbot.WorldBuff.0.9.2.80.80 = 53755,57327                    #WARLOCK DESTRUCTION (destro pve)
-AiPlayerbot.WorldBuff.0.11.0.80.80 = 53755,57327                   #DRUID BALANCE (balance pve)
-AiPlayerbot.WorldBuff.0.11.1.80.80 = 53749,53763,57367             #DRUID FERAL BEAR (bear pve)
-AiPlayerbot.WorldBuff.0.11.2.80.80 = 54212,57334                   #DRUID RESTORATION (resto pve)
-AiPlayerbot.WorldBuff.0.11.3.80.80 = 53760,57358                   #DRUID FERAL CAT (cat pve)
+AiPlayerbot.WorldBuff.1.0 = 53760,57358                    #WARRIOR ARMS (arms pve)
+AiPlayerbot.WorldBuff.1.1 = 53760,57358                    #WARRIOR FURY (fury pve)
+AiPlayerbot.WorldBuff.1.2 = 53758,57356                    #WARRIOR PROTECTION (prot pve)
+AiPlayerbot.WorldBuff.2.0 = 60347,53749,57332              #PALADIN HOLY (holy pve)
+AiPlayerbot.WorldBuff.2.1 = 53758,57356                    #PALADIN PROTECTION (prot pve)
+AiPlayerbot.WorldBuff.2.2 = 53760,57371                    #PALADIN RETRIBUTION (ret pve)
+AiPlayerbot.WorldBuff.3.0 = 53760,57325                    #HUNTER BEAST (bm pve)
+AiPlayerbot.WorldBuff.3.1 = 53760,57358                    #HUNTER MARKSMANSHIP (mm pve)
+AiPlayerbot.WorldBuff.3.2 = 53760,57367                    #HUNTER SURVIVAL (surv pve)
+AiPlayerbot.WorldBuff.4.0 = 53760,57325                    #ROGUE ASSASINATION (as pve)
+AiPlayerbot.WorldBuff.4.1 = 53760,57358                    #ROGUE COMBAT (combat pve)
+AiPlayerbot.WorldBuff.4.2 = 53760,57367                    #ROGUE SUBTLETY (subtlety pve)
+AiPlayerbot.WorldBuff.5.0 = 53755,57327                    #PRIEST DISCIPLINE (disc pve)
+AiPlayerbot.WorldBuff.5.1 = 53755,57327                    #PRIEST HOLY (holy pve)
+AiPlayerbot.WorldBuff.5.2 = 53755,57327                    #PRIEST SHADOW (shadow pve)
+AiPlayerbot.WorldBuff.6.0 = 53758,57356                    #DEATH KNIGHT BLOOD (blood pve)
+AiPlayerbot.WorldBuff.6.1 = 53760,57358                    #DEATH KNIGHT FROST (frost pve)
+AiPlayerbot.WorldBuff.6.2 = 53760,57358                    #DEATH KNIGHT UNHOLY (unholy pve)
+AiPlayerbot.WorldBuff.6.3 = 53760,57371                    #DEATH KNIGHT BLOOD DPS (double aura blood pve)
+AiPlayerbot.WorldBuff.7.0 = 53755,57327                    #SHAMAN ELEMENTAL (ele pve)
+AiPlayerbot.WorldBuff.7.1 = 53760,57325                    #SHAMAN ENHANCEMENT (enh pve)
+AiPlayerbot.WorldBuff.7.2 = 53755,57327                    #SHAMAN RESTORATION (resto pve)
+AiPlayerbot.WorldBuff.8.0 = 53755,57327                    #MAGE ARCANE (arcane pve)
+AiPlayerbot.WorldBuff.8.1 = 53755,57327                    #MAGE FIRE (fire pve)
+AiPlayerbot.WorldBuff.8.2 = 53755,57327                    #MAGE FROST (frost pve)
+AiPlayerbot.WorldBuff.9.0 = 53755,57327                    #WARLOCK AFFLICTION (affli pve)
+AiPlayerbot.WorldBuff.9.1 = 53755,57327                    #WARLOCK DEMONOLOGY (demo pve)
+AiPlayerbot.WorldBuff.9.2 = 53755,57327                    #WARLOCK DESTRUCTION (destro pve)
+AiPlayerbot.WorldBuff.11.0 = 53755,57327                   #DRUID BALANCE (balance pve)
+AiPlayerbot.WorldBuff.11.1 = 53749,53763,57367             #DRUID FERAL BEAR (bear pve)
+AiPlayerbot.WorldBuff.11.2 = 54212,57334                   #DRUID RESTORATION (resto pve)
+AiPlayerbot.WorldBuff.11.3 = 53760,57358                   #DRUID FERAL CAT (cat pve)
 
 #
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -471,23 +471,16 @@ bool PlayerbotAIConfig::Initialize()
     worldBuffs.clear();
 
     LOG_INFO("playerbots", "Loading Worldbuff...");
-    for (uint32 factionId = 0; factionId < 3; factionId++)
-    {
         for (uint32 classId = 0; classId < MAX_CLASSES; classId++)
         {
             for (uint32 specId = 0; specId <= MAX_WORLDBUFF_SPECNO; specId++)
             {
-                for (uint32 minLevel = 0; minLevel <= randomBotMaxLevel; minLevel++)
-                {
-                    for (uint32 maxLevel = minLevel; maxLevel <= randomBotMaxLevel; maxLevel++)
-                    {
-                        loadWorldBuff(factionId, classId, specId, minLevel, maxLevel);
-                    }
-                    loadWorldBuff(factionId, classId, specId, minLevel, 0);
-                }
+                loadWorldBuff(classId, specId);
             }
         }
-    }
+
+    WorldBuffMinLevel = sConfigMgr->GetOption<uint32>("AiPlayerbot.WorldBuffMinLevel", 80);
+    WorldBuffMaxLevel = sConfigMgr->GetOption<uint32>("AiPlayerbot.WorldBuffMaxLevel", 80);
 
     randomBotAccountPrefix = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotAccountPrefix", "rndbot");
     randomBotAccountCount = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotAccountCount", 0);
@@ -733,78 +726,36 @@ void PlayerbotAIConfig::log(std::string const fileName, char const* str, ...)
     fflush(stdout);
 }
 
-void PlayerbotAIConfig::loadWorldBuff(uint32 factionId1, uint32 classId1, uint32 specId1, uint32 minLevel1, uint32 maxLevel1)
+void PlayerbotAIConfig::loadWorldBuff(uint32 classId, uint32 specId)
 {
     std::vector<uint32> buffs;
 
     std::ostringstream os;
-    os << "AiPlayerbot.WorldBuff." << factionId1 << "." << classId1 << "." << specId1 << "." << minLevel1 << "." << maxLevel1;
+    os << "AiPlayerbot.WorldBuff." << classId << "." << specId;
 
     LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>(os.str().c_str(), "", false), buffs);
 
     for (auto buff : buffs)
     {
-        worldBuff wb = {buff, factionId1, classId1, specId1, minLevel1, maxLevel1};
+        worldBuff wb = {buff, classId, specId};
         worldBuffs.push_back(wb);
     }
 
-    if (maxLevel1 == 0)
+    if (specId == 0)
     {
         std::ostringstream os;
-        os << "AiPlayerbot.WorldBuff." << factionId1 << "." << classId1 << "." << specId1 << "." << minLevel1;
+        os << "AiPlayerbot.WorldBuff." << classId;
 
         LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>(os.str().c_str(), "", false), buffs);
 
         for (auto buff : buffs)
         {
-            worldBuff wb = {buff, factionId1, classId1, specId1, minLevel1, maxLevel1};
+            worldBuff wb = {buff, classId, specId};
             worldBuffs.push_back(wb);
         }
     }
 
-    if (maxLevel1 == 0 && minLevel1 == 0)
-    {
-        std::ostringstream os;
-        os << "AiPlayerbot.WorldBuff." << factionId1 << "." << factionId1 << "." << classId1 << "." << specId1;
-
-        LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>(os.str().c_str(), "", false), buffs);
-
-        for (auto buff : buffs)
-        {
-            worldBuff wb = {buff, factionId1, classId1, specId1, minLevel1, maxLevel1};
-            worldBuffs.push_back(wb);
-        }
-    }
-
-    if (maxLevel1 == 0 && minLevel1 == 0 && specId1 == 0)
-    {
-        std::ostringstream os;
-        os << "AiPlayerbot.WorldBuff." << factionId1 << "." << factionId1 << "." << classId1;
-
-        LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>(os.str().c_str(), "", false), buffs);
-
-        for (auto buff : buffs)
-        {
-            worldBuff wb = {buff, factionId1, classId1, specId1, minLevel1, maxLevel1};
-            worldBuffs.push_back(wb);
-        }
-    }
-
-    if (classId1 == 0 && maxLevel1 == 0 && minLevel1 == 0 && specId1 == 0)
-    {
-        std::ostringstream os;
-        os << "AiPlayerbot.WorldBuff." << factionId1;
-
-        LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>(os.str().c_str(), "", false), buffs);
-
-        for (auto buff : buffs)
-        {
-            worldBuff wb = {buff, factionId1, classId1, specId1, minLevel1, maxLevel1};
-            worldBuffs.push_back(wb);
-        }
-    }
-
-    if (factionId1 == 0 && classId1 == 0 && maxLevel1 == 0 && minLevel1 == 0 && specId1 == 0)
+    if (classId == 0 && specId == 0)
     {
         std::ostringstream os;
         os << "AiPlayerbot.WorldBuff";
@@ -813,7 +764,7 @@ void PlayerbotAIConfig::loadWorldBuff(uint32 factionId1, uint32 classId1, uint32
 
         for (auto buff : buffs)
         {
-            worldBuff wb = {buff, factionId1, classId1, specId1, minLevel1, maxLevel1};
+            worldBuff wb = {buff, classId, specId};
             worldBuffs.push_back(wb);
         }
     }

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -266,12 +266,12 @@ public:
     struct worldBuff
     {
         uint32 spellId;
-        uint32 factionId = 0;
-        uint32 classId = 0;
-        uint32 specId = 0;
-        uint32 minLevel = 0;
-        uint32 maxLevel = 0;
+        uint32 classId;
+        uint32 specId;
     };
+
+    uint32 WorldBuffMinLevel;
+    uint32 WorldBuffMaxLevel;
 
     std::vector<worldBuff> worldBuffs;
 
@@ -376,7 +376,8 @@ public:
     }
     void log(std::string const fileName, const char* str, ...);
 
-    void loadWorldBuff(uint32 factionId, uint32 classId, uint32 specId, uint32 minLevel, uint32 maxLevel);
+    void loadWorldBuff(uint32 classId, uint32 specId); 
+
     static std::vector<std::vector<uint32>> ParseTempTalentsOrder(uint32 cls, std::string temp_talents_order);
     static std::vector<std::vector<uint32>> ParseTempPetTalentsOrder(uint32 spec, std::string temp_talents_order);
 };


### PR DESCRIPTION
I've proposed some changes to allow setting a global minimum and maximum level in the config for bots that can apply worldbuffs with the nc +worldbuff strategy. I decided to implement it on a global basis instead of spec-by-spec or class-by-class because I don't see much use for levels to be tailored on such a granular level, and thus I thought a global setting would be preferable due to its user-friendliness. I also removed references to faction from the code and config because it didn't seem to be doing anything of value and also didn't seem worthwhile to adapt into a configurable feature like bot level.

I've kept the default minimum/maximum level at 80 and also kept the default spells the same as what existed before. My personal preference is to set default at 0 (so no level limitation) and then have no default spells, but I'd like to get some input on the approach there.

This is my first PR working with the code, and I have no programming experience, so feedback is very much welcome.