### PR TITLE
[Fix issue  #1517] Harden playerbot logout & packet dispatch; add null-safety in chat hooks and RPG checks

### DIFF
--- a/src/BroadcastHelper.cpp
+++ b/src/BroadcastHelper.cpp
@@ -947,8 +947,21 @@ bool BroadcastHelper::BroadcastSuggestThunderfury(PlayerbotAI* ai, Player* bot)
     {
         std::map<std::string, std::string> placeholders;
         ItemTemplate const* thunderfuryProto = sObjectMgr->GetItemTemplate(19019);
-        placeholders["%thunderfury_link"] = GET_PLAYERBOT_AI(bot)->GetChatHelper()->FormatItem(thunderfuryProto);
-
+        // placeholders["%thunderfury_link"] = GET_PLAYERBOT_AI(bot)->GetChatHelper()->FormatItem(thunderfuryProto); // Old code
+		// [Crash fix] Protect from nil AI : a real player doesn't have PlayerbotAI.
+        // Before: direct deref GET_PLAYERBOT_AI(bot)->... could crash World/General.
+        if (auto* ai = GET_PLAYERBOT_AI(bot))
+        {
+	        if (auto* chat = ai->GetChatHelper())
+		        placeholders["%thunderfury_link"] = chat->FormatItem(thunderfuryProto);
+	        else
+		        placeholders["%thunderfury_link"] = ""; // fallback: no chat helper
+        }
+        else
+        {
+	        placeholders["%thunderfury_link"] = "";     // fallback: no d'AI (real player)
+        }
+        // End crash fix
         return BroadcastToChannelWithGlobalChance(
             ai,
             BOT_TEXT2("thunderfury_spam", placeholders),

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -2373,7 +2373,7 @@ std::string PlayerbotAI::GetLocalizedGameObjectName(uint32 entry)
     return name;
 }
 
-std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
+/*std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
 {
     std::vector<Player*> members;
 
@@ -2390,6 +2390,34 @@ std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
             continue;
 
         members.push_back(ref->GetSource());
+    }
+
+    return members;
+}*/
+
+std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
+{
+    std::vector<Player*> members;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return members;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member)
+            continue;
+
+        // Celaning, we don't call 2 times GET_PLAYERBOT_AI and never reference it if nil
+        if (auto* ai = GET_PLAYERBOT_AI(member))
+        {
+            // If it's a bot (not real player) => we ignor it
+            if (!ai->IsRealPlayer())
+                continue;
+        }
+
+        members.push_back(member);
     }
 
     return members;


### PR DESCRIPTION
### Harden playerbot logout & packet dispatch; add null-safety in chat hooks and RPG checks
### Summary
This PR fixes a handful of crash paths and UB by:

- guarding client opcode dispatch against missing handlers,
- hardening the bot logout flow (including instant-logout and safe cleanup),
- avoiding null dereferences in chat hooks,
- guarding RPG destination checks against missing AI/context/faction data.

Collectively, these changes remove several avenues for access violations and double-frees observed during heavy bot activity.

### Why
I’ve seen crashes in two main areas:

1. Incoming packet handling sometimes tried to call a null ClientOpcodeHandler (e.g., unknown/disabled opcode in the queue).
Fix: skip such packets safely.
2. The logout path could dereference or delete objects after they were already destroyed by the core (racey LogoutRequest vs. bot/session lifetime), and pointer-typed AI context values (like “travel target”) weren’t consistently cleared.
Fix: centralize pointer cleanup and make the logout flow defensive. 

I also had some sporadic null derefs around chat event hooks and RPG destination checks.
Fix: add straightforward null guards.

### What changed

**1. Safe opcode dispatch for bot sessions**

- In PlayerbotHolder::HandleBotPackets, we now guard the lookup and drop packets with no handler:

```
const ClientOpcodeHandler* opHandle = opcodeTable[opcode];
if (!opHandle) { delete packet; continue; }
opHandle->Call(session, *packet);
```
This prevents a call through a null function pointer.

**2. Safer logout flow + centralized AI pointer cleanup**

- Introduced a small helper to clear pointer-typed values in the AI context (currently clears "travel target"), and call it from the logout/disable paths.
This avoids dangling pointers that could be read during/after logout. 

- In LogoutPlayerBot:

- Defensive grabs of session pointers and null checks,
- Unified “instant logout” path (we force logout = true for stability while investigating),
- After sending LogoutRequest, if the bot is already gone, we stop touching the old Player and only remove it from the holder & delete the session safely,
- Removed manual deletion of travel targets (ownership is handled by AI/context now).

- In DisablePlayerBot, we likewise rely on the centralized cleanup instead of deleting ad-hoc pointers.

**3. Null-safety in chat hooks**

- OnPlayerCanUseChat: ensure receiver is non-null before GET_PLAYERBOT_AI(receiver).
- OnPlayerChat(Player*, ..., Group*): guard group and each member before use.
- OnPlayerChat(Player*, ..., msg) (guild): check the AI pointer before HandleCommand.

**4. Safer RPG destination activation**

- RpgTravelDestination::isActive now checks for bot, botAI, context and safely reads the ignore-list; faction lookup is also guarded. This prevents null derefs when a real player (no AI) or missing data flows into the path.

**5. Related stability touches in AI**

- In the AI logout handling we ensure the conditions for instant logout are respected and we delegate to the manager’s hardened path. (No functional behavior change beyond increased safety.)

### Risk / compatibility

- I currently force instant logout for bots to avoid races seen in normal logout; this is a behavioral change (faster bot exits). If needed, we can put this behind a config gate later.
- Unknown client opcodes are now dropped for bot sessions (previously, they could crash). Expected and safe.

### How I tested

- Repeatedly whisper bots and issue commands with/without receivers and in/without groups — no null derefs in hooks. 
- Queue synthetic packets with invalid/unknown opcodes to a bot session — packets dropped cleanly, no crashes. 
- Spam login/logout during travel and group changes; verified that:

- travel target pointers get nulled,
- session is deleted exactly once,
- no double frees or use-after-free in the logout path.

### Follow-ups

- Extend ClearAIContextPointerValues to any other pointer-typed Value objects we discover over time in PlayerbotMgr
- Consider making “force instant logout” configurable to allow reverting to timed logout once we’re confident the race is gone.

PS: This solve also this issue: https://github.com/liyunfan1223/mod-playerbots/issues/1517 