### PR TITLE
Fix uses of restrictHealerDPS and randomBotCombatStrategies.

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -814,12 +814,13 @@ AiPlayerbot.OpenGoSpell = 6477
 #
 
 # Additional randombot strategies
-# Strategies added here are applied to all randombots, in addition (or subtraction) to spec-based default strategies. These rules are processed after the defaults.
-AiPlayerbot.RandomBotCombatStrategies = "+dps,+dps assist,-threat"
+# Strategies added here are applied to all randombots, in addition (or subtraction) to spec/role-based default strategies. These rules are processed after the defaults.
+# Example: "+threat,-potions"
+AiPlayerbot.RandomBotCombatStrategies = ""
 AiPlayerbot.RandomBotNonCombatStrategies = ""
 
 # Additional altbot strategies
-# Strategies added here are applied to all altbots, in addition (or subtraction) to spec-based default strategies. These rules are processed after the defaults.
+# Strategies added here are applied to all altbots, in addition (or subtraction) to spec/role-based default strategies. These rules are processed after the defaults.
 AiPlayerbot.CombatStrategies = ""
 AiPlayerbot.NonCombatStrategies = ""
 

--- a/src/AiFactory.cpp
+++ b/src/AiFactory.cpp
@@ -472,6 +472,10 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             }
         }
     }
+    if (sRandomPlayerbotMgr->IsRandomBot(player))
+    {
+        engine->ChangeStrategy(sPlayerbotAIConfig->randomBotCombatStrategies);
+    }
     else
     {
         engine->ChangeStrategy(sPlayerbotAIConfig->combatStrategies);

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -722,7 +722,8 @@ void PlayerbotAI::HandleTeleportAck()
         // SetNextCheckDelay(urand(2000, 5000));
         if (sPlayerbotAIConfig->applyInstanceStrategies)
             ApplyInstanceStrategies(bot->GetMapId(), true);
-        EvaluateHealerDpsStrategy();
+        if (sPlayerbotAIConfig->restrictHealerDPS)
+            EvaluateHealerDpsStrategy();
         Reset(true);
     }
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -369,7 +369,7 @@ bool PlayerbotAIConfig::Initialize()
 
     randomChangeMultiplier = sConfigMgr->GetOption<float>("AiPlayerbot.RandomChangeMultiplier", 1.0);
 
-    randomBotCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotCombatStrategies", "-threat");
+    randomBotCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotCombatStrategies", "");
     randomBotNonCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotNonCombatStrategies", "");
     combatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.CombatStrategies", "+custom::say");
     nonCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.NonCombatStrategies", "+custom::say,+return");


### PR DESCRIPTION
I don't think this will fix #1549 since the scope of this is limited to specific strategies, but trying to figure out how that could happen led me to noticing a couple other issues.

- My own mistake with where `restrictHealerDPS` is checked would allow it to be ignored in certain cases, so another check was added to close the loophole.
- An older oversight: `randomBotCombatStrategies` never actually got used beyond the config files and anything set in the conf for that would always be ignored. This adds it to AiFactory and I've locally confirmed it's now working.
    - I've also removed the 'default' list for `randomBotCombatStrategies` in the conf.dist and in PlayerbotAIConfig, which will make the behavior the same as current as long as users also update their conf files to not erroneously still include those (since they'll now actually be changed instead of ignored). I don't think this should've had conf defaults set for it in the first place instead of having them set in AiFactory with the rest of the *actual* defaults.