### PR TITLE
Fix: Crash when most/all RPG weights set to 0

### DIFF
--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -1060,6 +1060,13 @@ bool NewRpgBaseAction::RandomChangeStatus(std::vector<NewRpgStatus> candidateSta
             probSum += sPlayerbotAIConfig->RpgStatusProbWeight[status];
         }
     }
+    // Safety check. Default to "rest" if all RPG weights = 0
+    if (availableStatus.empty() || probSum == 0)
+    {
+        botAI->rpgInfo.ChangeToRest();
+        bot->SetStandState(UNIT_STAND_STATE_SIT);
+        return true;
+    }
     uint32 rand = urand(1, probSum);
     uint32 accumulate = 0;
     NewRpgStatus chosenStatus = RPG_STATUS_END;


### PR DESCRIPTION
Fixed crash happening at `uint32 rand = urand(1, probSum);` when probSum = 0 by the time we reach that line. Bots now default to "rest" strat if all other strats are unavailable or set to 0.

Closes: #1584