### PR TITLE
Warlock Soulstone/Soulshard hotfix

### DIFF
--- a/src/strategy/warlock/WarlockActions.cpp
+++ b/src/strategy/warlock/WarlockActions.cpp
@@ -116,6 +116,12 @@ bool CastSoulshatterAction::isUseful()
 // Checks if the bot has enough bag space to create a soul shard, then does so
 bool CreateSoulShardAction::Execute(Event event)
 {
+    uint32 now = getMSTime();
+
+    // 1000 ms = 1 second cooldown
+    if (now < lastCreateSoulShardTime + 1000)
+        return false;
+
     Player* bot = botAI->GetBot();
     if (!bot)
         return false;
@@ -130,6 +136,7 @@ bool CreateSoulShardAction::Execute(Event event)
         SQLTransaction<CharacterDatabaseConnection> trans = CharacterDatabase.BeginTransaction();
         bot->SaveInventoryAndGoldToDB(trans);
         CharacterDatabase.CommitTransaction(trans);
+        lastCreateSoulShardTime = now;  // update timer on successful creation
         return true;
     }
     return false;

--- a/src/strategy/warlock/WarlockActions.h
+++ b/src/strategy/warlock/WarlockActions.h
@@ -47,6 +47,8 @@ public:
     CreateSoulShardAction(PlayerbotAI* botAI) : Action(botAI, "create soul shard") {}
     bool Execute(Event event) override;
     bool isUseful() override;
+private:
+    uint32 lastCreateSoulShardTime = 0;  // Per-bot cooldown timer in ms
 };
 
 class DestroySoulShardAction : public InventoryAction

--- a/src/strategy/warlock/WarlockTriggers.h
+++ b/src/strategy/warlock/WarlockTriggers.h
@@ -72,8 +72,18 @@ public:
 
     bool IsActive() override
     {
-        // Just check if we have a soulstone item available
-        return AI_VALUE2(uint32, "item count", "soulstone") > 0;
+        static const std::vector<uint32> soulstoneSpellIds = {20707, 20762, 20763, 20764, 20765, 27239, 47883};
+
+        if (AI_VALUE2(uint32, "item count", "soulstone") == 0)
+            return false;
+
+        for (uint32 spellId : soulstoneSpellIds)
+        {
+            if (!bot->HasSpellCooldown(spellId))
+                return true;  // Ready to use
+        }
+
+        return false;  // All are on cooldown
     }
 };
 


### PR DESCRIPTION
Hello everybody,

This PR is to address issues #1439 and #1451.

I added a 1 second cooldown to the createsoulshard action, as the warlock can't realistically use more than 1 soul shard per second.

I also added a cooldown check to the soulstone trigger, so it doesn't simply try to use the ss healer, ss self, ss tank, or ss master actions if the soulstone is present in the inventory.  I checked the logs, and was able to recreate the issue of #1451 - the bot was shifting targets over and over again, and that was because previously the trigger was just checking to see if a soulstone was present at all. Now it won't fire if it's on cooldown.