### PR TITLE
Update English readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
     <a href="https://github.com/liyunfan1223/mod-playerbots/blob/master/README.md">English</a>
     |
     <a href="https://github.com/liyunfan1223/mod-playerbots/blob/master/README_CN.md">中文</a>
+    |
+    <a href="https://github.com/brighton-chi/mod-playerbots/blob/readme/README_ES.md">Español</a>
 </p>
 
 
@@ -16,23 +18,25 @@
 </div>
 
 # Playerbots Module
-`mod-playerbots` is an [AzerothCore](https://www.azerothcore.org/) module that adds player-like bots to a server. The project is based off [IKE3's Playerbots](https://github.com/ike3/mangosbot). Features include:
+`mod-playerbots` is an [AzerothCore](https://www.azerothcore.org/) module that adds player-like bots to a server. The project is based off [IKE3's Playerbots](https://github.com/ike3/mangosbot) and requires a custom branch of AzerothCore to compile and run: [liyunfan1223/azerothcore-wotlk/tree/Playerbot](https://github.com/liyunfan1223/azerothcore-wotlk/tree/Playerbot).
 
-- Bots that utilize real player data, allowing players to interact with their other characters, form parties, level up, and more;
-- Random bots that wander through the world and behave like players, simulating the MMO experience;
-- Bots capable of running raids and battlegrounds;
+Features include:
+
+- The ability to log in alt characters as bots, allowing players to interact with their other characters, form parties, level up, and more;
+- Random bots that wander through the world, complete quests, and otherwise behave like players, simulating the MMO experience;
+- Bots capable of running most raids and battlegrounds;
 - Highly configurable settings to define how bots behave;
 - Excellent performance, even when running thousands of bots.
 
 **This project is still under development**. If you encounter any errors or experience crashes, we kindly request that you [report them as GitHub issues](https://github.com/liyunfan1223/mod-playerbots/issues/new?template=bug_report.md). Your valuable feedback will help us improve this project collaboratively.
 
-**Playerbots Module** has a **[Discord server](https://discord.gg/NQm5QShwf9)** where you can discuss the project.
+`mod-playerbots` has a **[Discord server](https://discord.gg/NQm5QShwf9)** where you can discuss the project, ask questions, and get involved in the community!
 
 ## Installation
 
 ### Classic Installation
 
-`mod-playerbots` requires a custom branch of AzerothCore to work: [liyunfan1223/azerothcore-wotlk/tree/Playerbot](https://github.com/liyunfan1223/azerothcore-wotlk/tree/Playerbot). To install the module, simply run:
+As noted above, `mod-playerbots` requires a custom branch of AzerothCore: [liyunfan1223/azerothcore-wotlk/tree/Playerbot](https://github.com/liyunfan1223/azerothcore-wotlk/tree/Playerbot). To install the module, simply run:
 
 ```bash
 git clone https://github.com/liyunfan1223/azerothcore-wotlk.git --branch=Playerbot
@@ -81,21 +85,21 @@ Use `docker compose up -d --build` to build and run the server. For more informa
 
 ## Documentation
 
-The [Playerbots Wiki](https://github.com/liyunfan1223/mod-playerbots/wiki) contains an extensive overview of addons, commands, and recommended configurations. Please note that documentation may be incomplete or out-of-date in some sections. Contributions are welcome.
+The [Playerbots Wiki](https://github.com/liyunfan1223/mod-playerbots/wiki) contains an extensive overview of addons, commands, raids with programmed bot strategies, and recommended performance configurations. Please note that documentation may be incomplete or out-of-date in some sections. Contributions are welcome.
 
 ## Frequently Asked Questions
 
 - **Why aren't my bots casting spells?** Please make sure that the necessary English DBC file (enUS) is present.
 - **What platforms are supported?** We support Ubuntu, Windows, and macOS. Other Linux distros may work, but will not receive support.
-- **Why isn't my source compiling?** Please [check the build status of our CI](https://github.com/liyunfan1223/mod-playerbots/actions). If the latest build is failing, rever to the last successful commit until we address the issue.
+- **Why isn't my source compiling?** Please ensure that you are compiling with the required [custom branch of AzerothCore](https://github.com/liyunfan1223/azerothcore-wotlk/tree/Playerbot). Additionally, please [check the build status of our CI](https://github.com/liyunfan1223/mod-playerbots/actions). If the latest build is failing, rever to the last successful commit until we address the issue.
 
 ## Addons
 
 Typically, bots are controlled via chat commands. For larger bot groups, this can be unwieldy. As an alternative, community members have developed client Add-Ons to allow controlling bots through the in-game UI. We recommend you check out their projects:
 
-- [Multibot](https://github.com/Macx-Lio/MultiBot) (by Macx-Lio)
-- [Unbot Addon (zh)](https://github.com/liyunfan1223/unbot-addon) (Chinese version by Liyunfan)
-- [Unbot Addon (en)](https://github.com/noisiver/unbot-addon/tree/english) (English version translated by @Revision)
+- [Multibot](https://github.com/Macx-Lio/MultiBot) (by Macx-Lio), which includes English, Chinese, French, German, Korean, Russian, and Spanish support [note: active development is temporarily continuing on a fork in Macx-Lio's absence (https://github.com/Wishmaster117/MultiBot)]
+- [Unbot Addon (zh)](https://github.com/liyunfan1223/unbot-addon) (Chinese version by Liyunfan) [note: no longer under active development]
+- [Unbot Addon (en)](https://github.com/noisiver/unbot-addon/tree/english) (English version translated by @Revision) [note: no longer under active development]
 
 ## Acknowledgements
 


### PR DESCRIPTION
This PR is to bring some of the English readme references up to date and to move the reference and link to liyunfan's AC fork and branch to the very top. If this helps keep just one more person from trying to compile with the main repo, I would consider this change a success.

I proposed a few other updates to the language, including to note that Unbot is no longer under active development, but should we instead remove it from the readme entirely? I'm not sure if there's any reason somebody would want to use it instead of Multibot now.