### PR TITLE
NamedObjectContext improvements

### DIFF
--- a/src/strategy/NamedObjectContext.cpp
+++ b/src/strategy/NamedObjectContext.cpp
@@ -14,10 +14,10 @@ void Qualified::Qualify(int qual)
     qualifier = out.str();
 }
 
-std::string const Qualified::MultiQualify(std::vector<std::string> qualifiers, const std::string& separator, const std::string_view brackets)
+std::string const Qualified::MultiQualify(const std::vector<std::string>& qualifiers, const std::string& separator, const std::string_view brackets)
 {
     std::stringstream out;
-    for (uint8 i = 0; i < qualifiers.size(); i++)
+    for (uint8 i = 0; i < qualifiers.size(); ++i)
     {
         const std::string& qualifier = qualifiers[i];
         if (i == qualifiers.size() - 1)
@@ -40,13 +40,13 @@ std::string const Qualified::MultiQualify(std::vector<std::string> qualifiers, c
     }
 }
 
-std::vector<std::string> Qualified::getMultiQualifiers(std::string const qualifier1)
+std::vector<std::string> Qualified::getMultiQualifiers(const std::string& qualifier1)
 {
     std::istringstream iss(qualifier1);
     return {std::istream_iterator<std::string>{iss}, std::istream_iterator<std::string>{}};
 }
 
-int32 Qualified::getMultiQualifier(std::string const qualifier1, uint32 pos)
+int32 Qualified::getMultiQualifier(const std::string& qualifier1, uint32 pos)
 {
     return std::stoi(getMultiQualifiers(qualifier1)[pos]);
 }


### PR DESCRIPTION
remove unneccessary pass by copy
replace typedef with using std::fuction to allow lambda ObjectCreators simplification in strategies