### PR TITLE
Warlock Dismount Pet Fix

### DIFF
--- a/src/strategy/warlock/WarlockTriggers.cpp
+++ b/src/strategy/warlock/WarlockTriggers.cpp
@@ -207,7 +207,11 @@ bool WrongPetTrigger::IsActive()
     if (enabledCount != 1)
         return false;
 
-    // Step 3: At this point, we know only one pet strategy is enabled.
+    // Step 3: If there is no pet, do not trigger.
+    if (!pet)
+        return false;
+
+    // Step 4: At this point, we know only one pet strategy is enabled.
     //         We check if the currently summoned pet matches the enabled strategy.
     bool correctPet = false;
     if (pet)
@@ -218,16 +222,16 @@ bool WrongPetTrigger::IsActive()
             correctPet = true;
     }
 
-    // Step 4: If the correct pet is already summoned, the trigger should not activate.
+    // Step 5: If the correct pet is already summoned, the trigger should not activate.
     if (correctPet)
         return false;
 
-    // Step 5: Finally, check if the bot actually knows the spell to summon the desired pet.
+    // Step 6: Finally, check if the bot actually knows the spell to summon the desired pet.
     //         If so, the trigger is active (bot should summon the correct pet).
     if (bot->HasSpell(enabledPet->spellId))
         return true;
 
-    // Step 6: If we get here, the bot doesn't know the spell required to support the active pet strategy
+    // Step 7: If we get here, the bot doesn't know the spell required to support the active pet strategy
     return false;
 }
 


### PR DESCRIPTION
Hello everyone,

This PR is to address #1489, where the warlock summons a pet when they dismount.

A tester found that the cause was the "wrong pet" triggering "summon (pet)". I looked into the "wrong pet" trigger, and noticed that there was not a clause if there was no active pet. It was inadvertently casting "summon (pet)" because for a brief second after dismounting, the warlock didn't technically have a pet.

I was able to recreate the issue based on tester feedback (dismounting with a warlock bot that has a pet). I tested this fix locally - it seems to work as intended. The warlock no longer attempts to summon a pet when dismounting. I tested it with nc +debug, and noticed that the "wrong pet" trigger was no longer firing. I also checked the logs - nothing.

Thank y'all for the testing and feedback!