### PR TITLE
Add config to disable hunters from generating specified pet families

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -699,6 +699,10 @@ AiPlayerbot.AutoUpgradeEquip = 1
 # Default: 0 (disabled)
 AiPlayerbot.HunterWolfPet = 0
 
+# Prohibit hunter bots from creating pets with any family ID listed below in ExcludedHunterPetFamilies
+# See the creature_family database table for all pet families by ID (note: ID for spiders is 3)
+AiPlayerbot.ExcludedHunterPetFamilies = ""
+
 #
 #
 #

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -667,7 +667,7 @@ AiPlayerbot.IncrementalGearInit = 1
 AiPlayerbot.MinEnchantingBotLevel = 60
 
 # Enable expansion limitation for bot enchants
-# If enabled, bots will not use TBC enchants until level 61 or WotLK enchanges until level 71
+# If enabled, bots will not use TBC enchants until level 61 or WotLK enchants until level 71
 # Default: 1 (enabled)
 AiPlayerbot.LimitEnchantExpansion = 1
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -630,6 +630,9 @@ bool PlayerbotAIConfig::Initialize()
         sPlayerbotDungeonSuggestionMgr->LoadDungeonSuggestions();
     }
 
+    excludedHunterPetFamilies.clear();
+    LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.ExcludedHunterPetFamilies", ""), excludedHunterPetFamilies);
+
     LOG_INFO("server.loading", "---------------------------------------");
     LOG_INFO("server.loading", "        AI Playerbots initialized       ");
     LOG_INFO("server.loading", "---------------------------------------");

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -406,6 +406,8 @@ public:
     bool restrictHealerDPS = false;
     std::vector<uint32> restrictedHealerDPSMaps;
     bool IsRestrictedHealerDPSMap(uint32 mapId) const;
+
+    std::vector<uint32> excludedHunterPetFamilies;
 };
 
 #define sPlayerbotAIConfig PlayerbotAIConfig::instance()

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -828,6 +828,7 @@ void PlayerbotFactory::InitPet()
         std::vector<uint32> ids;
 
         CreatureTemplateContainer const* creatures = sObjectMgr->GetCreatureTemplates();
+
         for (CreatureTemplateContainer::const_iterator itr = creatures->begin(); itr != creatures->end(); ++itr)
         {
             if (!itr->second.IsTameable(bot->CanTameExoticPets()))
@@ -841,6 +842,12 @@ void PlayerbotFactory::InitPet()
                              bot->GetLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL));
             // Wolf only (for higher dps)
             if (onlyWolf && itr->second.family != CREATURE_FAMILY_WOLF)
+                continue;
+
+            // Exclude configured pet families
+            if (std::find(sPlayerbotAIConfig->excludedHunterPetFamilies.begin(),
+                          sPlayerbotAIConfig->excludedHunterPetFamilies.end(),
+                          itr->second.family) != sPlayerbotAIConfig->excludedHunterPetFamilies.end())
                 continue;
 
             ids.push_back(itr->first);


### PR DESCRIPTION
This PR lets you add into the config any number of IDs from CreatureFamily.dbc to exclude any families of pets from the InitPet function. Essentially it should prevent randombots from generating pets from excluded families and also prevents excluded families from being generated via the maintenance command.

This was inspired by a personal desire to eliminate spiders, and it was very hard to resist having spiders excluded by default.