### PR TITLE
Has spell check

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2697,12 +2697,18 @@ void PlayerbotFactory::InitSpecialSpells()
          i != sPlayerbotAIConfig->randomBotSpellIds.end(); ++i)
     {
         uint32 spellId = *i;
-        bot->learnSpell(spellId);
+        if (!bot->HasSpell(spellId))
+        {
+            bot->learnSpell(spellId);
+        }
     }
     // to leave DK starting area
     if (bot->getClass() == CLASS_DEATH_KNIGHT)
     {
-        bot->learnSpell(50977, false);
+        if (!bot->HasSpell(50977))
+        {
+            bot->learnSpell(50977, false);
+        }
     }
 }
 

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2574,8 +2574,8 @@ void PlayerbotFactory::InitAvailableSpells()
 
             if (tSpell->IsCastable())
                 bot->CastSpell(bot, tSpell->spell, true);
-            else
-                bot->learnSpell(tSpell->learnedSpell[0], false);
+            else if (!bot->HasSpell(tSpell->learnedSpell[0]))
+                bot->learnSpell(tSpell->learnedSpell[0], false, true);
         }
     }
 }


### PR DESCRIPTION
Meant to reduce amount of duplicate spell entry errors when bots changes levels: 

SQL(p): INSERT INTO character_spell (guid, spell, specMask) VALUES (xxxxx, xxxxx, xxx)
 [ERROR]: [1062] Duplicate entry 'xxxxx-xxxxx' for key 'character_spell.PRIMARY'
 
 Does not solve all errors - still get a lot specifically for:
 54197 - cold weather flying