### PR TITLE
Prefer group/raid buffs when possible (Paladin/Druid/Mage), with reagent checks and no rebuff if equivalent aura present

### DIFF
--- a/src/strategy/actions/GenericSpellActions.h
+++ b/src/strategy/actions/GenericSpellActions.h
@@ -215,17 +215,18 @@ protected:
     uint32 dispelType;
 };
 
+// Make Bots Paladin, druid, mage use the greater buff rank spell
 class BuffOnPartyAction : public CastBuffSpellAction, public PartyMemberActionNameSupport
 {
 public:
     BuffOnPartyAction(PlayerbotAI* botAI, std::string const spell)
-        : CastBuffSpellAction(botAI, spell), PartyMemberActionNameSupport(spell)
-    {
-    }
+        : CastBuffSpellAction(botAI, spell), PartyMemberActionNameSupport(spell) { }
 
     Value<Unit*>* GetTargetValue() override;
+    bool Execute(Event event) override;
     std::string const getName() override { return PartyMemberActionNameSupport::getName(); }
 };
+// End Fix
 
 class CastShootAction : public CastSpellAction
 {


### PR DESCRIPTION
### Small change to the non-combat buffing logic for bots:

- When in a party/raid of 3+ players, Paladin/Druid/Mage bots now prefer the group/raid variant of their buffs (Greater/Gift/Brilliance) if the spell is known and the required components are in the bags.
- If not possible (solo/duo, spell not learned, or component missing), bots fall back to the single-target version.
- Target selection now treats single and group variants as equivalent auras, so we don’t rebuff someone who already has the “other” version.

No changes to rotations/strategies beyond buffing behaviour. Priests were already covered by Prayer of ... logic, so untouched.


Based on my knowledge of wotlk 3.3.5, Paladins, Druids and Mages use the group buff out of combat to save GCDs and keep things blizzlike. The current code only ever asks for the single-target spell by name, so bots never attempt the raid version even when they have the component. Also, target lookup didn’t consider “equivalent” auras, causing some pointless rebuffs if someone else applied the group version.
This PR fixes both pain points while keeping the implementation tight and centralised.

Mecanics:
**Target selection (BuffOnPartyAction::GetTargetValue):**
Build an aura qualifier that lists both variants (exemple:"mark of the wild,gift of the wild"), so “party member without aura” ignores units already covered by either one.

**Cast decision (BuffOnPartyAction::Execute):**

- If group->GetMembersCount() >= 3, try to map the single-target spell name to its group variant:

Paladin: Kings/Might/Wisdom/Sanctuary => Greater ...
Druid: Mark of the Wild =>Gift of the Wild
Mage: Arcane Intellect =>Arcane Brilliance

- Resolve the highest learned rank via existing "spell id" value.

- Check component from SpellInfo::Reagent[i]/ReagentCount[i]. If any are missing, stick to the single-target spell.

- Cast proceeds as usual.

**Hard coded choice (may be changed, i don't bor better roleplay?):**

- Threshold = 3 members before using group buffs. This avoids burning componants in a 2 man party where the benefit is marginal.

- No new strategies/triggers, just a centralised decision in the generic action.

**Results:**

- Paladin: uses Greater Blessings (consuming Symbol of Kings) in groups of 3+, otherwise single blessings.
- Druid: uses Gift of the Wild (consuming Wild Spineleaf at max rank) in groups of 3+.
- Mage: uses Arcane Brilliance (consuming Arcane Powder) in groups of 3+.
- Priest: unchanged (Prayer of Fortitude/Spirit/Shadow Protection already supported).

**Bonus:**
Added some funny RP sentences

**How to test this:**

- Solo: bot sticks to single-target buffs only.
- Duo (2 players): still single-target (by design).
- 3+ players, with componant in bags: bot uses Greater/Gift/Brilliance and does not rebuff players who already have the “other” variant.
- 3+ players, no component: clean fallback to single-target, no spam.
- Mixed parties where someone else applied the group aura: target selection correctly skips already-buffed players.