### PR TITLE
[Fix issue #1528] Close small window where the “in a BG/arena” state can change between the check (InBattleground() / InArena()) and grabbing the pointer (GetBattleground()), which leads to a null dereference.

### DIFF
--- a/src/BroadcastHelper.cpp
+++ b/src/BroadcastHelper.cpp
@@ -947,8 +947,21 @@ bool BroadcastHelper::BroadcastSuggestThunderfury(PlayerbotAI* ai, Player* bot)
     {
         std::map<std::string, std::string> placeholders;
         ItemTemplate const* thunderfuryProto = sObjectMgr->GetItemTemplate(19019);
-        placeholders["%thunderfury_link"] = GET_PLAYERBOT_AI(bot)->GetChatHelper()->FormatItem(thunderfuryProto);
-
+        // placeholders["%thunderfury_link"] = GET_PLAYERBOT_AI(bot)->GetChatHelper()->FormatItem(thunderfuryProto); // Old code
+		// [Crash fix] Protect from nil AI : a real player doesn't have PlayerbotAI.
+        // Before: direct deref GET_PLAYERBOT_AI(bot)->... could crash World/General.
+        if (auto* ai = GET_PLAYERBOT_AI(bot))
+        {
+	        if (auto* chat = ai->GetChatHelper())
+		        placeholders["%thunderfury_link"] = chat->FormatItem(thunderfuryProto);
+	        else
+		        placeholders["%thunderfury_link"] = ""; // fallback: no chat helper
+        }
+        else
+        {
+	        placeholders["%thunderfury_link"] = "";     // fallback: no d'AI (real player)
+        }
+        // End crash fix
         return BroadcastToChannelWithGlobalChance(
             ai,
             BOT_TEXT2("thunderfury_spam", placeholders),

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -2373,7 +2373,7 @@ std::string PlayerbotAI::GetLocalizedGameObjectName(uint32 entry)
     return name;
 }
 
-std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
+/*std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
 {
     std::vector<Player*> members;
 
@@ -2390,6 +2390,34 @@ std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
             continue;
 
         members.push_back(ref->GetSource());
+    }
+
+    return members;
+}*/
+
+std::vector<Player*> PlayerbotAI::GetPlayersInGroup()
+{
+    std::vector<Player*> members;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return members;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member)
+            continue;
+
+        // Celaning, we don't call 2 times GET_PLAYERBOT_AI and never reference it if nil
+        if (auto* ai = GET_PLAYERBOT_AI(member))
+        {
+            // If it's a bot (not real player) => we ignor it
+            if (!ai->IsRealPlayer())
+                continue;
+        }
+
+        members.push_back(member);
     }
 
     return members;

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -994,9 +994,18 @@ void RandomPlayerbotMgr::CheckBgQueue()
                     isRated = ginfo.IsRated;
                 }
 
-                if (bgQueue.IsPlayerInvitedToRatedArena(player->GetGUID()) ||
+                /*if (bgQueue.IsPlayerInvitedToRatedArena(player->GetGUID()) ||
                     (player->InArena() && player->GetBattleground()->isRated()))
+                    isRated = true;*/
+                if (bgQueue.IsPlayerInvitedToRatedArena(player->GetGUID())) // [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528
+                {
                     isRated = true;
+                }
+                else if (Battleground const* bg = player->GetBattleground())
+                {
+                    if (player->InArena() && bg->isRated())
+                        isRated = true;
+                }
 
                 if (isRated)
                     BattlegroundData[queueTypeId][bracketId].ratedArenaPlayerCount++;
@@ -1011,15 +1020,24 @@ void RandomPlayerbotMgr::CheckBgQueue()
                 else
                     BattlegroundData[queueTypeId][bracketId].bgHordePlayerCount++;
 
-                // If a player has joined the BG, update the instance count in BattlegroundData (for consistency)
+                /*// If a player has joined the BG, update the instance count in BattlegroundData (for consistency)
                 if (player->InBattleground())
                 {
                     std::vector<uint32>* instanceIds = nullptr;
                     uint32 instanceId = player->GetBattleground()->GetInstanceID();
 
-                    instanceIds = &BattlegroundData[queueTypeId][bracketId].bgInstances;
-                    if (instanceIds &&
+                    instanceIds = &BattlegroundData[queueTypeId][bracketId].bgInstances;*/
+                // If a player has joined the BG, update the instance count in BattlegroundData (for consistency)
+                if (Battleground const* bg = player->GetBattleground()) // [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528
+                {
+                    std::vector<uint32>* instanceIds = nullptr;
+                    uint32 instanceId = bg->GetInstanceID();
+
+                    instanceIds = &BattlegroundData[queueTypeId][bracketId].bgInstances;					
+                   
+				   if (instanceIds &&
                         std::find(instanceIds->begin(), instanceIds->end(), instanceId) == instanceIds->end())
+						
                         instanceIds->push_back(instanceId);
 
                     BattlegroundData[queueTypeId][bracketId].bgInstanceCount = instanceIds->size();
@@ -1082,10 +1100,20 @@ void RandomPlayerbotMgr::CheckBgQueue()
                     isRated = ginfo.IsRated;
                 }
 
-                if (bgQueue.IsPlayerInvitedToRatedArena(guid) || (bot->InArena() && bot->GetBattleground()->isRated()))
+                /*if (bgQueue.IsPlayerInvitedToRatedArena(guid) || (bot->InArena() && bot->GetBattleground()->isRated()))
+                    isRated = true;*/
+				if (bgQueue.IsPlayerInvitedToRatedArena(guid)) // [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528
+                {
                     isRated = true;
-
-                if (isRated)
+                }
+                else if (Battleground const* bg = bot->GetBattleground())
+                {
+                    if (bot->InArena() && bg->isRated())
+                        isRated = true;
+                }
+                // END [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528
+                
+				if (isRated)
                     BattlegroundData[queueTypeId][bracketId].ratedArenaBotCount++;
                 else
                     BattlegroundData[queueTypeId][bracketId].skirmishArenaBotCount++;
@@ -1098,10 +1126,15 @@ void RandomPlayerbotMgr::CheckBgQueue()
                     BattlegroundData[queueTypeId][bracketId].bgHordeBotCount++;
             }
 
-            if (bot->InBattleground())
+            /*if (bot->InBattleground())
             {
                 std::vector<uint32>* instanceIds = nullptr;
-                uint32 instanceId = bot->GetBattleground()->GetInstanceID();
+                uint32 instanceId = bot->GetBattleground()->GetInstanceID();*/
+            if (Battleground const* bg = bot->GetBattleground()) // [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528
+            {
+                std::vector<uint32>* instanceIds = nullptr;
+                uint32 instanceId = bg->GetInstanceID();
+                //END  [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528				
                 bool isArena = false;
                 bool isRated = false;
 
@@ -1109,7 +1142,8 @@ void RandomPlayerbotMgr::CheckBgQueue()
                 if (bot->InArena())
                 {
                     isArena = true;
-                    if (bot->GetBattleground()->isRated())
+                    // if (bot->GetBattleground()->isRated())
+					if (bg->isRated())	// [Crash Fix] Issue Crash in RandomPlayerbotMgr:1018 #1528
                     {
                         isRated = true;
                         instanceIds = &BattlegroundData[queueTypeId][bracketId].ratedArenaInstances;


### PR DESCRIPTION
This PR will fix issue https://github.com/liyunfan1223/mod-playerbots/issues/1528.

There’s a small window where the “in a BG/arena” state can change between the check (InBattleground() / InArena()) and grabbing the pointer (GetBattleground()), which leads to a null dereference.
The robust fix is to fetch the bg pointer once, check it for null, and then use it.

### Why this fixes the crash

- InBattleground() / InArena() return a state that can change immediately after the check (e.g. switching to STATUS_WAIT_LEAVE, teleport, etc.).
- GetBattleground() can therefore return nullptr even if the previous check was true → immediate crash on dereference.
- By first grabbing the bg pointer and checking that it is not null, we eliminate this TOCTOU (time-of-check / time-of-use).