### PR TITLE
[Large server fix] #1537 Serialize playerBots/botLoading with a mutex and use snapshot-based loops to fix concurrency crashes

### DIFF
--- a/src/BotMovementUtils.h
+++ b/src/BotMovementUtils.h
@@ -4,27 +4,31 @@
  */
  
 #pragma once
+#include "Unit.h"
 #include "Player.h"
 #include "MotionMaster.h"
-#include "Unit.h"
 
-inline bool CanStartMoveSpline(Unit* u)
-{
+inline bool CanStartMoveSpline(Player* bot) {
+    if (!bot) return false;
+    if (!bot->IsAlive()) return false;
+    if (bot->IsBeingTeleported() || bot->IsInFlight()) return false;
+    if (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) || bot->HasRootAura() ||
+        bot->HasStunAura() || bot->IsCharmed() || bot->isFrozen() || bot->IsPolymorphed())
+        return false;
+    if (bot->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE)
+        return false;
+    if (bot->GetSpeed(MOVE_RUN) <= 0.01f) return false;
+    return true;
+}
+
+inline bool CanStartMoveSpline(Unit* u) {
     if (!u) return false;
     if (!u->IsAlive()) return false;
-
-    // states that block movement
     if (u->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED | UNIT_STATE_CONFUSED | UNIT_STATE_FLEEING))
         return false;
-
-    // no spline if a "CONTROLLED" movement is in progress (knockback/fear, etc.)
     if (u->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE)
         return false;
-
-    // MoveSpline constraint: speed > 0.01f
-    if (u->GetSpeed(MOVE_RUN) <= 0.01f)
-        return false;
-
+    if (u->GetSpeed(MOVE_RUN) <= 0.01f) return false;
     return true;
 }
 

--- a/src/BotMovementUtils.h
+++ b/src/BotMovementUtils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license, you may redistribute it
+ * and/or modify it under version 2 of the License, or (at your option), any later version.
+ */
+ 
+#pragma once
+#include "Player.h"
+#include "MotionMaster.h"
+#include "Unit.h"
+
+inline bool CanStartMoveSpline(Unit* u)
+{
+    if (!u) return false;
+    if (!u->IsAlive()) return false;
+
+    // states that block movement
+    if (u->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED | UNIT_STATE_CONFUSED | UNIT_STATE_FLEEING))
+        return false;
+
+    // no spline if a "CONTROLLED" movement is in progress (knockback/fear, etc.)
+    if (u->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE)
+        return false;
+
+    // MoveSpline constraint: speed > 0.01f
+    if (u->GetSpeed(MOVE_RUN) <= 0.01f)
+        return false;
+
+    return true;
+}
+
+

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -57,6 +57,7 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "Vehicle.h"
+#include "BotMovementUtils.h"
 
 const int SPELL_TITAN_GRIP = 49152;
 
@@ -6325,11 +6326,27 @@ void PlayerbotAI::PetFollow()
     if (!pet)
         return;
     pet->AttackStop();
-    pet->InterruptNonMeleeSpells(false);
+    /* pet->InterruptNonMeleeSpells(false);
     pet->ClearInPetCombat();
     pet->GetMotionMaster()->MoveFollow(bot, PET_FOLLOW_DIST, pet->GetFollowAngle());
     if (pet->ToPet())
+        pet->ToPet()->ClearCastWhenWillAvailable();*/
+	// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+	pet->InterruptNonMeleeSpells(false);
+    pet->ClearInPetCombat();
+
+    if (CanStartMoveSpline(pet))
+    {
+        pet->GetMotionMaster()->MoveFollow(bot, PET_FOLLOW_DIST, pet->GetFollowAngle());
+    }
+    else
+    {
+        pet->StopMovingOnCurrentPos();  // on n’envoie pas d’ordre invalide
+    }
+
+    if (pet->ToPet())
         pet->ToPet()->ClearCastWhenWillAvailable();
+	//End Fix
     CharmInfo* charmInfo = pet->GetCharmInfo();
     if (!charmInfo)
         return;

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -721,6 +721,7 @@ void PlayerbotAI::HandleTeleportAck()
             bot->GetSession()->HandleMoveWorldportAck();
         }
         // SetNextCheckDelay(urand(2000, 5000));
+		SetNextCheckDelay(urand(500, 1500)); // short delay to break bursts without hindering gameplay
         if (sPlayerbotAIConfig->applyInstanceStrategies)
             ApplyInstanceStrategies(bot->GetMapId(), true);
         EvaluateHealerDpsStrategy();

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -41,6 +41,10 @@
 #include "Log.h"
 #include <shared_mutex> // removes a long-standing crash (0xC0000005 ACCESS_VIOLATION)
 #include "TravelMgr.h"
+#include <mutex>
+#include <vector>
+
+static std::mutex g_botMapsMx; // protect playerBots and botLoading
 
 namespace {
     // [Crash fix] Centralize clearing of pointer values in the AI context
@@ -105,9 +109,16 @@ public:
 
 void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId)
 {
-    // bot is loading
+    /*// bot is loading
     if (botLoading.find(playerGuid) != botLoading.end())
-        return;
+        return;*/
+	
+	// bot is loading (protégé)
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        if (botLoading.find(playerGuid) != botLoading.end())
+            return;
+    }
 
     // has bot already been added?
     Player* bot = ObjectAccessor::FindConnectedPlayer(playerGuid);
@@ -145,7 +156,16 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
             LOG_DEBUG("mod-playerbots", "PlayerbotMgr not found for master player with GUID: {}", masterPlayer->GetGUID().GetRawValue());
             return;
         }
-        uint32 count = mgr->GetPlayerbotsCount() + botLoading.size();
+		
+		// read botLoading.size() locked
+        size_t loadingCount = 0;
+        {
+            std::lock_guard<std::mutex> lk(g_botMapsMx);
+            loadingCount = botLoading.size();
+        }
+		
+        // uint32 count = mgr->GetPlayerbotsCount() + botLoading.size();
+		uint32 count = mgr->GetPlayerbotsCount() + static_cast<uint32>(loadingCount);
         if (count >= sPlayerbotAIConfig->maxAddedBots)
         {
             allowed = false;
@@ -161,14 +181,22 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
         }
         return;
     }
-    std::shared_ptr<PlayerbotLoginQueryHolder> holder =
-        std::make_shared<PlayerbotLoginQueryHolder>(this, masterAccountId, accountId, playerGuid);
+    // std::shared_ptr<PlayerbotLoginQueryHolder> holder = 
+	      // std::make_shared<PlayerbotLoginQueryHolder>(this, masterAccountId, accountId, playerGuid);
+	auto holder = std::make_shared<PlayerbotLoginQueryHolder>(this, masterAccountId, accountId, playerGuid);
     if (!holder->Initialize())
     {
         return;
     }
 
-    botLoading.insert(playerGuid);
+    // botLoading.insert(playerGuid);
+	// Protected insert
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        if (botLoading.find(playerGuid) != botLoading.end())
+            return;                     // already loging
+        botLoading.insert(playerGuid);  // we reserve the GUID
+    }
 
     // Always login in with world session to avoid race condition
     sWorld->AddQueryHolderCallback(CharacterDatabase.DelayQueryHolder(holder))
@@ -185,7 +213,11 @@ bool PlayerbotHolder::IsAccountLinked(uint32 accountId, uint32 linkedAccountId)
 
 void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder const& holder)
 {
+    // Copy immediatly holder value
+    const ObjectGuid guid = holder.GetGuid();
+    const uint32 masterAccountId = holder.GetMasterAccountId();
     uint32 botAccountId = holder.GetAccountId();
+	
     // At login DBC locale should be what the server is set to use by default (as spells etc are hardcoded to ENUS this
     // allows channels to work as intended)
     WorldSession* botSession = new WorldSession(botAccountId, "", 0x0, nullptr, SEC_PLAYER, EXPANSION_WRATH_OF_THE_LICH_KING,
@@ -200,11 +232,16 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
         LOG_DEBUG("mod-playerbots", "Bot player could not be loaded for account ID: {}", botAccountId);
         botSession->LogoutPlayer(true);
         delete botSession;
-        botLoading.erase(holder.GetGuid());
+        // botLoading.erase(holder.GetGuid());
+		{
+            std::lock_guard<std::mutex> lk(g_botMapsMx);
+            botLoading.erase(guid);
+        }
         return;
     }
 
-    uint32 masterAccount = holder.GetMasterAccountId();
+    // uint32 masterAccount = holder.GetMasterAccountId();
+	uint32 masterAccount = masterAccountId;  // Avoid read in 'holder' after login
     WorldSession* masterSession = masterAccount ? sWorldSessionMgr->FindSession(masterAccount) : nullptr;
 
     // Check if masterSession->GetPlayer() is valid
@@ -217,10 +254,14 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
     sRandomPlayerbotMgr->OnPlayerLogin(bot);
     OnBotLogin(bot);
 
-    botLoading.erase(holder.GetGuid());
+    // botLoading.erase(holder.GetGuid());
+	{
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        botLoading.erase(guid);
+    }
 }
 
-void PlayerbotHolder::UpdateSessions()
+/*void PlayerbotHolder::UpdateSessions()
 {
     for (PlayerBotMap::const_iterator itr = GetPlayerBotsBegin(); itr != GetPlayerBotsEnd(); ++itr)
     {
@@ -232,6 +273,29 @@ void PlayerbotHolder::UpdateSessions()
             {
                 botAI->HandleTeleportAck();
             }
+        }
+        else if (bot->IsInWorld())
+        {
+            HandleBotPackets(bot->GetSession());
+        }
+    }
+}*/
+
+void PlayerbotHolder::UpdateSessions()
+{
+    PlayerBotMap botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        botsCopy = playerBots;
+    }
+
+    for (const auto& kv : botsCopy)
+    {
+        Player* const bot = kv.second;
+        if (bot->IsBeingTeleported())
+        {
+            if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                botAI->HandleTeleportAck();
         }
         else if (bot->IsInWorld())
         {
@@ -287,8 +351,27 @@ void PlayerbotHolder::LogoutAllBots()
     }
     */
 
-    PlayerBotMap bots = playerBots;
+    /*PlayerBotMap bots = playerBots;
     for (auto& itr : bots)
+    {
+        Player* bot = itr.second;
+        if (!bot)
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI || botAI->IsRealPlayer())
+            continue;
+
+        LogoutPlayerBot(bot->GetGUID());
+    }*/
+	// Snapshot under lock for safe iteration
+    PlayerBotMap botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        botsCopy = playerBots;
+    }
+
+    for (auto& itr : botsCopy)
     {
         Player* bot = itr.second;
         if (!bot)
@@ -302,7 +385,7 @@ void PlayerbotHolder::LogoutAllBots()
     }
 }
 
-void PlayerbotMgr::CancelLogout()
+/*void PlayerbotMgr::CancelLogout()
 {
     Player* master = GetMaster();
     if (!master)
@@ -311,6 +394,53 @@ void PlayerbotMgr::CancelLogout()
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
         Player* const bot = it->second;
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI || botAI->IsRealPlayer())
+            continue;
+
+        if (bot->GetSession()->isLogingOut())
+        {
+            WorldPackets::Character::LogoutCancel data = WorldPacket(CMSG_LOGOUT_CANCEL);
+            bot->GetSession()->HandleLogoutCancelOpcode(data);
+            botAI->TellMaster("Logout cancelled!");
+        }
+    }
+
+    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
+         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    {
+        Player* const bot = it->second;
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI || botAI->IsRealPlayer())
+            continue;
+
+        if (botAI->GetMaster() != master)
+            continue;
+
+        if (bot->GetSession()->isLogingOut())
+        {
+            WorldPackets::Character::LogoutCancel data = WorldPacket(CMSG_LOGOUT_CANCEL);
+            bot->GetSession()->HandleLogoutCancelOpcode(data);
+        }
+    }
+}*/
+
+void PlayerbotMgr::CancelLogout()
+{
+    Player* master = GetMaster();
+    if (!master)
+        return;
+
+    // Snapshot of "master" bots under lock
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+    {
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (!botAI || botAI->IsRealPlayer())
             continue;
@@ -489,33 +619,47 @@ void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)
 }
 
 void PlayerbotHolder::RemoveFromPlayerbotsMap(ObjectGuid guid)
+// {
+//     playerBots.erase(guid);
+// }
+// Protected erase
 {
+    std::lock_guard<std::mutex> lk(g_botMapsMx);
     playerBots.erase(guid);
 }
 
 Player* PlayerbotHolder::GetPlayerBot(ObjectGuid playerGuid) const
 {
+	std::lock_guard<std::mutex> lk(g_botMapsMx); // We protect
     PlayerBotMap::const_iterator it = playerBots.find(playerGuid);
-    return (it == playerBots.end()) ? 0 : it->second;
+    return (it == playerBots.end()) ? nullptr : it->second;// (nullptr)
 }
 
 Player* PlayerbotHolder::GetPlayerBot(ObjectGuid::LowType lowGuid) const
 {
     ObjectGuid playerGuid = ObjectGuid::Create<HighGuid::Player>(lowGuid);
+	std::lock_guard<std::mutex> lk(g_botMapsMx); // We protect
     PlayerBotMap::const_iterator it = playerBots.find(playerGuid);
-    return (it == playerBots.end()) ? 0 : it->second;
+    return (it == playerBots.end()) ? nullptr : it->second;
 }
 
 void PlayerbotHolder::OnBotLogin(Player* const bot)
 {
     // Prevent duplicate login
-    if (playerBots.find(bot->GetGUID()) != playerBots.end())
+    /*if (playerBots.find(bot->GetGUID()) != playerBots.end())
     {
         return;
+    }*/
+	{
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        if (playerBots.find(bot->GetGUID()) != playerBots.end())
+            return;
+
+        playerBots[bot->GetGUID()] = bot;
     }
 
     sPlayerbotsMgr->AddPlayerbotData(bot, true);
-    playerBots[bot->GetGUID()] = bot;
+    // playerBots[bot->GetGUID()] = bot;
 
     OnBotLoginInternal(bot);
 
@@ -1230,8 +1374,13 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             // If the user requested a specific gender, skip any character that doesn't match.
             if (gender != -1 && GetOfflinePlayerGender(guid) != gender)
                 continue;			
-            if (botLoading.find(guid) != botLoading.end())
-                continue;
+            /*if (botLoading.find(guid) != botLoading.end())
+                continue;*/
+			{
+                std::lock_guard<std::mutex> lk(g_botMapsMx);
+                if (botLoading.find(guid) != botLoading.end())
+                    continue;
+            }
             if (ObjectAccessor::FindConnectedPlayer(guid))
                 continue;
             uint32 guildId = sCharacterCache->GetCharacterGuildIdByGuid(guid);
@@ -1295,12 +1444,25 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
 
     if (charnameStr == "!" && master && master->GetSession()->GetSecurity() > SEC_GAMEMASTER)
     {
-        for (PlayerBotMap::const_iterator i = GetPlayerBotsBegin(); i != GetPlayerBotsEnd(); ++i)
+        /*for (PlayerBotMap::const_iterator i = GetPlayerBotsBegin(); i != GetPlayerBotsEnd(); ++i)
         {
             if (Player* bot = i->second)
                 if (bot->IsInWorld())
                     bots.insert(bot->GetName());
-        }
+        }*/
+		// Snapshot under lock
+       std::vector<Player*> botsCopy;
+       {
+           std::lock_guard<std::mutex> lk(g_botMapsMx);
+           for (PlayerBotMap::const_iterator i = GetPlayerBotsBegin(); i != GetPlayerBotsEnd(); ++i)
+               botsCopy.push_back(i->second);
+       }
+       for (Player* const bot : botsCopy)
+       {
+           if (bot && bot->IsInWorld())
+               bots.insert(bot->GetName());
+       }
+
     }
 
     std::vector<std::string> chars = split(charnameStr, ',');
@@ -1404,7 +1566,7 @@ uint32 PlayerbotHolder::GetAccountId(ObjectGuid guid)
     return 0;
 }
 
-std::string const PlayerbotHolder::ListBots(Player* master)
+/*std::string const PlayerbotHolder::ListBots(Player* master)
 {
     std::set<std::string> bots;
     std::map<uint8, std::string> classNames;
@@ -1491,6 +1653,103 @@ std::string const PlayerbotHolder::ListBots(Player* master)
     }
 
     return out.str();
+}*/
+
+std::string const PlayerbotHolder::ListBots(Player* master)
+{
+    std::set<std::string> bots;
+    std::map<uint8, std::string> classNames;
+
+    classNames[CLASS_DEATH_KNIGHT] = "Death Knight";
+    classNames[CLASS_DRUID] = "Druid";
+    classNames[CLASS_HUNTER] = "Hunter";
+    classNames[CLASS_MAGE] = "Mage";
+    classNames[CLASS_PALADIN] = "Paladin";
+    classNames[CLASS_PRIEST] = "Priest";
+    classNames[CLASS_ROGUE] = "Rogue";
+    classNames[CLASS_SHAMAN] = "Shaman";
+    classNames[CLASS_WARLOCK] = "Warlock";
+    classNames[CLASS_WARRIOR] = "Warrior";
+    classNames[CLASS_DEATH_KNIGHT] = "DeathKnight";
+
+    std::map<std::string, std::string> online;
+    std::vector<std::string> names;
+    std::map<std::string, std::string> classes;
+
+    // Snapshot under lock
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+    {
+        std::string const name = bot->GetName();
+        bots.insert(name);
+
+        names.push_back(name);
+        online[name] = "+";
+        classes[name] = classNames[bot->getClass()];
+    }
+
+    if (master)
+    {
+        QueryResult results = CharacterDatabase.Query(
+            "SELECT class, name FROM characters WHERE account = {}",
+            master->GetSession()->GetAccountId());
+
+        if (results)
+        {
+            do
+            {
+                Field* fields = results->Fetch();
+                uint8 cls = fields[0].Get<uint8>();
+                std::string const name = fields[1].Get<std::string>();
+                if (bots.find(name) == bots.end() && name != master->GetSession()->GetPlayerName())
+                {
+                    names.push_back(name);
+                    online[name] = "-";
+                    classes[name] = classNames[cls];
+                }
+            } while (results->NextRow());
+        }
+    }
+
+    std::sort(names.begin(), names.end());
+
+    if (master)
+    {
+        if (Group* group = master->GetGroup())
+        {
+            Group::MemberSlotList const& groupSlot = group->GetMemberSlots();
+            for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
+            {
+                Player* member = ObjectAccessor::FindPlayer(itr->guid);
+                if (member && sRandomPlayerbotMgr->IsRandomBot(member))
+                {
+                    std::string const name = member->GetName();
+
+                    names.push_back(name);
+                    online[name] = "+";
+                    classes[name] = classNames[member->getClass()];
+                }
+            }
+        }
+    }
+
+    std::ostringstream out;
+    bool first = true;
+    out << "Bot roster: ";
+    for (std::vector<std::string>::iterator i = names.begin(); i != names.end(); ++i)
+    {
+        if (first) first = false; else out << ", ";
+        std::string const name = *i;
+        out << online[name] << name << " " << classes[name];
+    }
+
+    return out.str();
 }
 
 std::string const PlayerbotHolder::LookupBots(Player* master)
@@ -1516,7 +1775,7 @@ std::string const PlayerbotHolder::LookupBots(Player* master)
     return ret_msg;
 }
 
-uint32 PlayerbotHolder::GetPlayerbotsCountByClass(uint32 cls)
+/*uint32 PlayerbotHolder::GetPlayerbotsCountByClass(uint32 cls)
 {
     uint32 count = 0;
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
@@ -1527,6 +1786,25 @@ uint32 PlayerbotHolder::GetPlayerbotsCountByClass(uint32 cls)
             count++;
         }
     }
+    return count;
+}*/
+
+uint32 PlayerbotHolder::GetPlayerbotsCountByClass(uint32 cls)
+{
+    uint32 count = 0;
+
+    // Snapshot under lock
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+        if (bot && bot->IsInWorld() && bot->getClass() == cls)
+            ++count;
+
     return count;
 }
 
@@ -1544,7 +1822,7 @@ void PlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
     CheckTellErrors(elapsed);
 }
 
-void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)
+/*void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)
 {
     Player* master = GetMaster();
     if (!master)
@@ -1578,9 +1856,50 @@ void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)
         if (botAI && botAI->GetMaster() == master)
             botAI->HandleCommand(type, text, master);
     }
+}*/
+
+void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)
+{
+    Player* master = GetMaster();
+    if (!master)
+        return;
+
+    if (text.find(sPlayerbotAIConfig->commandSeparator) != std::string::npos)
+    {
+        std::vector<std::string> commands;
+        split(commands, text, sPlayerbotAIConfig->commandSeparator.c_str());
+        for (std::vector<std::string>::iterator i = commands.begin(); i != commands.end(); ++i)
+            HandleCommand(type, *i);
+        return;
+    }
+
+    // Snapshot of "master" bots under lock to avoid race conditions
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+    {
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI)
+            botAI->HandleCommand(type, text, master);
+    }
+
+    // Random bots : unchanges
+    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
+         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    {
+        Player* const bot = it->second;
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI && botAI->GetMaster() == master)
+            botAI->HandleCommand(type, text, master);
+    }
 }
 
-void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
+/*void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
 {
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
@@ -1616,9 +1935,57 @@ void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
             break;
         }
     }
+}*/
+
+void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
+{
+    // Snapshot of "master" bots under lock
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+    {
+        if (!bot)
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI)
+            botAI->HandleMasterIncomingPacket(packet);
+    }
+
+    // Boucle random bots (inchangée)
+    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
+         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    {
+        Player* const bot = it->second;
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI && botAI->GetMaster() == GetMaster())
+            botAI->HandleMasterIncomingPacket(packet);
+    }
+
+    switch (packet.GetOpcode())
+    {
+        // if master is logging out, log out all bots
+        case CMSG_LOGOUT_REQUEST:
+        {
+            LogoutAllBots();
+            break;
+        }
+        // if master cancelled logout, cancel too
+        case CMSG_LOGOUT_CANCEL:
+        {
+            CancelLogout();
+            break;
+        }
+    }
 }
 
-void PlayerbotMgr::HandleMasterOutgoingPacket(WorldPacket const& packet)
+
+/*void PlayerbotMgr::HandleMasterOutgoingPacket(WorldPacket const& packet)
 {
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
@@ -1636,9 +2003,36 @@ void PlayerbotMgr::HandleMasterOutgoingPacket(WorldPacket const& packet)
         if (botAI && botAI->GetMaster() == GetMaster())
             botAI->HandleMasterOutgoingPacket(packet);
     }
+}*/
+void PlayerbotMgr::HandleMasterOutgoingPacket(WorldPacket const& packet)
+{
+    // Snapshot of "master" bots under lock
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+    {
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI)
+            botAI->HandleMasterOutgoingPacket(packet);
+    }
+
+    // Random bots loop unchanged
+    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
+         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    {
+        Player* const bot = it->second;
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI && botAI->GetMaster() == GetMaster())
+            botAI->HandleMasterOutgoingPacket(packet);
+    }
 }
 
-void PlayerbotMgr::SaveToDB()
+/*void PlayerbotMgr::SaveToDB()
 {
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
@@ -1651,6 +2045,32 @@ void PlayerbotMgr::SaveToDB()
     {
         Player* const bot = it->second;
         if (GET_PLAYERBOT_AI(bot) && GET_PLAYERBOT_AI(bot)->GetMaster() == GetMaster())
+            bot->SaveToDB(false, false);
+    }
+}*/
+
+void PlayerbotMgr::SaveToDB()
+{
+    // Snapshot of "master" bots under lock
+    std::vector<Player*> botsCopy;
+    {
+        std::lock_guard<std::mutex> lk(g_botMapsMx);
+        for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+            botsCopy.push_back(it->second);
+    }
+
+    for (Player* const bot : botsCopy)
+    {
+        if (bot)
+            bot->SaveToDB(false, false);
+    }
+
+    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
+         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    {
+        Player* const bot = it->second;
+        PlayerbotAI* ai = GET_PLAYERBOT_AI(bot);
+        if (ai && ai->GetMaster() == GetMaster())
             bot->SaveToDB(false, false);
     }
 }

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -591,6 +591,17 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
         bot->CleanupAfterTaxiFlight();
     }
 
+    // [Fix MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full: 0x00000000000019ba Type: Player Low: 6586] Ensure valid speeds before any next movement command
+    bot->StopMoving();
+    bot->UpdateSpeed(MOVE_WALK,   true);
+    bot->UpdateSpeed(MOVE_RUN,    true);
+    bot->UpdateSpeed(MOVE_SWIM,   true);
+    bot->UpdateSpeed(MOVE_FLIGHT, true);   // OK even if not flying
+    
+    if (bot->GetSpeed(MOVE_RUN) <= 0.01f) // Belt-and-suspenders: if the run speed has stayed ~0, reset to the default rate
+        bot->SetSpeedRate(MOVE_RUN, 1.0f);
+    // End Fix
+
     // check activity
     botAI->AllowActivity(ALL_ACTIVITY, true);
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -1772,7 +1772,8 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (botAI)
             botAI->Reset(true);
-        bot->TeleportTo(loc.GetMapId(), x, y, z, 0);
+        //bot->TeleportTo(loc.GetMapId(), x, y, z, 0);
+		TeleportToSafe(bot, loc.GetMapId(), x, y, z, 0); // [Fix] Avoid silly teleports
         bot->SendMovementFlagUpdate();
 
         if (pmo)
@@ -3047,7 +3048,8 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
             } while (true);
         }
 
-        player->TeleportTo(botPos);
+        // player->TeleportTo(botPos);
+		TeleportToSafe(player, botPos); // [Fix] Avoid silly teleports
 
         // player->Relocate(botPos.getX(), botPos.getY(), botPos.getZ(), botPos.getO());
     }

--- a/src/strategy/actions/AreaTriggerAction.cpp
+++ b/src/strategy/actions/AreaTriggerAction.cpp
@@ -9,6 +9,7 @@
 #include "LastMovementValue.h"
 #include "Playerbots.h"
 #include "Transport.h"
+#include "BotMovementUtils.h"
 
 bool ReachAreaTriggerAction::Execute(Event event)
 {
@@ -40,7 +41,18 @@ bool ReachAreaTriggerAction::Execute(Event event)
         return true;
     }
 
-    bot->GetMotionMaster()->MovePoint(at->map, at->x, at->y, at->z);
+    // bot->GetMotionMaster()->MovePoint(at->map, at->x, at->y, at->z);
+	// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+	if (CanStartMoveSpline(bot))
+	{
+		bot->GetMotionMaster()->MovePoint(at->map, at->x, at->y, at->z);
+	}
+	else
+	{
+		bot->StopMovingOnCurrentPos();
+		botAI->SetNextCheckDelay(sPlayerbotAIConfig->reactDelay);
+		return false;
+	}
 
     float distance = bot->GetDistance(at->x, at->y, at->z);
     float delay = 1000.0f * distance / bot->GetSpeed(MOVE_RUN) + sPlayerbotAIConfig->reactDelay;

--- a/src/strategy/actions/BattleGroundJoinAction.cpp
+++ b/src/strategy/actions/BattleGroundJoinAction.cpp
@@ -176,7 +176,8 @@ bool BGJoinAction::gatherArenaTeam(ArenaType type)
             continue;
 
         memberBotAI->Reset();
-        member->TeleportTo(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), 0);
+        // member->TeleportTo(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), 0);
+		TeleportToSafe(member, bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), 0);
 
         LOG_INFO("playerbots", "Bot {} <{}>: Member of <{}>", member->GetGUID().ToString().c_str(),
                  member->GetName().c_str(), arenateam->GetName().c_str());

--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -4289,9 +4289,11 @@ bool ArenaTactics::moveToCenter(Battleground* bg)
             {
                 // they like to hang around at the tip of the pipes doing nothing, so we just teleport them down
                 if (bot->GetDistance(1333.07f, 817.18f, 13.35f) < 4)
-                    bot->TeleportTo(bg->GetMapId(), 1330.96f, 816.75f, 3.2f, bot->GetOrientation());
+                    // bot->TeleportTo(bg->GetMapId(), 1330.96f, 816.75f, 3.2f, bot->GetOrientation());
+				TeleportToSafe(bot, bg->GetMapId(), 1330.96f, 816.75f, 3.2f, bot->GetOrientation()); // [Fix] Avaid silly teleport
                 if (bot->GetDistance(1250.13f, 764.79f, 13.34f) < 4)
-                    bot->TeleportTo(bg->GetMapId(), 1252.19f, 765.41f, 3.2f, bot->GetOrientation());
+                    // bot->TeleportTo(bg->GetMapId(), 1252.19f, 765.41f, 3.2f, bot->GetOrientation());
+				TeleportToSafe(bot, bg->GetMapId(), 1252.19f, 765.41f, 3.2f, bot->GetOrientation());  // [Fix] Avaid silly teleport
             }
             break;
         case BATTLEGROUND_RV:

--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -42,6 +42,7 @@
 #include "Vehicle.h"
 #include "WaypointMovementGenerator.h"
 #include "Corpse.h"
+#include "BotMovementUtils.h"
 
 MovementAction::MovementAction(PlayerbotAI* botAI, std::string const name) : Action(botAI, name)
 {
@@ -81,6 +82,10 @@ bool MovementAction::JumpTo(uint32 mapId, float x, float y, float z, MovementPri
     float botZ = bot->GetPositionZ();
     float speed = bot->GetSpeed(MOVE_RUN);
     MotionMaster& mm = *bot->GetMotionMaster();
+	// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+	if (!CanStartMoveSpline(bot))
+    return false;
+    // End Fix
     mm.Clear();
     mm.MoveJump(x, y, z, speed, speed, 1);
     AI_VALUE(LastMovement&, "last movement").Set(mapId, x, y, z, bot->GetOrientation(), 1000, priority);
@@ -207,6 +212,10 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
         if (distance > 0.01f)
         {
             MotionMaster& mm = *vehicleBase->GetMotionMaster();  // need to move vehicle, not bot
+			// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+			if (!CanStartMoveSpline(bot))
+            return false;
+		    // End Fix
             mm.Clear();
             if (!backwards)
             {
@@ -242,6 +251,10 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             //     botAI->InterruptSpell();
             // }
             MotionMaster& mm = *bot->GetMotionMaster();
+			//[Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+			if (!CanStartMoveSpline(bot))
+            return false;
+		    // End Fix
             mm.Clear();
             if (!backwards)
             {
@@ -284,6 +297,10 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
             // }
             MotionMaster& mm = *bot->GetMotionMaster();
             G3D::Vector3 endP = path.back();
+			// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+			if (!CanStartMoveSpline(bot))
+            return false;
+			// End Fix
             mm.Clear();
             if (!backwards)
             {

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -147,7 +147,8 @@ bool AutoReleaseSpiritAction::HandleBattlegroundSpiritHealer()
         // and in IOC it's not within clicking range when they res in own base
 
         // Teleport to nearest friendly Spirit Healer when not currently in range of one.
-        bot->TeleportTo(bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f);
+        // bot->TeleportTo(bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f);
+		TeleportToSafe(bot, bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f); // [Fix] Avoid silly teleport
         RESET_AI_VALUE(bool, "combat::self target");
         RESET_AI_VALUE(WorldPosition, "current position");
     }
@@ -244,7 +245,8 @@ int64 RepopAction::CalculateDeadTime() const
 
 void RepopAction::PerformGraveyardTeleport(const GraveyardStruct* graveyard) const
 {
-    bot->TeleportTo(graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f);
+    // bot->TeleportTo(graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f);
+	TeleportToSafe(bot, graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f); // [Fix] Avoid Silly teleport
     RESET_AI_VALUE(bool, "combat::self target");
     RESET_AI_VALUE(WorldPosition, "current position");
 }

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -169,7 +169,8 @@ bool FindCorpseAction::Execute(Event event)
         if (deadTime > delay)
         {
             bot->GetMotionMaster()->Clear();
-            bot->TeleportTo(moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0);
+            // bot->TeleportTo(moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0);
+			TeleportToSafe(bot, moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0); // [fix] Avoid Silly Teleport
         }
 
         moved = true;
@@ -350,7 +351,8 @@ bool SpiritHealerAction::Execute(Event event)
     // if (!botAI->HasActivePlayerMaster())
     // {
     context->GetValue<uint32>("death count")->Set(dCount + 1);
-    return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
+    // return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
+	return TeleportToSafe(bot, ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f); // [Fix] Avoid Silly teleport
     // }
 
     // LOG_INFO("playerbots", "Bot {} {}:{} <{}> can't find a spirit healer", bot->GetGUID().ToString().c_str(),

--- a/src/strategy/raids/icecrown/RaidIccActions.cpp
+++ b/src/strategy/raids/icecrown/RaidIccActions.cpp
@@ -957,7 +957,8 @@ bool IccGunshipTeleportHordeAction::Execute(Event event)
 
 bool IccGunshipTeleportHordeAction::TeleportTo(const Position& position)
 {
-    return bot->TeleportTo(bot->GetMapId(), position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),
+    // return bot->TeleportTo(bot->GetMapId(), position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),
+	return TeleportToSafe(bot, bot->GetMapId(), position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),// [Fix]Avoid silly teleport
                            bot->GetOrientation());
 }
 

--- a/src/strategy/raids/naxxramas/RaidNaxxActions.cpp
+++ b/src/strategy/raids/naxxramas/RaidNaxxActions.cpp
@@ -9,6 +9,7 @@
 #include "RaidNaxxStrategy.h"
 #include "ScriptedCreature.h"
 #include "SharedDefines.h"
+#include "BotMovementUtils.h"
 
 bool GrobbulusGoBehindAction::Execute(Event event)
 {
@@ -258,11 +259,26 @@ bool RazuviousUseObedienceCrystalAction::Execute(Event event)
             return false;
         }
         if (charm->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_ACTIVE) == NULL_MOTION_TYPE)
-        {
+        /*{
             charm->GetMotionMaster()->Clear();
             charm->GetMotionMaster()->MoveChase(target);
             charm->GetAI()->AttackStart(target);
+        }*/
+		// [Fix: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID Full:]
+		{
+            if (CanStartMoveSpline(charm))
+            {
+                charm->GetMotionMaster()->Clear();
+                charm->GetMotionMaster()->MoveChase(target);
+            }
+            else
+            {
+                charm->StopMoving();
+            }
+        
+            charm->GetAI()->AttackStart(target);
         }
+		// End Fix
         Aura* forceObedience = botAI->GetAura("force obedience", charm);
         uint32 duration_time;
         if (!forceObedience)

--- a/src/strategy/raids/ulduar/RaidUlduarActions.cpp
+++ b/src/strategy/raids/ulduar/RaidUlduarActions.cpp
@@ -1357,10 +1357,14 @@ bool KologarnMarkDpsTargetAction::Execute(Event event)
 
 bool KologarnFallFromFloorAction::Execute(Event event)
 {
-    return bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionX(),
+    /*return bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionX(),
                            ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionY(),
                            ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionZ(),
-                           ULDUAR_KOLOGARN_RESTORE_POSITION.GetOrientation());
+                           ULDUAR_KOLOGARN_RESTORE_POSITION.GetOrientation());*/
+	return TeleportToSafe(bot, bot->GetMapId(), ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionX(), // [Fix] Avoid silly teleport
+                      ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionY(),
+                      ULDUAR_KOLOGARN_RESTORE_POSITION.GetPositionZ(),
+                      ULDUAR_KOLOGARN_RESTORE_POSITION.GetOrientation());					   
 }
 
 bool KologarnFallFromFloorAction::isUseful()
@@ -1407,14 +1411,18 @@ bool KologarnEyebeamAction::Execute(Event event)
     KologarnEyebeamTrigger kologarnEyebeamTrigger(botAI);
     if (runToLeftSide)
     {
-        teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionX(),
+        // teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionX(),
+		teleportedToPoint = TeleportToSafe(bot, bot->GetMapId(), 
+		                                    ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionX(),
                                             ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionY(),
                                             ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetPositionZ(),
                                             ULDUAR_KOLOGARN_EYEBEAM_LEFT_POSITION.GetOrientation());
     }
     else
     {
-        teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionX(),
+        // teleportedToPoint = bot->TeleportTo(bot->GetMapId(), ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionX(),
+		teleportedToPoint = TeleportToSafe(bot, bot->GetMapId(),
+		                                    ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionX(),
                                             ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionY(),
                                             ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetPositionZ(),
                                             ULDUAR_KOLOGARN_EYEBEAM_RIGHT_POSITION.GetOrientation());

--- a/src/strategy/raids/vaultofarchavon/RaidVoAActions.cpp
+++ b/src/strategy/raids/vaultofarchavon/RaidVoAActions.cpp
@@ -175,9 +175,13 @@ bool EmalonOverchargeAction::isUseful()
 
 bool EmalonFallFromFloorAction::Execute(Event event)
 {
-    return bot->TeleportTo(bot->GetMapId(), VOA_EMALON_RESTORE_POSITION.GetPositionX(),
+    /*return bot->TeleportTo(bot->GetMapId(), VOA_EMALON_RESTORE_POSITION.GetPositionX(),
                            VOA_EMALON_RESTORE_POSITION.GetPositionY(), VOA_EMALON_RESTORE_POSITION.GetPositionZ(),
-                           VOA_EMALON_RESTORE_POSITION.GetOrientation());
+                           VOA_EMALON_RESTORE_POSITION.GetOrientation());*/
+	return TeleportToSafe(bot, bot->GetMapId(), VOA_EMALON_RESTORE_POSITION.GetPositionX(), //[Fix] Avoid Silly Teleport
+                      VOA_EMALON_RESTORE_POSITION.GetPositionY(),
+                      VOA_EMALON_RESTORE_POSITION.GetPositionZ(),
+                      VOA_EMALON_RESTORE_POSITION.GetOrientation());					   
 }
 
 bool EmalonFallFromFloorAction::isUseful()

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -67,7 +67,8 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
             bot->GetName(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot->GetMapId(),
             dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(), dest.getMapId(), bot->GetZoneId(),
             zone_name);
-        return bot->TeleportTo(dest);
+        // return bot->TeleportTo(dest);
+		return TeleportToSafe(bot, dest); //[Fix] Avoid Silly teleport
     }
 
     float dis = bot->GetExactDist(dest);


### PR DESCRIPTION
### Summary
This PR fixes intermittent crashes and container corruptions caused by concurrent access to playerBots (map) and botLoading (unordered_set) in PlayerbotMgr/PlayerbotHolder.

### Approach

- Introduce a single global mutex to serialize all reads/writes to playerBots and botLoading.
- Replace “live” iterations over playerBots with snapshots taken under the lock, then iterate outside the lock.
- Harden critical login/logout code paths (AddPlayerBot, HandlePlayerBotLoginCallback, OnBotLogin, etc.).

### Context & Symptoms

- Crash in std::_Hash<...>::erase inside HandlePlayerBotLoginCallback (erasing from botLoading).
- Sporadic visibility/relocation crashes consistent with iterating playerBots while it’s being modified.
- Multi-thread context: world thread, PlayerbotCommandServer (network) thread, async DB callbacks, etc.

### Root Cause

- No global synchronization around playerBots/botLoading.
- Writes (insert/erase) can occur while other threads read/iterate those containers → iterator invalidation and internal corruption.

**Changes (by area)**
**Global mutex**
Added at the top of PlayerbotMgr.cpp:

```
#include <mutex>
static std::mutex g_botMapsMx; // protects playerBots and botLoading
```
AddPlayerBot

- Merge check + insert into a single critical section:


- if (botLoading.find(guid)) return; and botLoading.insert(guid); are now atomic under the same lock.


- Read botLoading.size() under the lock and use a local loadingCount for quota calculations.
- Removes a small race window during concurrent adds.

**HandlePlayerBotLoginCallback**

- Copy guid and masterAccountId before HandlePlayerLoginFromDB(holder).
- All erases from botLoading now go through:

```
{ std::lock_guard<std::mutex> lk(g_botMapsMx); botLoading.erase(guid); }
Avoids reading from holder after login and removes unguarded erase.
```

**OnBotLogin**

- Perform check + insert into playerBots inside the same lock.
- Remove duplicate write to playerBots that happened later without a lock.

**Get/Remove helpers**

- RemoveFromPlayerbotsMap(ObjectGuid) does erase under the lock.
- GetPlayerBot(ObjectGuid) and GetPlayerBot(LowType) do find under the lock.

**Iterations → snapshots**
All functions that previously iterated directly over playerBots now take a snapshot (local copy) under the lock and iterate outside the lock:

- LogoutAllBots()
- UpdateSessions()
- CancelLogout() (first loop for master’s bots)
- HandleMasterIncomingPacket() (master’s bots loop)
- HandleMasterOutgoingPacket() (master’s bots loop)
- HandleCommand() (master’s bots loop)
- SaveToDB() (master’s bots loop)
- ListBots()
- GetPlayerbotsCountByClass()
- ProcessBotCommand() — charnameStr == "!" branch (online names collection)

**Guard read access too (when writers exist)**

- Any botLoading.find(...)/size() used where concurrent writes can happen is now done under g_botMapsMx
- (e.g., in addclass flows).

**Expected Effects**
✅ No more crashes in unordered_set::erase on botLoading.
✅ No more invalid-iterator asserts while iterating playerBots.
✅ Deterministic add/logout behavior under load (mass adds, “logout all”, cancel spam).

**Performance Impact**

- Minor overhead from the mutex and snapshot copies (mostly noticeable in Debug).
- In Release, impact is negligible versus the stability gain.
- Locks are held only while taking snapshots, keeping critical sections short.


**Testing Plan (manual)**

1. Concurrent adds: spam add commands (in-game + command server) → no crashes, no asserts.
2. Double add same GUID: two quick adds for the same bot → single login, no corruption.
3. LogoutAllBots: initiate master logout (Esc → Logout or /logout) while adds are ongoing → all bots log out cleanly.
4. CancelLogout spam: repeatedly start/cancel master logout → bots cancel cleanly, no crashes.
5. Packet traffic: move/cast with master to exercise HandleMasterIncoming/OutgoingPacket → no issues.
6. Save under load: run save operations while bots connect/disconnect → no errors, no contention spikes.

**Notes on Design Choices**

- Single std::mutex keeps things simple. We favor snapshots to minimize lock duration rather than introducing std::shared_mutex.
- No public API changes; purely internal synchronization and iteration strategy.

**Compatibility & Risks**

- Backward compatible: no signature changes.
- Main risk is future unguarded access sneaking back in.


- Mitigation: simple rule — any access to playerBots/botLoading must be done either under the mutex or via a snapshot taken under the mutex.

**Checklist**

1.  Global mutex added.
2.  AddPlayerBot: atomic check+insert; size() guarded.
3.  HandlePlayerBotLoginCallback: local copies; guarded erase.
4.  OnBotLogin: guarded insert; removed unlocked duplicate write.
5.  Get/Remove: find/erase guarded.
6.  All master-bot loops converted to snapshots.
7.  All botLoading reads guarded where writers exist.
8. Debug build stable; manual tests pass.
