### PR TITLE
Improve Arena Bot Behavior When Target is Behind Obstacles

### DIFF
--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -26,7 +26,7 @@
 #include "Playerbots.h"
 #include "PositionValue.h"
 #include "PvpTriggers.h"
-#include "PathFinder.h"
+#include "PathGenerator.h"
 #include "ServerFacade.h"
 #include "Vehicle.h"
 
@@ -4167,7 +4167,7 @@ bool ArenaTactics::Execute(Event event)
     Unit* target = bot->GetVictim();
     if (target && (!bot->IsWithinLOSInMap(target) || fabs(bot->GetPositionZ() - target->GetPositionZ()) > 5.0f))
     {
-        PathFinder path(bot);
+        PathGenerator path(bot);
         path.CalculatePath(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), false);
 
         if (path.IsValid() && path.GetPathType() != PATHFIND_NOPATH)

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -26,6 +26,7 @@
 #include "Playerbots.h"
 #include "PositionValue.h"
 #include "PvpTriggers.h"
+#include "PathFinder.h"
 #include "ServerFacade.h"
 #include "Vehicle.h"
 

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4172,7 +4172,7 @@ bool ArenaTactics::Execute(Event event)
             if (path.GetPathType() != PATHFIND_NOPATH)
             {
                 // If you are casting a spell and lost your target due to LoS, interrupt the cast and move
-                if (bot->IsNonMeleeSpellCasted(false, true, true))
+                if (bot->IsNonMeleeSpellCast(false, true, true, false, true))
                     bot->InterruptNonMeleeSpells(true);
 
                 float x, y, z;

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4152,7 +4152,6 @@ bool ArenaTactics::Execute(Event event)
     if (bot->isMoving())
         return false;
 
-
     // startup phase
     if (bg->GetStartDelayTime() > 0)
         return false;
@@ -4163,12 +4162,15 @@ bool ArenaTactics::Execute(Event event)
     if (botAI->HasStrategy("buff", BOT_STATE_NON_COMBAT))
         botAI->ChangeStrategy("-buff", BOT_STATE_NON_COMBAT);
 
-    // this causes bot to reset constantly in arena
-    //    if (sBattlegroundMgr->IsArenaType(bg->GetBgTypeID()))
-    //    {
-    //        botAI->ResetStrategies(false);
-    //        botAI->SetMaster(nullptr);
-    //    }
+    // Repositioning if the target is out of line of sight
+    Unit* target = botAI->GetCombatTarget();
+    if (target && !bot->IsWithinLOSInMap(target))
+    {
+        float x, y, z;
+        target->GetPosition(x, y, z);
+        botAI->TellMasterNoFacing("Repositioning to exit LoS");
+        return MoveTo(target->GetMapId(), x + frand(-1, +1), y + frand(-1, +1), z, false, true);
+    }
 
     if (!bot->IsInCombat())
         return moveToCenter(bg);

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4164,12 +4164,18 @@ bool ArenaTactics::Execute(Event event)
 
     // Repositioning if the target is out of line of sight
     Unit* target = bot->GetVictim();
-    if (target && !bot->IsWithinLOSInMap(target))
+    if (target && (!bot->IsWithinLOSInMap(target) || fabs(bot->GetPositionZ() - target->GetPositionZ()) > 5.0f))
     {
-        float x, y, z;
-        target->GetPosition(x, y, z);
-        botAI->TellMasterNoFacing("Repositioning to exit LoS");
-        return MoveTo(target->GetMapId(), x + frand(-1, +1), y + frand(-1, +1), z, false, true);
+        PathFinder path(bot);
+        path.CalculatePath(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), false);
+
+        if (path.IsValid() && path.GetPathType() != PATHFIND_NOPATH)
+        {
+            float x, y, z;
+            target->GetPosition(x, y, z);
+            botAI->TellMasterNoFacing("Repositioning to exit LoS or Height");
+            return MoveTo(target->GetMapId(), x + frand(-1, +1), y + frand(-1, +1), z, false, true);
+        }
     }
 
     if (!bot->IsInCombat())

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4150,6 +4150,10 @@ bool ArenaTactics::Execute(Event event)
     if (bot->isDead())
         return false;
 
+    if (bot->isMoving())
+        return false;
+
+    // startup phase
     if (bg->GetStartDelayTime() > 0)
         return false;
 
@@ -4177,7 +4181,7 @@ bool ArenaTactics::Execute(Event event)
 
                 float x, y, z;
                 target->GetPosition(x, y, z);
-                botAI->TellMasterNoFacing("Repositioning to regain LoS");
+                botAI->TellMasterNoFacing("Repositioning to exit the LoS target!");
                 return MoveTo(target->GetMapId(), x + frand(-1, +1), y + frand(-1, +1), z, false, true);
             }
         }

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4163,7 +4163,7 @@ bool ArenaTactics::Execute(Event event)
         botAI->ChangeStrategy("-buff", BOT_STATE_NON_COMBAT);
 
     // Repositioning if the target is out of line of sight
-    Unit* target = botAI->GetAiObject<Unit>("current target");
+    Unit* target = bot->GetVictim();
     if (target && !bot->IsWithinLOSInMap(target))
     {
         float x, y, z;

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4170,7 +4170,7 @@ bool ArenaTactics::Execute(Event event)
         PathGenerator path(bot);
         path.CalculatePath(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), false);
 
-        if (path.IsValid() && path.GetPathType() != PATHFIND_NOPATH)
+        if (path.GetPathType() != PATHFIND_NOPATH)
         {
             float x, y, z;
             target->GetPosition(x, y, z);

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4163,7 +4163,7 @@ bool ArenaTactics::Execute(Event event)
         botAI->ChangeStrategy("-buff", BOT_STATE_NON_COMBAT);
 
     // Repositioning if the target is out of line of sight
-    Unit* target = botAI->GetCombatTarget();
+    Unit* target = botAI->GetAiObject<Unit>("current target");
     if (target && !bot->IsWithinLOSInMap(target))
     {
         float x, y, z;


### PR DESCRIPTION
This update enhances bot behavior in arena scenarios by addressing the issue where bots remain idle if their target moves behind line-of-sight (LoS obstacles). The bot now attempts to reposition near the target to regain LoS instead of standing still, preventing situations where enemies can recover without pressure.

Could someone test it?