### PR TITLE
WIP:  Agnostic Naxx40+Ony40 strat integration (mod-individual-progression) without adding dependency to external code/module

### DIFF
--- a/src/strategy/raids/naxxramas/RaidNaxxAi40.h
+++ b/src/strategy/raids/naxxramas/RaidNaxxAi40.h
@@ -1,0 +1,83 @@
+/*
+ * Cast intended Naxxramas 40 struct for mod-individual-progression Naxx classes
+ */
+
+#ifndef _PLAYERBOT_RAIDNAXXAI40_H
+#define _PLAYERBOT_RAIDNAXXAI40_H
+
+#include "EventMap.h"
+#include "CreatureAIImpl.h"
+#include "ObjectGuid.h"
+#include "ScriptMgr.h"
+#include "ScriptedCreature.h"
+#include "SpellInfo.h"
+#include <list>
+
+struct BossAiHeigan40 : BossAI
+{
+    EventMap events;
+    uint8 currentPhase{};
+    uint8 currentSection{};
+    bool moveRight{};
+    GuidList portedPlayersThisPhase;
+};
+
+struct BossAiGrobbulus40 : BossAI
+{
+    EventMap events;
+    SummonList summons;
+    uint32 dropSludgeTimer{};
+};
+
+struct BossAiGluth40 : BossAI
+{
+    EventMap events;
+    SummonList summons;
+};
+
+struct BossAiThaddius40 : BossAI
+{
+    EventMap events;
+    SummonList summons;
+    uint32 summonTimer{};
+    uint32 reviveTimer{};
+    uint32 resetTimer{};
+    bool ballLightningEnabled;
+};
+
+struct BossAiRazuvious40 : BossAI
+{
+    EventMap events;
+    SummonList summons;
+};
+
+struct BossAiFourhorsemen40 : BossAI
+{
+    EventMap events;
+    uint8 horsemanId;
+    bool doneFirstShieldWall;
+};
+
+struct BossAiLoatheb40 : BossAI
+{
+    uint8 doomCounter;
+    EventMap events;
+    SummonList summons;
+};
+
+struct BossAiSapphiron40 : BossAI
+{
+    EventMap events;
+    uint8 iceboltCount{};
+    uint32 spawnTimer{};
+    GuidList blockList;
+    ObjectGuid currentTarget;
+};
+
+struct BossAiKelthuzad40 : BossAI
+{
+    EventMap events;
+    SummonList summons;
+};
+
+#endif

--- a/src/strategy/raids/naxxramas/RaidNaxxTriggers.cpp
+++ b/src/strategy/raids/naxxramas/RaidNaxxTriggers.cpp
@@ -20,7 +20,7 @@ bool AuraRemovedTrigger::IsActive()
 bool MutatingInjectionRemovedTrigger::IsActive()
 {
     Unit* boss = AI_VALUE2(Unit*, "find target", "grobbulus");
-    if (!boss)
+    if (!boss || boss->isDead())
     {
         return false;
     }
@@ -31,11 +31,17 @@ template <class T>
 bool BossEventTrigger<T>::IsActive()
 {
     Unit* boss = AI_VALUE(Unit*, "boss target");
-    if (!boss || boss->GetEntry() != boss_entry)
+    if (!boss 
+        || (boss->GetEntry() != boss_entry // Default Azerothcore from BossEventTrigger instanciation
+            && (boss_entry_secondary == 0 || boss->GetEntry() != boss_entry_secondary))) // If an other boss version exists from an external module
     {
         return false;
     }
     T* ai = dynamic_cast<T*>(boss->GetAI());
+    if(!ai)
+    {
+        return false;
+    }
     EventMap* eventMap = &ai->events;
     if (!eventMap)
     {
@@ -53,7 +59,9 @@ bool BossEventTrigger<T>::IsActive()
 bool GrobbulusCloudTrigger::IsActive()
 {
     Unit* boss = AI_VALUE(Unit*, "boss target");
-    if (!boss || boss->GetEntry() != boss_entry)
+    if (!boss 
+        || (boss->GetEntry() != boss_entry // Default Azerothcore Grobbulus (15931)
+            && boss->GetEntry() != boss_entry_secondary)) // mod-individual-progression Grobbulus (351003)
     {
         return false;
     }
@@ -69,7 +77,7 @@ bool GrobbulusCloudTrigger::IsActive()
 bool HeiganMeleeTrigger::IsActive()
 {
     Unit* heigan = AI_VALUE2(Unit*, "find target", "heigan the unclean");
-    if (!heigan)
+    if (!heigan || heigan->isDead())
     {
         return false;
     }
@@ -79,7 +87,7 @@ bool HeiganMeleeTrigger::IsActive()
 bool HeiganRangedTrigger::IsActive()
 {
     Unit* heigan = AI_VALUE2(Unit*, "find target", "heigan the unclean");
-    if (!heigan)
+    if (!heigan || heigan->isDead())
     {
         return false;
     }
@@ -171,7 +179,7 @@ bool KelthuzadTrigger::IsActive() { return helper.UpdateBossAI(); }
 
 bool AnubrekhanTrigger::IsActive() {
     Unit* boss = AI_VALUE2(Unit*, "find target", "anub'rekhan");
-    if (!boss)
+    if (!boss || boss->isDead())
     {
         return false;
     }

--- a/src/strategy/raids/naxxramas/RaidNaxxTriggers.h
+++ b/src/strategy/raids/naxxramas/RaidNaxxTriggers.h
@@ -36,23 +36,24 @@ template <class T>
 class BossEventTrigger : public Trigger
 {
 public:
-    BossEventTrigger(PlayerbotAI* ai, uint32 boss_entry, uint32 event_id, std::string name = "boss event")
+    BossEventTrigger(PlayerbotAI* ai, uint32 event_id, uint32 boss_entry, uint32 boss_entry_secondary = 0, std::string name = "boss event")
         : Trigger(ai, name, 1)
     {
-        this->boss_entry = boss_entry;
         this->event_id = event_id;
+        this->boss_entry = boss_entry;
+        this->boss_entry_secondary = boss_entry_secondary;
         this->last_event_time = -1;
     }
     virtual bool IsActive();
 
 protected:
-    uint32 boss_entry, event_id, last_event_time;
+    uint32 event_id, boss_entry, boss_entry_secondary, last_event_time;
 };
 
 class GrobbulusCloudTrigger : public BossEventTrigger<Grobbulus::boss_grobbulus::boss_grobbulusAI>
 {
 public:
-    GrobbulusCloudTrigger(PlayerbotAI* ai) : BossEventTrigger(ai, 15931, 2, "grobbulus cloud event") {}
+    GrobbulusCloudTrigger(PlayerbotAI* ai) : BossEventTrigger(ai, 2, 15931, 351003, "grobbulus cloud event") {}
     virtual bool IsActive();
 };
 

--- a/src/strategy/raids/onyxia/RaidOnyxiaActions.cpp
+++ b/src/strategy/raids/onyxia/RaidOnyxiaActions.cpp
@@ -42,7 +42,7 @@ bool RaidOnyxiaSpreadOutAction::Execute(Event event)
 {
     Unit* boss = AI_VALUE2(Unit*, "find target", "onyxia");
 
-    if (!boss)
+    if (!boss || boss->isDead())
         return false;
 
     Player* target = boss->GetCurrentSpell(CURRENT_GENERIC_SPELL)->m_targets.GetUnitTarget()->ToPlayer();
@@ -56,7 +56,7 @@ bool RaidOnyxiaSpreadOutAction::Execute(Event event)
 bool RaidOnyxiaMoveToSafeZoneAction::Execute(Event event)
 {
     Unit* boss = AI_VALUE2(Unit*, "find target", "onyxia");
-    if (!boss)
+    if (!boss || boss->isDead())
         return false;
 
     Spell* currentSpell = boss->GetCurrentSpell(CURRENT_GENERIC_SPELL);
@@ -98,7 +98,9 @@ bool RaidOnyxiaKillWhelpsAction::Execute(Event event)
 {
     Unit* currentTarget = AI_VALUE(Unit*, "current target");
     // If already attacking a whelp, don't swap targets
-    if (currentTarget && currentTarget->GetEntry() == 11262)
+    if (currentTarget
+        && (currentTarget->GetEntry() == 11262 // Default AzerothCore Onyxian Whelp
+            || currentTarget->GetEntry() == 301001)) // mod-individual-progression Onyxian Whelp
     {
         return false;
     }
@@ -109,7 +111,8 @@ bool RaidOnyxiaKillWhelpsAction::Execute(Event event)
         if (!unit || !unit->IsAlive() || !unit->IsInWorld())
             continue;
 
-        if (unit->GetEntry() == 11262)  // Onyxia Whelp
+        if (unit->GetEntry() == 11262 // Default AzerothCore Onyxian Whelp
+            || unit->GetEntry() == 301001) // mod-individual-progression Onyxian Whelp
         {
             // bot->Yell("Attacking Whelps!", LANG_UNIVERSAL);
             return Attack(unit);


### PR DESCRIPTION
No worry if in the end you don't want to merge it (because vanilla strat for other modules are not really in the actual scope of mod-playerbots).

I'm taking your advice on how to improve this.
The code is a bit borderline because it use a LOT of reinterpret_casts.

Overall, it allows bots to play the vanilla fights (for mod-individual-progression) of Heigan / Grobbulus / Gluth / Razuvious / Loatheb / Sapphiron / KT and also to properly focus the adds on Onyxia.
Right now it's not well suited for Four Horsemen and it remains difficult on Thaddius, but overall the bots try to play the strat.

Works better with 10 players than with 40 (for example, with an autobalance module).
