### PR TITLE
Allow random bots to unlock achievements (not realm firsts)

### DIFF
--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -197,21 +197,13 @@ public:
         sRandomPlayerbotMgr->HandleCommand(type, msg, player);
     }
 
-    bool OnPlayerBeforeCriteriaProgress(Player* player, AchievementCriteriaEntry const* /*criteria*/) override
+    bool OnPlayerBeforeAchievementComplete(Player* player, AchievementEntry const* achievement) override
     {
-        if (sRandomPlayerbotMgr->IsRandomBot(player))
+        if (sRandomPlayerbotMgr->IsRandomBot(player) && (achievement->flags == 256 || achievement->flags == 768))
         {
             return false;
         }
-        return true;
-    }
 
-    bool OnPlayerBeforeAchievementComplete(Player* player, AchievementEntry const* /*achievement*/) override
-    {
-        if (sRandomPlayerbotMgr->IsRandomBot(player))
-        {
-            return false;
-        }
         return true;
     }
 


### PR DESCRIPTION
- Removed OnPlayerBeforeCriteriaProgress since it isn't needed.
- Changed OnPlayerBeforeAchievementComplete to allow random bots to unlock all achievements except realm first