### PR TITLE
MoveToTravelTargetAction prevent delay when in combat

### DIFF
--- a/src/strategy/actions/MoveToTravelTargetAction.cpp
+++ b/src/strategy/actions/MoveToTravelTargetAction.cpp
@@ -18,7 +18,7 @@ bool MoveToTravelTargetAction::Execute(Event event)
     WorldLocation location = *target->getPosition();
 
     Group* group = bot->GetGroup();
-    if (group && !urand(0, 1) && bot == botAI->GetGroupMaster())
+    if (group && !urand(0, 1) && bot == botAI->GetGroupMaster() && !bot->IsInCombat())
     {
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {


### PR DESCRIPTION
This code makes sure the group stays within range, by adding checkDelay which isnt ideal when in combat. Doing that in combat can freeze or slow the leader’s combat reactions (taunts, heals, interrupts whatever). 

When in combat bot the bot should prioritize on not dieing, not herding group members.
