### PR TITLE
Add /w botname "glyphs" and  "glyph equip" commands

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -39,6 +39,7 @@
 #include "SpellAuraDefines.h"
 #include "StatsWeightCalculator.h"
 #include "World.h"
+#include "AiObjectContext.h"
 
 const uint64 diveMask = (1LL << 7) | (1LL << 44) | (1LL << 37) | (1LL << 38) | (1LL << 26) | (1LL << 30) | (1LL << 27) |
                         (1LL << 33) | (1LL << 24) | (1LL << 34);
@@ -3330,6 +3331,9 @@ void PlayerbotFactory::InitReagents()
 void PlayerbotFactory::InitGlyphs(bool increment)
 {
     bot->InitGlyphsForLevel();
+    if (!increment &&
+        botAI->GetAiObjectContext()->GetValue<bool>("custom_glyphs")->Get())
+        return;   // // Added for custom Glyphs - custom glyphs flag test
 
     if (!increment)
     {

--- a/src/strategy/AiObjectContext.h
+++ b/src/strategy/AiObjectContext.h
@@ -27,6 +27,7 @@ typedef UntypedValue* (*ValueCreator)(PlayerbotAI* botAI);
 class AiObjectContext : public PlayerbotAIAware
 {
 public:
+    static BoolCalculatedValue* custom_glyphs(PlayerbotAI* ai); // Added for cutom glyphs
     AiObjectContext(PlayerbotAI* botAI,
                     SharedNamedObjectContextList<Strategy>& sharedStrategyContext = sharedStrategyContexts,
                     SharedNamedObjectContextList<Action>& sharedActionContext = sharedActionContexts,

--- a/src/strategy/actions/ChangeTalentsAction.cpp
+++ b/src/strategy/actions/ChangeTalentsAction.cpp
@@ -11,9 +11,18 @@
 #include "PlayerbotAIConfig.h"
 #include "PlayerbotFactory.h"
 #include "Playerbots.h"
+#include "AiObjectContext.h"
+#include "Log.h" 
 
 bool ChangeTalentsAction::Execute(Event event)
 {
+    auto* flag = botAI->GetAiObjectContext()->GetValue<bool>("custom_glyphs"); // Added for custom Glyphs
+
+    if (flag->Get()) // Added for custom Glyphs
+    {
+        flag->Set(false);
+        LOG_INFO("playerbots", "Custom Glyph Flag set to OFF");
+    }
     std::string param = event.getParam();
 
     std::ostringstream out;

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -79,6 +79,8 @@
 #include "UnlockItemAction.h"
 #include "UnlockTradedItemAction.h"
 #include "PetAction.h"
+#include "TellGlyphsAction.h"
+#include "EquipGlyphsAction.h"
 
 class ChatActionContext : public NamedObjectContext<Action>
 {
@@ -189,6 +191,8 @@ public:
         creators["calc"] = &ChatActionContext::calc;
         creators["wipe"] = &ChatActionContext::wipe;
         creators["pet"] = &ChatActionContext::pet;
+		creators["glyphs"] = &ChatActionContext::glyphs; // Added for custom Glyphs
+		creators["glyph equip"] = &ChatActionContext::glyph_equip; // Added for custom Glyphs
     }
 
 private:
@@ -296,6 +300,8 @@ private:
     static Action* calc(PlayerbotAI* ai) { return new TellCalculateItemAction(ai); }
     static Action* wipe(PlayerbotAI* ai) { return new WipeAction(ai); }
     static Action* pet(PlayerbotAI* botAI) { return new PetAction(botAI); }
+	static Action* glyphs(PlayerbotAI* botAI) { return new TellGlyphsAction(botAI); } // Added for custom Glyphs
+	static Action* glyph_equip(PlayerbotAI* ai) { return new EquipGlyphsAction(ai); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/actions/EquipGlyphsAction.cpp
+++ b/src/strategy/actions/EquipGlyphsAction.cpp
@@ -106,7 +106,7 @@ bool EquipGlyphsAction::Execute(Event event)
     std::vector<GlyphInfo const*> glyphs;
     if (!CollectGlyphs(itemIds, glyphs))
     {
-        botAI->TellMaster("glyph equip : liste invalide (IDs items glyphes de ta classe, max 6).");
+        botAI->TellMaster("Usage: glyph equip <6 glyph item IDs> (3 major, 3 minor).");
         return false;
     }
 

--- a/src/strategy/actions/EquipGlyphsAction.cpp
+++ b/src/strategy/actions/EquipGlyphsAction.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#include "EquipGlyphsAction.h"
+
+#include "Playerbots.h"
+#include "ObjectMgr.h"
+#include "SpellMgr.h"
+#include "DBCStores.h"
+#include "AiObjectContext.h"
+#include "Log.h"  
+
+#include <unordered_map>
+#include <sstream>
+#include <unordered_set>
+
+namespace
+{
+    // itemId -> GlyphInfo
+    std::unordered_map<uint32, EquipGlyphsAction::GlyphInfo> s_GlyphCache;
+}
+
+void EquipGlyphsAction::BuildGlyphCache()
+{
+    if (!s_GlyphCache.empty())
+        return;
+
+    ItemTemplateContainer const* store = sObjectMgr->GetItemTemplateStore();
+
+    for (auto const& kv : *store)
+    {
+        uint32 itemId = kv.first;
+        ItemTemplate const* proto = &kv.second;
+        if (!proto || proto->Class != ITEM_CLASS_GLYPH)
+            continue;
+
+        // inspect item spell
+        for (uint32 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+        {
+            uint32 spellId = proto->Spells[i].SpellId;
+            if (!spellId) continue;
+
+            SpellInfo const* si = sSpellMgr->GetSpellInfo(spellId);
+            if (!si)         continue;
+
+            for (uint8 eff = 0; eff <= EFFECT_2; ++eff)
+            {
+                if (si->Effects[eff].Effect != SPELL_EFFECT_APPLY_GLYPH)
+                    continue;
+
+                uint32 glyphId = si->Effects[eff].MiscValue;
+                if (!glyphId) continue;
+
+                if (auto const* gp = sGlyphPropertiesStore.LookupEntry(glyphId))
+                    s_GlyphCache[itemId] = {gp, proto};
+            }
+        }
+    }
+}
+
+EquipGlyphsAction::GlyphInfo const* EquipGlyphsAction::GetGlyphInfo(uint32 itemId)
+{
+    BuildGlyphCache();
+    auto it = s_GlyphCache.find(itemId);
+    return (it == s_GlyphCache.end()) ? nullptr : &it->second;
+}
+
+/// -----------------------------------------------------------------
+///  Validation and collect
+/// -----------------------------------------------------------------
+bool EquipGlyphsAction::CollectGlyphs(std::vector<uint32> const& itemIds,
+                                      std::vector<GlyphInfo const*>& out) const
+{
+    std::unordered_set<uint32> seen;
+
+    for (uint32 itemId : itemIds)
+    {
+        if (!seen.insert(itemId).second)
+            return false;                                 // double
+
+        auto const* info = GetGlyphInfo(itemId);
+        if (!info)                                        // no good glyph
+            return false;
+
+        // check class by AllowableClass
+        if ((info->proto->AllowableClass & bot->getClassMask()) == 0)
+            return false;
+
+        out.push_back(info);
+    }
+    return out.size() <= 6 && !out.empty();
+}
+
+/// -----------------------------------------------------------------
+///  Action
+/// -----------------------------------------------------------------
+bool EquipGlyphsAction::Execute(Event event)
+{
+    // 1) parse IDs
+    std::vector<uint32> itemIds;
+    std::istringstream iss(event.getParam());
+    for (uint32 id; iss >> id; ) itemIds.push_back(id);
+
+    std::vector<GlyphInfo const*> glyphs;
+    if (!CollectGlyphs(itemIds, glyphs))
+    {
+        botAI->TellMaster("glyph equip : liste invalide (IDs items glyphes de ta classe, max 6).");
+        return false;
+    }
+
+    // 2) prepare a empty slots table ?
+    bool used[6] = {false,false,false,false,false,false};
+
+    // 3) for each glyph, find the first available and compatible socket
+    for (auto const* g : glyphs)
+    {
+        bool placed = false;
+
+        for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
+        {
+            if (used[i]) continue;
+
+            uint32 slotId   = bot->GetGlyphSlot(i);
+            auto const* gs  = sGlyphSlotStore.LookupEntry(slotId);
+            if (!gs || gs->TypeFlags != g->prop->TypeFlags)
+                continue;                                   // major/minor don't match
+
+            // Remove aura if exist
+            uint32 cur = bot->GetGlyph(i);
+            if (cur)
+                if (auto* old = sGlyphPropertiesStore.LookupEntry(cur))
+                    bot->RemoveAurasDueToSpell(old->SpellId);
+
+            // Apply new one
+            bot->CastSpell(bot, g->prop->SpellId, true);
+            bot->SetGlyph(i, g->prop->Id, true);
+
+            used[i] = true;
+            placed  = true;
+            break;
+        }
+
+        if (!placed)
+        {
+            botAI->TellMaster("Not enought empty sockets for all glyphs.");
+            return false;
+        }
+    }
+
+    botAI->TellMaster("Glyphs updated.");
+
+	// Flag to custom glyphs
+    botAI->GetAiObjectContext()->GetValue<bool>("custom_glyphs")->Set(true);
+	LOG_INFO("playerbots", "Custom Glyph Flag set to ON");
+	
+    return true;
+}

--- a/src/strategy/actions/EquipGlyphsAction.cpp
+++ b/src/strategy/actions/EquipGlyphsAction.cpp
@@ -151,7 +151,7 @@ bool EquipGlyphsAction::Execute(Event event)
 
     botAI->TellMaster("Glyphs updated.");
 
-	// Flag to custom glyphs
+	// Flag for custom glyphs
     botAI->GetAiObjectContext()->GetValue<bool>("custom_glyphs")->Set(true);
 	LOG_INFO("playerbots", "Custom Glyph Flag set to ON");
 	

--- a/src/strategy/actions/EquipGlyphsAction.h
+++ b/src/strategy/actions/EquipGlyphsAction.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_EQUIPGLYPHSACTION_H
+#define _PLAYERBOT_EQUIPGLYPHSACTION_H
+
+#include "Action.h"
+
+// 1 = major, 2 = minor dans GlyphProperties.dbc
+enum class GlyphKind : uint32 { MAJOR = 1, MINOR = 2 };
+
+class EquipGlyphsAction : public Action
+{
+public:
+    EquipGlyphsAction(PlayerbotAI* ai) : Action(ai, "glyph equip") {}
+    bool Execute(Event event) override;
+
+    /// ---- Rendu public pour être utilisable par le cache global ----
+    struct GlyphInfo
+    {
+        GlyphPropertiesEntry const* prop;   ///< entrée GlyphProperties.dbc
+        ItemTemplate const*         proto;  ///< template de l’objet glyphe
+    };
+
+private:
+    /// Construit la cache {itemId -> GlyphInfo}
+    static void BuildGlyphCache();
+    static GlyphInfo const* GetGlyphInfo(uint32 itemId);
+
+    /// Parse & valide la liste d’items glyphes
+    bool CollectGlyphs(std::vector<uint32> const& itemIds,
+                       std::vector<GlyphInfo const*>& out) const;
+};
+
+#endif

--- a/src/strategy/actions/TellGlyphsAction.cpp
+++ b/src/strategy/actions/TellGlyphsAction.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#include "TellGlyphsAction.h"
+
+#include "Event.h"
+#include "Playerbots.h"
+
+#include "ObjectMgr.h"
+#include "SpellMgr.h"
+#include "World.h"
+
+#include <unordered_map>
+#include <sstream>
+
+namespace
+{
+    // -----------------------------------------------------------------
+    // Cache : GlyphID (MiscValue) -> ItemTemplate*
+    // -----------------------------------------------------------------
+    std::unordered_map<uint32, ItemTemplate const*> s_GlyphItemCache;
+
+    void BuildGlyphItemCache()
+    {
+        if (!s_GlyphItemCache.empty())
+            return;
+
+        ItemTemplateContainer const* store = sObjectMgr->GetItemTemplateStore();
+
+        for (auto const& kv : *store)                       // C++17 : range-for sur map
+        {
+            ItemTemplate const* proto = &kv.second;
+
+            if (!proto || proto->Class != ITEM_CLASS_GLYPH)
+                continue;
+
+            for (uint32 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+            {
+                uint32 spellId = proto->Spells[i].SpellId;
+                if (!spellId)
+                    continue;
+
+                SpellInfo const* spell = sSpellMgr->GetSpellInfo(spellId);
+                if (!spell)
+                    continue;
+
+                for (uint32 eff = 0; eff <= EFFECT_2; ++eff)
+                {
+                    if (spell->Effects[eff].Effect != SPELL_EFFECT_APPLY_GLYPH)
+                        continue;
+
+                    uint32 glyphId = spell->Effects[eff].MiscValue;
+                    if (glyphId)
+                        s_GlyphItemCache[glyphId] = proto;
+                }
+            }
+        }
+    }
+} // namespace
+
+// -----------------------------------------------------------------
+// Action
+// -----------------------------------------------------------------
+bool TellGlyphsAction::Execute(Event event)
+{
+    //-----------------------------------------------------------------
+    // 1. who sended the wisp ?  (source of event)
+    //-----------------------------------------------------------------
+    Player* sender = event.getOwner();          // API Event
+    if (!sender)
+        return false;
+
+    //-----------------------------------------------------------------
+    // 2. Generate glyphId cache -> item
+    //-----------------------------------------------------------------
+    BuildGlyphItemCache();
+
+    //-----------------------------------------------------------------
+    // 3. Look at the 6 glyphs sockets
+    //-----------------------------------------------------------------
+    std::ostringstream list;
+    bool first = true;
+
+    for (uint8 slot = 0; slot < MAX_GLYPH_SLOT_INDEX; ++slot)
+    {
+        uint32 glyphId = bot->GetGlyph(slot);
+        if (!glyphId)
+            continue;
+
+        auto it = s_GlyphItemCache.find(glyphId);
+        if (it == s_GlyphItemCache.end())
+            continue;                                // No glyph found (rare)
+
+        if (!first)
+            list << ", ";
+
+        // chat->FormatItem
+        list << chat->FormatItem(it->second);
+        first = false;
+    }
+
+    //-----------------------------------------------------------------
+    // 4. Send chat messages
+    //-----------------------------------------------------------------
+    if (first)                                       // no glyphs
+        botAI->TellMaster("No glyphs equipped");
+    else
+        botAI->TellMaster(std::string("Glyphs: ") + list.str());
+
+    return true;
+}

--- a/src/strategy/actions/TellGlyphsAction.h
+++ b/src/strategy/actions/TellGlyphsAction.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_TELLGLYPHSACTION_H
+#define _PLAYERBOT_TELLGLYPHSACTION_H
+
+#include "Action.h"
+
+class TellGlyphsAction : public Action
+{
+public:
+    TellGlyphsAction(PlayerbotAI* ai, std::string const name = "glyphs")
+        : Action(ai, name) {}
+
+    bool Execute(Event event) override;
+};
+
+#endif
+

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -104,7 +104,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
     triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
-    triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
+triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -104,7 +104,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
     triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
- triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
+  triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -104,7 +104,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
     triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
-	triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
+    triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)
@@ -185,6 +185,6 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("unlock items");
     supported.push_back("unlock traded item");
     supported.push_back("pet");
-	supported.push_back("glyphs"); // Added for custom Glyphs
-	supported.push_back("glyph equip"); // Added for custom Glyphs
+    supported.push_back("glyphs"); // Added for custom Glyphs
+    supported.push_back("glyph equip"); // Added for custom Glyphs
 }

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -104,7 +104,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
     triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
-  triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
+   triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -104,7 +104,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
     triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
-triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
+ triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -104,7 +104,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
     triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
-   triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
+    triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)

--- a/src/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -103,6 +103,8 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     triggers.push_back(
         new TriggerNode("wipe", NextAction::array(0, new NextAction("wipe", relevance), nullptr)));
     triggers.push_back(new TriggerNode("pet", NextAction::array(0, new NextAction("pet", relevance), nullptr)));
+    triggers.push_back(new TriggerNode("glyphs", NextAction::array(0, new NextAction("glyphs", relevance), nullptr))); // Added for custom Glyphs
+	triggers.push_back(new TriggerNode("glyph equip", NextAction::array(0, new NextAction("glyph equip", relevance), nullptr))); // Added for custom Glyphs
 }
 
 ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : PassTroughStrategy(botAI)
@@ -183,4 +185,6 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("unlock items");
     supported.push_back("unlock traded item");
     supported.push_back("pet");
+	supported.push_back("glyphs"); // Added for custom Glyphs
+	supported.push_back("glyph equip"); // Added for custom Glyphs
 }

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -249,8 +249,8 @@ private:
     static Trigger* qi(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "qi"); }
     static Trigger* wipe(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "wipe"); }
     static Trigger* pet(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "pet"); }
-  static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
-  static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
+   static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
+   static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -249,8 +249,8 @@ private:
     static Trigger* qi(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "qi"); }
     static Trigger* wipe(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "wipe"); }
     static Trigger* pet(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "pet"); }
-	static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
-	static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
+static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
+static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -134,8 +134,8 @@ public:
         creators["qi"] = &ChatTriggerContext::qi;
         creators["wipe"] = &ChatTriggerContext::wipe;
         creators["pet"] = &ChatTriggerContext::pet;
-		creators["glyphs"] = &ChatTriggerContext::glyphs; // Added for custom Glyphs
-		creators["glyph equip"] = &ChatTriggerContext::glyph_equip; // Added for custom Glyphs
+        creators["glyphs"] = &ChatTriggerContext::glyphs; // Added for custom Glyphs
+        creators["glyph equip"] = &ChatTriggerContext::glyph_equip; // Added for custom Glyphs
     }
 
 private:

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -134,6 +134,8 @@ public:
         creators["qi"] = &ChatTriggerContext::qi;
         creators["wipe"] = &ChatTriggerContext::wipe;
         creators["pet"] = &ChatTriggerContext::pet;
+		creators["glyphs"] = &ChatTriggerContext::glyphs; // Added for custom Glyphs
+		creators["glyph equip"] = &ChatTriggerContext::glyph_equip; // Added for custom Glyphs
     }
 
 private:
@@ -247,6 +249,8 @@ private:
     static Trigger* qi(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "qi"); }
     static Trigger* wipe(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "wipe"); }
     static Trigger* pet(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "pet"); }
+	static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
+	static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -249,8 +249,8 @@ private:
     static Trigger* qi(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "qi"); }
     static Trigger* wipe(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "wipe"); }
     static Trigger* pet(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "pet"); }
-   static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
-   static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
+    static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
+    static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -249,8 +249,8 @@ private:
     static Trigger* qi(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "qi"); }
     static Trigger* wipe(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "wipe"); }
     static Trigger* pet(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "pet"); }
- static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
- static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
+  static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
+  static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/triggers/ChatTriggerContext.h
+++ b/src/strategy/triggers/ChatTriggerContext.h
@@ -249,8 +249,8 @@ private:
     static Trigger* qi(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "qi"); }
     static Trigger* wipe(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "wipe"); }
     static Trigger* pet(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "pet"); }
-static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
-static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
+ static Trigger* glyphs(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "glyphs"); } // Added for custom Glyphs
+ static Trigger* glyph_equip(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "glyph equip"); } // Added for custom Glyphs
 };
 
 #endif

--- a/src/strategy/values/ValueContext.h
+++ b/src/strategy/values/ValueContext.h
@@ -160,6 +160,7 @@ public:
         creators["my attacker count"] = &ValueContext::my_attacker_count;
         creators["has aggro"] = &ValueContext::has_aggro;
         creators["mounted"] = &ValueContext::mounted;
+		creators["custom_glyphs"] = &ValueContext::custom_glyphs;   // Added for custom glyphs
 
         creators["can loot"] = &ValueContext::can_loot;
         creators["loot target"] = &ValueContext::loot_target;
@@ -554,6 +555,13 @@ private:
     static UntypedValue* last_flee_angle(PlayerbotAI* ai) { return new LastFleeAngleValue(ai); }
     static UntypedValue* last_flee_timestamp(PlayerbotAI* ai) { return new LastFleeTimestampValue(ai); }
     static UntypedValue* recently_flee_info(PlayerbotAI* ai) { return new RecentlyFleeInfo(ai); }
+	// -------------------------------------------------------
+    // Flag for cutom glyphs : true when /w bot glyph equip …
+    // -------------------------------------------------------
+    static UntypedValue* custom_glyphs(PlayerbotAI* ai)
+    {
+        return new ManualSetValue<bool>(ai, false, "custom_glyphs");
+    }
 };
 
 #endif


### PR DESCRIPTION
Description:
This PR enhances Playerbots with two new chat commands and a persistence workflow for custom glyph sets:

`/w glyphs`

Lists the bot’s currently equipped glyphs in the client locale, using item links for proper translations.

Implements TellGlyphsAction and wiring in ChatTriggerContext / ChatActionContext.

`/w glyph equip GlyphID1 GlyphID2 GlyphID3 GlyphID4 GlyphID5 GlyphID6`

Accepts up to 6 glyph item IDs (any order), auto-splits into 3 majors & 3 minors, checks duplicates and class/race requirements.

Applies each glyph’s aura and saves it via bot->SetGlyph(...).

Persistent custom glyph set

On successful glyph equip, sets an AI flag custom_glyphs = true.

On server restart or relog, if all 6 slots are occupied and custom_glyphs == true, skips applying the preset from playerbot.conf.

Whispering glyph equip again overwrites the set and re-sets the flag.

Auto-reapply on spec change

ChangeTalentsAction clears custom_glyphs before applying a new spec.

PlayerbotFactory::InitGlyphs(false) now early-exits only when custom_glyphs == true, otherwise applies the preset glyphs for the new spec.

Debug logging

INFO-level logs when the flag toggles ON/OFF and prints equipped item IDs.

Implementation Details:

New Actions:

TellGlyphsAction in src/strategy/actions/TellGlyphsAction.*

EquipGlyphsAction in src/strategy/actions/EquipGlyphsAction.*

Chat Wiring:

Added triggers & creators for "glyphs" and "glyph equip" in ChatTriggerContext.h, ChatActionContext.h, and ChatCommandHandlerStrategy.cpp.

AI Value:

Registered custom_glyphs in ValueContext as a ManualSetValue (default false).

Factory Change:

PlayerbotFactory::InitGlyphs now checks custom_glyphs via ai->GetAiObjectContext() and skips preset if true.

Spec Change Hook:

ChangeTalentsAction clears the custom_glyphs flag before switching specs.


Testing Guide:

List Equipped Glyphs :

/w glyphs
→ Bot replies with localized, colored glyph names.

Equip Custom Glyphs :

/w glyph equip 40913 43331 40906 43335 43674 45623
→ Bot applies glyphs, replies “Glyphs updated.”, and console logs IDs + “Flag set to ON”.

Persistence :

Relog or server restart → custom glyphs remain if all slots filled.

Spec Change :

/w talents spec healpve
→ Bot logs “Flag set to OFF” once, then applies preset glyphs for the new spec.

Notes:

Backward-compatible: bots that don’t use glyph equip continue using presets from playerbot.conf.

No changes to existing talent or gear workflows.

Please review and let me know of any feedback or adjustments!

Here is an example of the implementation I made with this change in the MultiBot addon (i'me waiting from this merge to make the PR).

<img width="771" height="754" alt="image" src="https://github.com/user-attachments/assets/d00c1821-e7ce-4494-a994-c9b77a40f840" />

<img width="1217" height="954" alt="image" src="https://github.com/user-attachments/assets/cbb9c0a5-a909-4c84-8b61-52ba89b6ce43" />

<img width="785" height="748" alt="image" src="https://github.com/user-attachments/assets/32242085-6a11-45a5-80e6-3a3053b28cb0" />

BOT Level 15 Two slots:
<img width="1191" height="745" alt="image" src="https://github.com/user-attachments/assets/78990893-8316-4a69-aa59-557cca8db872" />

BOT Level 30 Three Slots:
<img width="1188" height="797" alt="image" src="https://github.com/user-attachments/assets/91aeeac7-bc95-421f-ba7f-50ef4f06b013" />

BOT Level 50 Four Slots:
<img width="1198" height="794" alt="image" src="https://github.com/user-attachments/assets/7545bc90-5af2-4ec9-b03e-56406ab94ed4" />

BOT Level 70 Five Slots:
<img width="1180" height="755" alt="image" src="https://github.com/user-attachments/assets/20191a67-61bb-49b3-a81b-920585b83ffc" />

BOT Level 80 Six Slots:
<img width="1225" height="702" alt="image" src="https://github.com/user-attachments/assets/35a15204-751a-46ab-bb95-bb1d37a3d655" />
 
<img width="788" height="758" alt="image" src="https://github.com/user-attachments/assets/8d43fd1b-5cbf-495f-a042-48c844a9da1c" />

And a Custom talents interface too:

<img width="720" height="760" alt="image" src="https://github.com/user-attachments/assets/8496eb3f-db12-489d-946d-d08e32b48902" />
