### PR TITLE
Add optional gender parameter to .playerbot bot addclass command

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -36,6 +36,8 @@
 #include "BroadcastHelper.h"
 #include "PlayerbotDbStore.h"
 #include "WorldSessionMgr.h"
+#include "DatabaseEnv.h"        // Added for gender choice
+#include <algorithm>            // Added for gender choice
 
 class BotInitGuard
 {
@@ -837,6 +839,18 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
     return "unknown command";
 }
 
+// Added for gender choice : Returns the gender of an offline character: 0 = male, 1 = female.
+static uint8 GetOfflinePlayerGender(ObjectGuid guid)
+{
+    QueryResult result = CharacterDatabase.Query(
+        "SELECT gender FROM characters WHERE guid = {}", guid.GetCounter());
+
+    if (result)
+        return (*result)[0].Get<uint8>();       // 0 = male, 1 = female
+
+    return GENDER_MALE;                         // fallback value
+}
+
 bool PlayerbotMgr::HandlePlayerbotMgrCommand(ChatHandler* handler, char const* args)
 {
     if (!sPlayerbotAIConfig->enabled)
@@ -879,15 +893,17 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
     if (!*args)
     {
         messages.push_back("usage: list/reload/tweak/self or add/addaccount/init/remove PLAYERNAME\n");
-        messages.push_back("usage: addclass CLASSNAME");
+        messages.push_back("usage: addclass CLASSNAME [male|female|0|1]");
         return messages;
     }
 
     char* cmd = strtok((char*)args, " ");
     char* charname = strtok(nullptr, " ");
+    char* genderArg = strtok(nullptr, " ");    // Added for gender choice [male|female|0|1] optionnel
+
     if (!cmd)
     {
-        messages.push_back("usage: list/reload/tweak/self or add/init/remove PLAYERNAME or addclass CLASSNAME");
+        messages.push_back("usage: list/reload/tweak/self or add/init/remove PLAYERNAME or addclass CLASSNAME [male|female]");
         return messages;
     }
 
@@ -1110,6 +1126,24 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             messages.push_back("Error: Invalid Class. Try again.");
             return messages;
         }
+        //  Added for gender choice : Parsing gender
+        int8 gender = -1; // -1 = gender will be random
+        if (genderArg)
+        {
+        	std::string g = genderArg;
+        	std::transform(g.begin(), g.end(), g.begin(), ::tolower);
+        
+        	if (g == "male" || g == "0")
+        		gender = GENDER_MALE; // 0
+        	else if (g == "female" || g == "1")
+        		gender = GENDER_FEMALE; // 1
+        	else
+        	{
+        		messages.push_back("Unknown gender : " + g + " (male/female/0/1)");
+        		return messages;
+        	}
+        } //end
+
         if (claz == 6 && master->GetLevel() < sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL))
         {
             messages.push_back("Your level is too low to summon Deathknight");
@@ -1119,6 +1153,9 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
         const std::unordered_set<ObjectGuid> &guidCache = sRandomPlayerbotMgr->addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(teamId == TEAM_ALLIANCE, claz)];
         for (const ObjectGuid &guid: guidCache)
         {
+            // If the user requested a specific gender, skip any character that doesn't match.
+            if (gender != -1 && GetOfflinePlayerGender(guid) != gender)
+                continue;			
             if (botLoading.find(guid) != botLoading.end())
                 continue;
             if (ObjectAccessor::FindConnectedPlayer(guid))


### PR DESCRIPTION
### PR Description
This is a small quality-of-life improvement that adds support for an optional gender parameter (male/female) when using the .playerbot bot addclass command.

While not a major change, it's a fun and immersive addition for roleplayers or anyone who wants to control the gender of bots they summon.

**Usage examples:**
```
.playerbot bot addclass warlock female/male
.playerbot bot addclass warrior 0       # 0 = male, 1 = female
.playerbot bot addclass mage            # still random if omitted
```

If it's merged i add that to Multibot Addon

If no gender is specified, the behavior remains unchanged (randomly chosen).