### PR TITLE
[Fix] teleport to invalid map or invalid coordinates (x , y , z  200000, o ) given when teleporting player (g UI d full type player low , name , map , x , y , z , o ) 

### DIFF
--- a/src/BotMovementUtils.h
+++ b/src/BotMovementUtils.h
@@ -4,27 +4,31 @@
  */
  
 #pragma once
+#include "Unit.h"
 #include "Player.h"
 #include "MotionMaster.h"
-#include "Unit.h"
 
-inline bool CanStartMoveSpline(Unit* u)
-{
+inline bool CanStartMoveSpline(Player* bot) {
+    if (!bot) return false;
+    if (!bot->IsAlive()) return false;
+    if (bot->IsBeingTeleported() || bot->IsInFlight()) return false;
+    if (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) || bot->HasRootAura() ||
+        bot->HasStunAura() || bot->IsCharmed() || bot->isFrozen() || bot->IsPolymorphed())
+        return false;
+    if (bot->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE)
+        return false;
+    if (bot->GetSpeed(MOVE_RUN) <= 0.01f) return false;
+    return true;
+}
+
+inline bool CanStartMoveSpline(Unit* u) {
     if (!u) return false;
     if (!u->IsAlive()) return false;
-
-    // states that block movement
     if (u->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED | UNIT_STATE_CONFUSED | UNIT_STATE_FLEEING))
         return false;
-
-    // no spline if a "CONTROLLED" movement is in progress (knockback/fear, etc.)
     if (u->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE)
         return false;
-
-    // MoveSpline constraint: speed > 0.01f
-    if (u->GetSpeed(MOVE_RUN) <= 0.01f)
-        return false;
-
+    if (u->GetSpeed(MOVE_RUN) <= 0.01f) return false;
     return true;
 }
 

--- a/src/BotMovementUtils.h
+++ b/src/BotMovementUtils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+ 
+#pragma once
+#include "Player.h"
+#include "MotionMaster.h"
+#include "Unit.h"
+
+inline bool CanStartMoveSpline(Unit* u)
+{
+    if (!u) return false;
+    if (!u->IsAlive()) return false;
+
+    // states that block movement
+    if (u->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED | UNIT_STATE_CONFUSED | UNIT_STATE_FLEEING))
+        return false;
+
+    // no spline if a "CONTROLLED" movement is in progress (knockback/fear, etc.)
+    if (u->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE)
+        return false;
+
+    // MoveSpline constraint: speed > 0.01f
+    if (u->GetSpeed(MOVE_RUN) <= 0.01f)
+        return false;
+
+    return true;
+}
+
+

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -57,6 +57,7 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "Vehicle.h"
+#include "BotMovementUtils.h"
 
 const int SPELL_TITAN_GRIP = 49152;
 
@@ -6325,11 +6326,27 @@ void PlayerbotAI::PetFollow()
     if (!pet)
         return;
     pet->AttackStop();
-    pet->InterruptNonMeleeSpells(false);
+    /* pet->InterruptNonMeleeSpells(false);
     pet->ClearInPetCombat();
     pet->GetMotionMaster()->MoveFollow(bot, PET_FOLLOW_DIST, pet->GetFollowAngle());
     if (pet->ToPet())
+        pet->ToPet()->ClearCastWhenWillAvailable();*/
+	// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+	pet->InterruptNonMeleeSpells(false);
+    pet->ClearInPetCombat();
+
+    if (CanStartMoveSpline(pet))
+    {
+        pet->GetMotionMaster()->MoveFollow(bot, PET_FOLLOW_DIST, pet->GetFollowAngle());
+    }
+    else
+    {
+        pet->StopMovingOnCurrentPos();  // on n’envoie pas d’ordre invalide
+    }
+
+    if (pet->ToPet())
         pet->ToPet()->ClearCastWhenWillAvailable();
+	//End Fix
     CharmInfo* charmInfo = pet->GetCharmInfo();
     if (!charmInfo)
         return;

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -721,6 +721,7 @@ void PlayerbotAI::HandleTeleportAck()
             bot->GetSession()->HandleMoveWorldportAck();
         }
         // SetNextCheckDelay(urand(2000, 5000));
+		SetNextCheckDelay(urand(500, 1500)); // short delay to break bursts without hindering gameplay
         if (sPlayerbotAIConfig->applyInstanceStrategies)
             ApplyInstanceStrategies(bot->GetMapId(), true);
         EvaluateHealerDpsStrategy();

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -591,6 +591,17 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
         bot->CleanupAfterTaxiFlight();
     }
 
+    // [Fix MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full: 0x00000000000019ba Type: Player Low: 6586] Ensure valid speeds before any next movement command
+    bot->StopMoving();
+    bot->UpdateSpeed(MOVE_WALK,   true);
+    bot->UpdateSpeed(MOVE_RUN,    true);
+    bot->UpdateSpeed(MOVE_SWIM,   true);
+    bot->UpdateSpeed(MOVE_FLIGHT, true);   // OK even if not flying
+    
+    if (bot->GetSpeed(MOVE_RUN) <= 0.01f) // Belt-and-suspenders: if the run speed has stayed ~0, reset to the default rate
+        bot->SetSpeedRate(MOVE_RUN, 1.0f);
+    // End Fix
+
     // check activity
     botAI->AllowActivity(ALL_ACTIVITY, true);
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1772,7 +1772,8 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (botAI)
             botAI->Reset(true);
-        bot->TeleportTo(loc.GetMapId(), x, y, z, 0);
+        //bot->TeleportTo(loc.GetMapId(), x, y, z, 0);
+		TeleportToSafe(bot, loc.GetMapId(), x, y, z, 0); // [Fix] Avoid silly teleports
         bot->SendMovementFlagUpdate();
 
         if (pmo)
@@ -3047,7 +3048,8 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
             } while (true);
         }
 
-        player->TeleportTo(botPos);
+        // player->TeleportTo(botPos);
+		TeleportToSafe(player, botPos); // [Fix] Avoid silly teleports
 
         // player->Relocate(botPos.getX(), botPos.getY(), botPos.getZ(), botPos.getO());
     }

--- a/src/strategy/actions/AreaTriggerAction.cpp
+++ b/src/strategy/actions/AreaTriggerAction.cpp
@@ -9,6 +9,7 @@
 #include "LastMovementValue.h"
 #include "Playerbots.h"
 #include "Transport.h"
+#include "BotMovementUtils.h"
 
 bool ReachAreaTriggerAction::Execute(Event event)
 {
@@ -40,7 +41,18 @@ bool ReachAreaTriggerAction::Execute(Event event)
         return true;
     }
 
-    bot->GetMotionMaster()->MovePoint(at->map, at->x, at->y, at->z);
+    // bot->GetMotionMaster()->MovePoint(at->map, at->x, at->y, at->z);
+	// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+	if (CanStartMoveSpline(bot))
+	{
+		bot->GetMotionMaster()->MovePoint(at->map, at->x, at->y, at->z);
+	}
+	else
+	{
+		bot->StopMovingOnCurrentPos();
+		botAI->SetNextCheckDelay(sPlayerbotAIConfig->reactDelay);
+		return false;
+	}
 
     float distance = bot->GetDistance(at->x, at->y, at->z);
     float delay = 1000.0f * distance / bot->GetSpeed(MOVE_RUN) + sPlayerbotAIConfig->reactDelay;

--- a/src/strategy/actions/BattleGroundJoinAction.cpp
+++ b/src/strategy/actions/BattleGroundJoinAction.cpp
@@ -176,7 +176,8 @@ bool BGJoinAction::gatherArenaTeam(ArenaType type)
             continue;
 
         memberBotAI->Reset();
-        member->TeleportTo(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), 0);
+        // member->TeleportTo(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), 0);
+		TeleportToSafe(member, bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), 0);
 
         LOG_INFO("playerbots", "Bot {} <{}>: Member of <{}>", member->GetGUID().ToString().c_str(),
                  member->GetName().c_str(), arenateam->GetName().c_str());

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4289,9 +4289,11 @@ bool ArenaTactics::moveToCenter(Battleground* bg)
             {
                 // they like to hang around at the tip of the pipes doing nothing, so we just teleport them down
                 if (bot->GetDistance(1333.07f, 817.18f, 13.35f) < 4)
-                    bot->TeleportTo(bg->GetMapId(), 1330.96f, 816.75f, 3.2f, bot->GetOrientation());
+                    // bot->TeleportTo(bg->GetMapId(), 1330.96f, 816.75f, 3.2f, bot->GetOrientation());
+				TeleportToSafe(bot, bg->GetMapId(), 1330.96f, 816.75f, 3.2f, bot->GetOrientation()); // [Fix] Avaid silly teleport
                 if (bot->GetDistance(1250.13f, 764.79f, 13.34f) < 4)
-                    bot->TeleportTo(bg->GetMapId(), 1252.19f, 765.41f, 3.2f, bot->GetOrientation());
+                    // bot->TeleportTo(bg->GetMapId(), 1252.19f, 765.41f, 3.2f, bot->GetOrientation());
+				TeleportToSafe(bot, bg->GetMapId(), 1252.19f, 765.41f, 3.2f, bot->GetOrientation());  // [Fix] Avaid silly teleport
             }
             break;
         case BATTLEGROUND_RV:

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -42,6 +42,7 @@
 #include "Vehicle.h"
 #include "WaypointMovementGenerator.h"
 #include "Corpse.h"
+#include "BotMovementUtils.h"
 
 MovementAction::MovementAction(PlayerbotAI* botAI, std::string const name) : Action(botAI, name)
 {
@@ -81,6 +82,10 @@ bool MovementAction::JumpTo(uint32 mapId, float x, float y, float z, MovementPri
     float botZ = bot->GetPositionZ();
     float speed = bot->GetSpeed(MOVE_RUN);
     MotionMaster& mm = *bot->GetMotionMaster();
+	// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+	if (!CanStartMoveSpline(bot))
+    return false;
+    // End Fix
     mm.Clear();
     mm.MoveJump(x, y, z, speed, speed, 1);
     AI_VALUE(LastMovement&, "last movement").Set(mapId, x, y, z, bot->GetOrientation(), 1000, priority);
@@ -207,6 +212,10 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
         if (distance > 0.01f)
         {
             MotionMaster& mm = *vehicleBase->GetMotionMaster();  // need to move vehicle, not bot
+			// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+			if (!CanStartMoveSpline(bot))
+            return false;
+		    // End Fix
             mm.Clear();
             if (!backwards)
             {
@@ -242,6 +251,10 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             //     botAI->InterruptSpell();
             // }
             MotionMaster& mm = *bot->GetMotionMaster();
+			//[Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+			if (!CanStartMoveSpline(bot))
+            return false;
+		    // End Fix
             mm.Clear();
             if (!backwards)
             {
@@ -284,6 +297,10 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             // }
             MotionMaster& mm = *bot->GetMotionMaster();
             G3D::Vector3 endP = path.back();
+			// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+			if (!CanStartMoveSpline(bot))
+            return false;
+			// End Fix
             mm.Clear();
             if (!backwards)
             {

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -147,7 +147,8 @@ bool AutoReleaseSpiritAction::HandleBattlegroundSpiritHealer()
         // and in IOC it's not within clicking range when they res in own base
 
         // Teleport to nearest friendly Spirit Healer when not currently in range of one.
-        bot->TeleportTo(bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f);
+        // bot->TeleportTo(bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f);
+		TeleportToSafe(bot, bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f); // [Fix] Avoid silly teleport
         RESET_AI_VALUE(bool, "combat::self target");
         RESET_AI_VALUE(WorldPosition, "current position");
     }
@@ -244,7 +245,8 @@ int64 RepopAction::CalculateDeadTime() const
 
 void RepopAction::PerformGraveyardTeleport(const GraveyardStruct* graveyard) const
 {
-    bot->TeleportTo(graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f);
+    // bot->TeleportTo(graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f);
+	TeleportToSafe(bot, graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f); // [Fix] Avoid Silly teleport
     RESET_AI_VALUE(bool, "combat::self target");
     RESET_AI_VALUE(WorldPosition, "current position");
 }

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -169,7 +169,8 @@ bool FindCorpseAction::Execute(Event event)
         if (deadTime > delay)
         {
             bot->GetMotionMaster()->Clear();
-            bot->TeleportTo(moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0);
+            // bot->TeleportTo(moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0);
+			TeleportToSafe(bot, moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0); // [fix] Avoid Silly Teleport
         }
 
         moved = true;
@@ -350,7 +351,8 @@ bool SpiritHealerAction::Execute(Event event)
     // if (!botAI->HasActivePlayerMaster())
     // {
     context->GetValue<uint32>("death count")->Set(dCount + 1);
-    return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
+    // return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
+	return TeleportToSafe(bot, ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f); // [Fix] Avoid Silly teleport
     // }
 
     // LOG_INFO("playerbots", "Bot {} {}:{} <{}> can't find a spirit healer", bot->GetGUID().ToString().c_str(),

--- a/src/strategy/raids/icecrown/RaidIccActions.cpp
+++ b/src/strategy/raids/icecrown/RaidIccActions.cpp
@@ -957,7 +957,8 @@ bool IccGunshipTeleportHordeAction::Execute(Event event)
 
 bool IccGunshipTeleportHordeAction::TeleportTo(const Position& position)
 {
-    return bot->TeleportTo(bot->GetMapId(), position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),
+    // return bot->TeleportTo(bot->GetMapId(), position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),
+	return TeleportToSafe(bot, bot->GetMapId(), position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),// [Fix]Avoid silly teleport
                            bot->GetOrientation());
 }
 

--- a/src/strategy/raids/naxxramas/RaidNaxxActions.cpp
+++ b/src/strategy/raids/naxxramas/RaidNaxxActions.cpp
@@ -9,6 +9,7 @@
 #include "RaidNaxxStrategy.h"
 #include "ScriptedCreature.h"
 #include "SharedDefines.h"
+#include "BotMovementUtils.h"
 
 bool GrobbulusGoBehindAction::Execute(Event event)
 {
@@ -258,11 +259,26 @@ bool RazuviousUseObedienceCrystalAction::Execute(Event event)
             return false;
         }
         if (charm->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_ACTIVE) == NULL_MOTION_TYPE)
-        {
+        /*{
             charm->GetMotionMaster()->Clear();
             charm->GetMotionMaster()->MoveChase(target);
             charm->GetAI()->AttackStart(target);
+        }*/
+		// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+		{
+            if (CanStartMoveSpline(charm))
+            {
+                charm->GetMotionMaster()->Clear();
+                charm->GetMotionMaster()->MoveChase(target);
+            }
+            else
+            {
+                charm->StopMoving();
+            }
+        
+            charm->GetAI()->AttackStart(target);
         }
+		// End Fix
         Aura* forceObedience = botAI->GetAura("force obedience", charm);
         uint32 duration_time;
         if (!forceObedience)

--- a/src/strategy/raids/ulduar/RaidUlduarActions.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarActions.cpp
@@ -1357,10 +1357,14 @@ bool KologarnMarkDpsTargetAction::Execute(Event event)
 
 bool KologarnFallFromFloorAction::Execute(Event event)
 {
-    return bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionX(),
+    /*return bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionX(),
                            ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionY(),
                            ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionZ(),
-                           ULDUAR_KOLOGARN_RESTORE_POSITION.GetOrientation());
+                           ULDUAR_KOLOGARN_RESTORE_POSITION.GetOrientation());*/
+	return TeleportToSafe(bot, bot->GetMapId(), ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionX(), // [Fix] Avoid silly teleport
+                      ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionY(),
+                      ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionZ(),
+                      ULDUAR_KOLOGARN_RESTORE_POSITION.GetOrientation());					   
 }
 
 bool KologarnFallFromFloorAction::isUseful()
@@ -1407,14 +1411,18 @@ bool KologarnEyebeamAction::Execute(Event event)
     KologarnEyebeamTrigger kologarnEyebeamTrigger(botAI);
     if (runToLeftSide)
     {
-        teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionX(),
+        // teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionX(),
+		teleportedToPoint = TeleportToSafe(bot, bot->GetMapId(), 
+		                                    ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionX(),
                                             ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionY(),
                                             ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionZ(),
                                             ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetOrientation());
     }
     else
     {
-        teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionX(),
+        // teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionX(),
+		teleportedToPoint = TeleportToSafe(bot, bot->GetMapId(),
+		                                    ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionX(),
                                             ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionY(),
                                             ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionZ(),
                                             ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetOrientation());

--- a/src/strategy/raids/vaultofarchavon/RaidVoAActions.cpp
+++ b/src/strategy/raids/vaultofarchavon/RaidVoAActions.cpp
@@ -175,9 +175,13 @@ bool EmalonOverchargeAction::isUseful()
 
 bool EmalonFallFromFloorAction::Execute(Event event)
 {
-    return bot->TeleportTo(bot->GetMapId(), VOA_EMALON_RESTORE_POSITION.GetPositionX(),
+    /*return bot->TeleportTo(bot->GetMapId(), VOA_EMALON_RESTORE_POSITION.GetPositionX(),
                            VOA_EMALON_RESTORE_POSITION.GetPositionY(), VOA_EMALON_RESTORE_POSITION.GetPositionZ(),
-                           VOA_EMALON_RESTORE_POSITION.GetOrientation());
+                           VOA_EMALON_RESTORE_POSITION.GetOrientation());*/
+	return TeleportToSafe(bot, bot->GetMapId(), VOA_EMALON_RESTORE_POSITION.GetPositionX(), //[Fix] Avoid Silly Teleport
+                      VOA_EMALON_RESTORE_POSITION.GetPositionY(),
+                      VOA_EMALON_RESTORE_POSITION.GetPositionZ(),
+                      VOA_EMALON_RESTORE_POSITION.GetOrientation());					   
 }
 
 bool EmalonFallFromFloorAction::isUseful()

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -67,7 +67,8 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
             bot->GetName(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot->GetMapId(),
             dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(), dest.getMapId(), bot->GetZoneId(),
             zone_name);
-        return bot->TeleportTo(dest);
+        // return bot->TeleportTo(dest);
+		return TeleportToSafe(bot, dest); //[Fix] Avoid Silly teleport
     }
 
     float dis = bot->GetExactDist(dest);


### PR DESCRIPTION
### Playerbots: guard against invalid-Z teleports

Avoid spam in console when bots decide to do a silly teleport:

Like:
```
TeleportTo: invalid map (0) or invalid coordinates (X: -940.0883, Y: -2843.7368, Z: -200000, O: 7.331777) given when teleporting player (GUID Full: 0x00000000000002ed Type: Player Low: 749, name: Ozuy, map: 0, X: -940.7874, Y: -2844.9495, Z: 61.477768, O: 7.331777).
TeleportTo: invalid map (0) or invalid coordinates (X: -11621.91, Y: 203.48108, Z: -200000, O: 3.2240791) given when teleporting player (GUID Full: 0x0000000000000289 Type: Player Low: 649, name: Justinor, map: 0, X: -11620.515, Y: 203.5972, Z: 23.282, O: 3.2240791).
TeleportTo: invalid map (1) or invalid coordinates (X: -7499.1714, Y: -3402.504, Z: -200000, O: 3.1415927) given when teleporting player (GUID Full: 0x000000000000022f Type: Player Low: 559, name: Geronavan, map: 1, X: -7497.7715, Y: -3402.5046, Z: 12.673878, O: 3.1415927).
TeleportTo: invalid map (571) or invalid coordinates (X: 8303.741, Y: 2736.2776, Z: -200000, O: 5.7079563) given when teleporting player (GUID Full: 0x0000000000000243 Type: Player Low: 579, name: Gantun, map: 571, X: 8302.567, Y: 2737.0388, Z: 653.82086, O: 5.7079563).
```

### Summary:
Stops bots from spamming TeleportTo with invalid height (Z = -200000). Adds module-level safe wrappers and updates call sites so bad teleports are skipped instead of flooding logs or looping.

### What changed

- Added TeleportToSafe(...) in Playerbots.h:

- Validates Z; if invalid, tries one GetHeight(...) on the same map; otherwise aborts.
- Overloads for (mapId, x, y, z, o), WorldPosition (by value), and Position.


- Replaced bot ->TeleportTo(...) calls with TeleportToSafe(...) in affected actions (e.g., ReviveFromCorpseAction, ICC gunship helper, Ulduar Kologarn block).

### Why

- -200000 is the “invalid height” sentinel; passing it to Player::TeleportTo caused console spam and retry loops.

### Scope

- Module-only; no core edits. Affects bots’ teleports only.

### Testing

- Reproduced previous spam case; with this patch, bots skip invalid teleports, logs are clean, normal teleports still work.