### PR TITLE
Adds triggers for low/medium/high mana and health

### DIFF
--- a/src/strategy/generic/UseFoodStrategy.cpp
+++ b/src/strategy/generic/UseFoodStrategy.cpp
@@ -11,13 +11,25 @@
 void UseFoodStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     Strategy::InitTriggers(triggers);
-    if (sPlayerbotAIConfig->freeFood)
-        triggers.push_back(new TriggerNode("medium health", NextAction::array(0, new NextAction("food", 3.0f), nullptr)));
-    else
-        triggers.push_back(new TriggerNode("low health", NextAction::array(0, new NextAction("food", 3.0f), nullptr)));
 
     if (sPlayerbotAIConfig->freeFood)
-        triggers.push_back(new TriggerNode("high mana", NextAction::array(0, new NextAction("drink", 3.0f), nullptr)));
+    {
+        triggers.push_back(new TriggerNode("high health", NextAction::array(0, new NextAction("food", 1.0f), nullptr)));
+        triggers.push_back(new TriggerNode("medium health", NextAction::array(0, new NextAction("food", 3.0f), nullptr)));
+        triggers.push_back(new TriggerNode("low health", NextAction::array(0, new NextAction("food", 5.0f), nullptr)));
+
+        triggers.push_back(new TriggerNode("high mana", NextAction::array(0, new NextAction("drink", 1.0f), nullptr)));
+        triggers.push_back(new TriggerNode("medium mana", NextAction::array(0, new NextAction("drink", 3.0f), nullptr)));
+        triggers.push_back(new TriggerNode("low mana", NextAction::array(0, new NextAction("drink", 5.0f), nullptr)));
+    }
     else
-        triggers.push_back(new TriggerNode("low mana", NextAction::array(0, new NextAction("drink", 3.0f), nullptr)));
+    {
+        triggers.push_back(new TriggerNode("low health", NextAction::array(0, new NextAction("food", 5.0f), nullptr)));
+        triggers.push_back(new TriggerNode("medium health", NextAction::array(0, new NextAction("food", 3.0f), nullptr)));
+        triggers.push_back(new TriggerNode("high health", NextAction::array(0, new NextAction("food", 1.0f), nullptr)));
+
+        triggers.push_back(new TriggerNode("low mana", NextAction::array(0, new NextAction("drink", 5.0f), nullptr)));
+        triggers.push_back(new TriggerNode("medium mana", NextAction::array(0, new NextAction("drink", 3.0f), nullptr)));
+        triggers.push_back(new TriggerNode("high mana", NextAction::array(0, new NextAction("drink", 1.0f), nullptr)));
+    }
 }


### PR DESCRIPTION
Previously, bots only used food/drink under very specific conditions, ignoring common scenarios like being at 50% mana. Now, bots can: Use food at low, medium, and high health, with different priorities. Use drinks at low, medium, and high mana, with different priorities. This change ensures more intelligent and reactive behavior outside of combat, covering a wider range of situations, especially when the bot is between 40–80% mana or health.

Closes https://github.com/liyunfan1223/mod-playerbots/issues/1457