### PR TITLE
nullptr fix

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -1017,15 +1017,18 @@ void PlayerbotFactory::ClearSkills()
     }
     bot->SetUInt32Value(PLAYER_SKILL_INDEX(0), 0);
     bot->SetUInt32Value(PLAYER_SKILL_INDEX(1), 0);
+    
     // unlearn default race/class skills
-    PlayerInfo const* info = sObjectMgr->GetPlayerInfo(bot->getRace(), bot->getClass());
-    for (PlayerCreateInfoSkills::const_iterator itr = info->skills.begin(); itr != info->skills.end(); ++itr)
-    {
-        uint32 skillId = itr->SkillId;
-        if (!bot->HasSkill(skillId))
-            continue;
-        bot->SetSkill(skillId, 0, 0, 0);
-    }
+    if (PlayerInfo const* info = sObjectMgr->GetPlayerInfo(bot->getRace(), bot->getClass()))
+    {    
+        for (PlayerCreateInfoSkills::const_iterator itr = info->skills.begin(); itr != info->skills.end(); ++itr)
+        {
+            uint32 skillId = itr->SkillId;
+            if (!bot->HasSkill(skillId))
+                continue;
+            bot->SetSkill(skillId, 0, 0, 0);
+        }
+    }    
 }
 
 void PlayerbotFactory::ClearEverything()


### PR DESCRIPTION
https://github.com/liyunfan1223/mod-playerbots/issues/1522


```
PlayerInfo const* info = sObjectMgr->GetPlayerInfo(bot->getRace(), bot->getClass());
for (PlayerCreateInfoSkills::const_iterator itr = info->skills.begin(); itr != info->skills.end(); ++itr)
```

GetPlayerInfo can return null in multiple scenario's, regardless whether the scenario should exist or not
it should not crash the server.

```
PlayerInfo const* ObjectMgr::GetPlayerInfo(uint32 race, uint32 class_) const
{
    if (race >= MAX_RACES)
        return nullptr;
    if (class_ >= MAX_CLASSES)
        return nullptr;
    PlayerInfo const* info = _playerInfo[race][class_];
    if (!info)
        return nullptr;
    return info;
}
```