### PR TITLE
Warlock Automatic Shards / Drain Soul Execute options

### DIFF
--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -612,7 +612,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
             {
                 nonCombatEngine->addStrategiesNoInit("imp", "firestone", nullptr);
             }
-            nonCombatEngine->addStrategiesNoInit("dps assist", "ss self", nullptr);
+            nonCombatEngine->addStrategiesNoInit("dps assist", "ss self", "auto shards", nullptr);
             break;
         case CLASS_DEATH_KNIGHT:
             if (tab == 0)

--- a/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
+++ b/src/strategy/warlock/GenericWarlockNonCombatStrategy.cpp
@@ -80,8 +80,6 @@ void GenericWarlockNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& tr
     NonCombatStrategy::InitTriggers(triggers);
     triggers.push_back(new TriggerNode("has pet", NextAction::array(0, new NextAction("toggle pet spell", 60.0f), nullptr)));
     triggers.push_back(new TriggerNode("no pet", NextAction::array(0, new NextAction("fel domination", 30.0f), nullptr)));
-    triggers.push_back(new TriggerNode("no soul shard", NextAction::array(0, new NextAction("create soul shard", 60.0f), nullptr)));
-    triggers.push_back(new TriggerNode("too many soul shards", NextAction::array(0, new NextAction("destroy soul shard", 60.0f), nullptr)));
     triggers.push_back(new TriggerNode("soul link", NextAction::array(0, new NextAction("soul link", 28.0f), nullptr)));
     triggers.push_back(new TriggerNode("demon armor", NextAction::array(0, new NextAction("fel armor", 27.0f), nullptr)));
     triggers.push_back(new TriggerNode("no healthstone", NextAction::array(0, new NextAction("create healthstone", 26.0f), nullptr)));
@@ -215,4 +213,16 @@ void UseFirestoneStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("no firestone", NextAction::array(0, new NextAction("create firestone", 24.0f), nullptr)));
     triggers.push_back(new TriggerNode("firestone", NextAction::array(0, new NextAction("firestone", 24.0f), nullptr)));
+}
+
+// Non-combat strategy for the automatic creation of soul shards
+// Enabled by default
+// To enable, type "nc +auto shards"
+// To disable, type "nc -auto shards"
+AutomaticSoulShardsStrategy::AutomaticSoulShardsStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
+
+void AutomaticSoulShardsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("no soul shard", NextAction::array(0, new NextAction("create soul shard", 60.0f), nullptr)));
+    triggers.push_back(new TriggerNode("too many soul shards", NextAction::array(0, new NextAction("destroy soul shard", 60.0f), nullptr)));
 }

--- a/src/strategy/warlock/GenericWarlockNonCombatStrategy.h
+++ b/src/strategy/warlock/GenericWarlockNonCombatStrategy.h
@@ -129,4 +129,14 @@ public:
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
 };
 
+class AutomaticSoulShardsStrategy : public NonCombatStrategy
+{
+public:
+    AutomaticSoulShardsStrategy(PlayerbotAI* ai);
+    virtual std::string const getName() override { return "auto shards"; }
+
+public:
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+};
+
 #endif

--- a/src/strategy/warlock/GenericWarlockStrategy.cpp
+++ b/src/strategy/warlock/GenericWarlockStrategy.cpp
@@ -41,8 +41,6 @@ void GenericWarlockStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("low mana", NextAction::array(0, new NextAction("life tap", 95.0f), nullptr)));
     triggers.push_back(new TriggerNode("medium threat", NextAction::array(0, new NextAction("soulshatter", 55.0f), nullptr)));
     triggers.push_back(new TriggerNode("spell lock", NextAction::array(0, new NextAction("spell lock", 40.0f), nullptr)));
-    triggers.push_back(new TriggerNode("no soul shard", NextAction::array(0, new NextAction("create soul shard", 60.0f), nullptr)));
-    triggers.push_back(new TriggerNode("too many soul shards", NextAction::array(0, new NextAction("destroy soul shard", 60.0f), nullptr)));
     triggers.push_back(new TriggerNode("devour magic purge", NextAction::array(0, new NextAction("devour magic purge", 50.0f), nullptr)));
     triggers.push_back(new TriggerNode("devour magic cleanse", NextAction::array(0, new NextAction("devour magic cleanse", 50.0f), nullptr)));
 }
@@ -132,4 +130,13 @@ void WarlockCurseOfTonguesStrategy::InitTriggers(std::vector<TriggerNode*>& trig
 void WarlockCurseOfWeaknessStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("curse of weakness", NextAction::array(0, new NextAction("curse of weakness", 29.0f), nullptr)));
+}
+
+// Combat strategy for using drain soul as an execute for all warlock specs
+// Disabled by default
+// To enable, type "co +drain soul"
+// To disable, type "co -drain soul"
+void WarlockDrainSoulStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("target low health", NextAction::array(0, new NextAction("drain soul", 29.5f), nullptr)));
 }

--- a/src/strategy/warlock/GenericWarlockStrategy.h
+++ b/src/strategy/warlock/GenericWarlockStrategy.h
@@ -111,4 +111,13 @@ public:
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
 };
 
+class WarlockDrainSoulStrategy : public Strategy
+{
+public:
+    WarlockDrainSoulStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    std::string const getName() override { return "drain soul"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+};
+
 #endif

--- a/src/strategy/warlock/WarlockActions.cpp
+++ b/src/strategy/warlock/WarlockActions.cpp
@@ -21,8 +21,8 @@
 
 const int ITEM_SOUL_SHARD = 6265;
 
-// Checks if the bot has less than 20 soul shards, and if so, allows casting Drain Soul
-bool CastDrainSoulAction::isUseful() { return AI_VALUE2(uint32, "item count", "soul shard") < 20; }
+// Checks if the bot has less than 26 soul shards, and if so, allows casting Drain Soul
+bool CastDrainSoulAction::isUseful() { return AI_VALUE2(uint32, "item count", "soul shard") < 26; }
 
 // Checks if the bot's health is above a certain threshold, and if so, allows casting Life Tap
 bool CastLifeTapAction::isUseful() { return AI_VALUE2(uint8, "health", "self target") > sPlayerbotAIConfig->lowHealth; }

--- a/src/strategy/warlock/WarlockAiObjectContext.cpp
+++ b/src/strategy/warlock/WarlockAiObjectContext.cpp
@@ -29,11 +29,11 @@ public:
         creators["boost"] = &WarlockStrategyFactoryInternal::boost;
         creators["cc"] = &WarlockStrategyFactoryInternal::cc;
         creators["pet"] = &WarlockStrategyFactoryInternal::pet;
-        creators["spellstone"] = &WarlockStrategyFactoryInternal::spellstone;
-        creators["firestone"] = &WarlockStrategyFactoryInternal::firestone;
         creators["meta melee"] = &WarlockStrategyFactoryInternal::meta_melee_aoe;
         creators["tank"] = &WarlockStrategyFactoryInternal::tank;
         creators["aoe"] = &WarlockStrategyFactoryInternal::aoe;
+        creators["auto shards"] = &WarlockStrategyFactoryInternal::auto_shards;
+        creators["drain soul"] = &WarlockStrategyFactoryInternal::drain_soul;
     }
 
 private:
@@ -42,11 +42,11 @@ private:
     static Strategy* boost(PlayerbotAI* botAI) { return new WarlockBoostStrategy(botAI); }
     static Strategy* cc(PlayerbotAI* botAI) { return new WarlockCcStrategy(botAI); }
     static Strategy* pet(PlayerbotAI* botAI) { return new WarlockPetStrategy(botAI); }
-    static Strategy* spellstone(PlayerbotAI* botAI) { return new UseSpellstoneStrategy(botAI); }
-    static Strategy* firestone(PlayerbotAI* botAI) { return new UseFirestoneStrategy(botAI); }
     static Strategy* meta_melee_aoe(PlayerbotAI* botAI) { return new MetaMeleeAoeStrategy(botAI); }
     static Strategy* tank(PlayerbotAI* botAI) { return new TankWarlockStrategy(botAI); }
     static Strategy* aoe(PlayerbotAI* botAI) { return new AoEWarlockStrategy(botAI); }
+    static Strategy* auto_shards(PlayerbotAI* botAI) { return new AutomaticSoulShardsStrategy(botAI); }
+    static Strategy* drain_soul(PlayerbotAI* botAI) { return new WarlockDrainSoulStrategy(botAI); }
 };
 
 class WarlockCombatStrategyFactoryInternal : public NamedObjectContext<Strategy>
@@ -123,6 +123,20 @@ private:
     static Strategy* curse_of_exhaustion(PlayerbotAI* botAI) { return new WarlockCurseOfExhaustionStrategy(botAI); }
     static Strategy* curse_of_tongues(PlayerbotAI* botAI) { return new WarlockCurseOfTonguesStrategy(botAI); }
     static Strategy* curse_of_weakness(PlayerbotAI* botAI) { return new WarlockCurseOfWeaknessStrategy(botAI); }
+};
+
+class WarlockWeaponStoneStrategyFactoryInternal : public NamedObjectContext<Strategy>
+{
+public:
+    WarlockWeaponStoneStrategyFactoryInternal() : NamedObjectContext<Strategy>(false, true)
+    {
+        creators["firestone"] = &WarlockWeaponStoneStrategyFactoryInternal::firestone;
+        creators["spellstone"] = &WarlockWeaponStoneStrategyFactoryInternal::spellstone;
+    }
+
+private:
+    static Strategy* firestone(PlayerbotAI* ai) { return new UseFirestoneStrategy(ai); }
+    static Strategy* spellstone(PlayerbotAI* ai) { return new UseSpellstoneStrategy(ai); }
 };
 
 class WarlockTriggerFactoryInternal : public NamedObjectContext<Trigger>
@@ -333,19 +347,13 @@ private:
     static Action* devour_magic_purge(PlayerbotAI* botAI) { return new CastDevourMagicPurgeAction(botAI); }
     static Action* devour_magic_cleanse(PlayerbotAI* botAI) { return new CastDevourMagicCleanseAction(botAI); }
     static Action* seed_of_corruption(PlayerbotAI* botAI) { return new CastSeedOfCorruptionAction(botAI); }
-    static Action* seed_of_corruption_on_attacker(PlayerbotAI* botAI)
-    {
-        return new CastSeedOfCorruptionOnAttackerAction(botAI);
-    }
+    static Action* seed_of_corruption_on_attacker(PlayerbotAI* botAI) { return new CastSeedOfCorruptionOnAttackerAction(botAI); }
     static Action* rain_of_fire(PlayerbotAI* botAI) { return new CastRainOfFireAction(botAI); }
     static Action* hellfire(PlayerbotAI* botAI) { return new CastHellfireAction(botAI); }
     static Action* shadowfury(PlayerbotAI* botAI) { return new CastShadowfuryAction(botAI); }
     static Action* life_tap(PlayerbotAI* botAI) { return new CastLifeTapAction(botAI); }
     static Action* unstable_affliction(PlayerbotAI* ai) { return new CastUnstableAfflictionAction(ai); }
-    static Action* unstable_affliction_on_attacker(PlayerbotAI* ai)
-    {
-        return new CastUnstableAfflictionOnAttackerAction(ai);
-    }
+    static Action* unstable_affliction_on_attacker(PlayerbotAI* ai) { return new CastUnstableAfflictionOnAttackerAction(ai); }
     static Action* haunt(PlayerbotAI* ai) { return new CastHauntAction(ai); }
     static Action* demonic_empowerment(PlayerbotAI* ai) { return new CastDemonicEmpowermentAction(ai); }
     static Action* metamorphosis(PlayerbotAI* ai) { return new CastMetamorphosisAction(ai); }
@@ -360,10 +368,7 @@ private:
     static Action* searing_pain(PlayerbotAI* botAI) { return new CastSearingPainAction(botAI); }
     static Action* shadow_ward(PlayerbotAI* botAI) { return new CastShadowWardAction(botAI); }
     static Action* curse_of_agony(PlayerbotAI* botAI) { return new CastCurseOfAgonyAction(botAI); }
-    static Action* curse_of_agony_on_attacker(PlayerbotAI* botAI)
-    {
-        return new CastCurseOfAgonyOnAttackerAction(botAI);
-    }
+    static Action* curse_of_agony_on_attacker(PlayerbotAI* botAI) { return new CastCurseOfAgonyOnAttackerAction(botAI); }
     static Action* curse_of_the_elements(PlayerbotAI* ai) { return new CastCurseOfTheElementsAction(ai); }
     static Action* curse_of_doom(PlayerbotAI* ai) { return new CastCurseOfDoomAction(ai); }
     static Action* curse_of_exhaustion(PlayerbotAI* ai) { return new CastCurseOfExhaustionAction(ai); }
@@ -397,6 +402,7 @@ void WarlockAiObjectContext::BuildSharedStrategyContexts(SharedNamedObjectContex
     strategyContexts.Add(new WarlockPetStrategyFactoryInternal());
     strategyContexts.Add(new WarlockSoulstoneStrategyFactoryInternal());
     strategyContexts.Add(new WarlockCurseStrategyFactoryInternal());
+    strategyContexts.Add(new WarlockWeaponStoneStrategyFactoryInternal());
 }
 
 void WarlockAiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Action>& actionContexts)


### PR DESCRIPTION
Hello everyone,

This PR is to address #1502 . Now you will be able to decide if you want both rndbots and altbots to automatically manage their soul shards (make 1 if at 0, delete 1 if more than 5) OR use drain soul as an execute while building up a stockpile (up to around 26 shards).

1. Added an "auto shards" non-combat strategy that is enabled by default for both rndbots and altbots. It does what they were doing before - automatically supplies them with soul shards without the use of drain soul. To remove this on either altbots or rndbots alone, go to your configs, and in the strategy section, add "nc -auto shards" to this: AiPlayerbot.NonCombatStrategies = ""

and add "co +drain soul" to this:
AiPlayerbot.RandomBotCombatStrategies = "+dps,+dps assist,-threat"

2. Changed the firestone and spellstone to an either or strategy - now you can only have 1 at a time.

**Remember to use both "reset botAI" for your altbots in party chat, and "playerbot rndbot refresh" in the worldserver console to apply these strategies!**