### PR TITLE
nullptr fix

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -161,23 +161,35 @@ void PlayerbotFactory::Init()
     {
         uint32 gemId = iter->GemID;
         if (gemId == 0)
+        {
             continue;
+        }
         
         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(gemId);
-        if (!proto) 
-            continue
-                
-        if (proto->ItemLevel < 60)    
-            continue;   
-
-        if (proto->Flags & ITEM_FLAG_UNIQUE_EQUIPPABLE)
+        if (!proto)
+        {
             continue;
+        }
+        
+        if (proto->ItemLevel < 60)
+        {
+            continue;
+        }
+        
+        if (proto->Flags & ITEM_FLAG_UNIQUE_EQUIPPABLE)
+        {
+            continue;
+        }
         
         if (sRandomItemMgr->IsTestItem(gemId))
-            continue;
-
+        {
+           continue;
+        }
+            
         if (!sGemPropertiesStore.LookupEntry(proto->GemProperties))
+        {
             continue;
+        }
         
         // LOG_INFO("playerbots", "Add {} to enchantment gems", gemId);
         enchantGemIdCache.push_back(gemId);

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -161,25 +161,24 @@ void PlayerbotFactory::Init()
     {
         uint32 gemId = iter->GemID;
         if (gemId == 0)
-        {
             continue;
-        }
+        
         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(gemId);
-
-        if (proto->ItemLevel < 60)
-            continue;
+        if (!proto) 
+            continue
+                
+        if (proto->ItemLevel < 60)    
+            continue;   
 
         if (proto->Flags & ITEM_FLAG_UNIQUE_EQUIPPABLE)
-        {
             continue;
-        }
+        
         if (sRandomItemMgr->IsTestItem(gemId))
             continue;
 
-        if (!proto || !sGemPropertiesStore.LookupEntry(proto->GemProperties))
-        {
+        if (!sGemPropertiesStore.LookupEntry(proto->GemProperties))
             continue;
-        }
+        
         // LOG_INFO("playerbots", "Add {} to enchantment gems", gemId);
         enchantGemIdCache.push_back(gemId);
     }


### PR DESCRIPTION
#1516

```
 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(gemId);

 if (proto->ItemLevel < 60) 
    continue;
```

proto can be nullptr

```
ItemTemplate const* ObjectMgr::GetItemTemplate(uint32 entry)
{
    return entry < _itemTemplateStoreFast.size() ? _itemTemplateStoreFast[entry] : nullptr;
}
```