### PR TITLE
Don't apply XPRate multiplier when bot is in group with real player

### DIFF
--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -221,7 +221,7 @@ public:
         if (Group* group = player->GetGroup())
         {
             Player* leader = group->GetLeader();
-            if (leader != player)
+            if (leader && leader != player)
             {
                 if (PlayerbotAI* leaderBotAI = GET_PLAYERBOT_AI(leader))
                 {

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -227,10 +227,10 @@ public:
             Player* leader = group->GetLeader();
             if (leader != player)
             {
-                if (!player->GetSession()->IsBot())
+                if (!leader->GetSession()->IsBot())
                     return;
         
-                if (!sRandomPlayerbotMgr->IsRandomBot(player))
+                if (!sRandomPlayerbotMgr->IsRandomBot(leader))
                     return;
             }
         }

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -215,6 +215,20 @@ public:
         if (!sRandomPlayerbotMgr->IsRandomBot(player))
             return;
 
+        // if player in group check leader is real player.
+        if (Group* group = player->GetGroup())
+        {
+            Player* leader = group->GetLeader();
+            if (leader != player)
+            {
+                if (!player->GetSession()->IsBot())
+                    return;
+        
+                if (!sRandomPlayerbotMgr->IsRandomBot(player))
+                    return;
+            }
+        }
+
         if (sPlayerbotAIConfig->randomBotXPRate != 1.0)
         {
             amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->randomBotXPRate));

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -209,13 +209,19 @@ public:
 
     void OnPlayerGiveXP(Player* player, uint32& amount, Unit* /*victim*/, uint8 /*xpSource*/) override
     {
+        // when default no XP scaling.
+        if (sPlayerbotAIConfig->randomBotXPRate == 1.0)
+            return;
+
+        // when player is no bot.
         if (!player->GetSession()->IsBot())
             return;
-        
+
+        // when player is no bot, double check.
         if (!sRandomPlayerbotMgr->IsRandomBot(player))
             return;
 
-        // if player in group check leader is real player.
+        // when bot has group where leader is a real player.
         if (Group* group = player->GetGroup())
         {
             Player* leader = group->GetLeader();
@@ -229,10 +235,8 @@ public:
             }
         }
 
-        if (sPlayerbotAIConfig->randomBotXPRate != 1.0)
-        {
-            amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->randomBotXPRate));
-        }
+        // otherwise apply bot XP scaling.
+        amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->randomBotXPRate));
     }
 };
 

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -213,29 +213,25 @@ public:
         if (sPlayerbotAIConfig->randomBotXPRate == 1.0 || !player)
             return;
 
-        // when player is no bot.
-        if (!player->GetSession()->IsBot())
+        // no XP multiplier, when player is no bot.
+        if (!player->GetSession()->IsBot() || !sRandomPlayerbotMgr->IsRandomBot(player))
             return;
 
-        // when player is no bot, double check.
-        if (!sRandomPlayerbotMgr->IsRandomBot(player))
-            return;
-
-        // when bot has group where leader is a real player.
+        // no XP multiplier, when bot has group where leader is a real player.
         if (Group* group = player->GetGroup())
         {
             Player* leader = group->GetLeader();
             if (leader != player)
             {
-                if (!leader->GetSession()->IsBot())
-                    return;
-        
-                if (!sRandomPlayerbotMgr->IsRandomBot(leader))
-                    return;
+                if (PlayerbotAI* leaderBotAI = GET_PLAYERBOT_AI(leader))
+                {
+                    if (leaderBotAI->HasRealPlayerMaster())
+                        return;
+                }
             }
         }
 
-        // otherwise apply bot XP scaling.
+        // otherwise apply bot XP multiplier.
         amount = static_cast<uint32>(std::round(static_cast<float>(amount) * sPlayerbotAIConfig->randomBotXPRate));
     }
 };

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -209,8 +209,8 @@ public:
 
     void OnPlayerGiveXP(Player* player, uint32& amount, Unit* /*victim*/, uint8 /*xpSource*/) override
     {
-        // when default no XP scaling.
-        if (sPlayerbotAIConfig->randomBotXPRate == 1.0)
+        // early return
+        if (sPlayerbotAIConfig->randomBotXPRate == 1.0 || !player)
             return;
 
         // when player is no bot.


### PR DESCRIPTION
No XP rate multiplier for bots when in group with real player.  Depending on the outcome of the tests, considering adding additional XP rate multiplier config setting for bot in groups with real player(s). In theory an additional custom multiplier should not be needed though.

additionally optimized the code path; cheap condition/checks first, expensive last.

See request: https://github.com/liyunfan1223/mod-playerbots/issues/1490

Expecting that the issue creator to test the change, until that time keeping the PR on draft.

