### PR TITLE
A few minor adjustments to the code from earlier PRs (oversights).

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -720,14 +720,16 @@ void PlayerbotAI::HandleTeleportAck()
         {
             bot->GetSession()->HandleMoveWorldportAck();
         }
-        // SetNextCheckDelay(urand(2000, 5000));
-		SetNextCheckDelay(urand(500, 1500)); // short delay to break bursts without hindering gameplay
+
         if (sPlayerbotAIConfig->applyInstanceStrategies)
             ApplyInstanceStrategies(bot->GetMapId(), true);
         EvaluateHealerDpsStrategy();
         Reset(true);
+		
+		SetNextCheckDelay(urand(300, 700)); // Safety : short delay after a worldport to prevent rapid re-teleports.
+		return;
     }
-
+    // If teleportNear : we stay cool and keep the standard GCD.
     SetNextCheckDelay(sPlayerbotAIConfig->globalCoolDown);
 }
 

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -352,7 +352,7 @@ public:
     }*/
 
     // New LFG Function
-    bool OnPlayerbotCheckLFGQueue(lfg::Lfg5Guids const& guidsList)
+    bool OnPlayerbotCheckLFGQueue(lfg::Lfg5Guids const& guidsList) override // Fix missing override
     {
         const size_t totalSlots = guidsList.guids.size();
         size_t ignoredEmpty = 0, ignoredNonPlayer = 0;

--- a/src/Playerbots.h
+++ b/src/Playerbots.h
@@ -58,6 +58,10 @@ inline bool TeleportToSafe(Player* p, uint32 mapId, float x, float y, float z, f
 {
     if (!p) return false;
 
+    // Do not attempt another teleport if the client is already teleporting (safety check).
+    if (p->IsBeingTeleportedNear() || p->IsBeingTeleportedFar())
+        return false;
+	
     // If the height is invalid (-200000) or not finite, attempt ONE correction on the same map.
     if (z <= -199000.0f || !std::isfinite(z))
     {
@@ -80,9 +84,7 @@ inline bool TeleportToSafe(Player* p, uint32 mapId, float x, float y, float z, f
 inline bool TeleportToSafe(Player* p, Position const& pos)
 {
     // Position doesn't have mapId: we keep actual bot map
-    return TeleportToSafe(p, p->GetMapId(),
-                          pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(),
-                          pos.GetOrientation());
+    return TeleportToSafe(p, p->GetMapId(), pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation());
 }
 
 inline bool TeleportToSafe(Player* p, WorldPosition pos)


### PR DESCRIPTION
Not a big deal but:
The override are important.
Added another security to "TeleportToSafe" function, to do not attempt another teleport if the client is already teleporting.

On "PlayerbotAI::HandleTeleportAck()": Just reduced the delay:

```
SetNextCheckDelay(urand(300, 700)); // Safety : short delay after a worldport to prevent rapid re-teleports.
		return;
```
