### PR TITLE
Smarter Loot Roll Logic for Playerbots

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -21,6 +21,7 @@
 #        THRESHOLDS
 #        QUESTS
 #        COMBAT
+#        PALADIN BUFFS STRATEGIES
 #        CHEATS
 #        SPELLS
 #        FLIGHTPATH
@@ -174,6 +175,10 @@ AiPlayerbot.SummonWhenGroup = 1
 # Selfbot permission level (0 = disabled, 1 = GM only (default), 2 = all players, 3 = activate on login)
 AiPlayerbot.SelfBotLevel = 1
 
+# Give free food to bots
+# Default: 1 (enabled)
+AiPlayerbot.FreeFood = 1
+
 # Non-GM player can only use init=auto to initialize bots based on their own level and gearscore
 # Default: 0 (non-GM player can use any intialization commands)
 AiPlayerbot.AutoInitOnly = 0
@@ -288,8 +293,46 @@ AiPlayerbot.SayWhenCollectingItems = 1
 AiPlayerbot.FreeMethodLoot = 0
 
 # Bots' loot roll level (0 = pass, 1 = greed, 2 = need)
-# Default: 1 (greed)
+# Default: 1 (greed), recommanded 2 with new loot AI 
 AiPlayerbot.LootRollLevel = 1
+
+# NEED only if the item matches the bot's MAIN spec (stats & armor/weapon type).
+# Off-spec upgrades are automatically downgraded to GREED.
+# Recommended default: 1 (enabled)
+AiPlayerbot.Roll.SmartNeedBySpec = 1
+
+# Bind-on-Equip etiquette: GREED by default to keep it tradeable.
+# Set to 1 to allow NEED on BoE if it's a clear upgrade.
+# Default: 0 (disabled)
+AiPlayerbot.Roll.AllowBoENeedIfUpgrade = 0
+
+# Bind-on-Use etiquette: GREED by default to keep it tradeable.
+# Set to 1 to allow NEED on BoU if it's a clear upgrade.
+# Default: 0 (disabled)
+AiPlayerbot.Roll.AllowBoUNeedIfUpgrade = 0
+
+# Cross-armor rule (cloth/leather/mail on a plate user, etc.):
+# Allow NEED only if newScore >= CrossArmorExtraMargin * bestEquippedScore.
+# Recommended default: 1.20 (conservative). Use 9.99 to effectively forbid cross-armor NEED.
+AiPlayerbot.Roll.CrossArmorExtraMargin = 1.20
+
+# If Need-Before-Greed is active and the item is only useful for disenchanting,
+# bots will press the "Disenchant" button instead of GREED.
+# Recommended default: 1 (enabled)
+AiPlayerbot.Roll.UseDEButton = 1
+
+# Minimum item level delta to treat a SET TOKEN as a real upgrade (0 means >=).
+# Prevents NEED on same-tier duplicates.
+# Example: Paladin Prot with chest ilvl 232:
+#  - “Trophy of the Crusade” (ilvl 245) => NEED allowed.
+#  - Token ilvl 232 with TokenILevelMargin=0.1 => GREED (no same-tier NEED).
+# Recommended default: 0.1
+AiPlayerbot.Roll.TokenILevelMargin = 0.1
+
+# Announce each bot's roll choice to its master via private whisper.
+# Useful for debugging; can be noisy in large groups.
+# Recommended default: 0 (disabled)
+AiPlayerbot.Roll.AnnounceToMaster = 0
 
 #
 #
@@ -458,6 +501,24 @@ AiPlayerbot.FleeingEnabled = 1
 ####################################################################################################
 
 ####################################################################################################
+# PALADIN BUFFS STRATEGIES
+#
+#
+
+# Min group size to use Greater buffs (Paladin, Mage, Druid)
+# Default: 3
+AiPlayerbot.MinBotsForGreaterBuff = 3
+
+# Cooldown (seconds) between reagent-missing RP warnings, per bot & per buff
+# Default: 30
+AiPlayerbot.RPWarningCooldown = 30
+
+#
+#
+#
+####################################################################################################
+
+####################################################################################################
 # CHEATS
 #
 #
@@ -492,7 +553,6 @@ AiPlayerbot.AutoGearQualityLimit = 3
 AiPlayerbot.AutoGearScoreLimit = 0
 
 # Enable/Disable cheats for bots
-# "food" (bots eat or drink without using food or drinks from their inventory)
 # "gold" (bots have infinite gold)
 # "health" (bots have infinite health)
 # "mana" (bots have infinite mana)
@@ -501,7 +561,7 @@ AiPlayerbot.AutoGearScoreLimit = 0
 # "raid" (bots use cheats implemented into raid strategies) 
 # To use multiple cheats, separate them by commas below (e.g., to enable all, use "gold,health,mana,power,raid,taxi")
 # Default: taxi and raid are enabled
-AiPlayerbot.BotCheats = "food,taxi,raid" 
+AiPlayerbot.BotCheats = "taxi,raid" 
 
 #
 #
@@ -811,13 +871,12 @@ AiPlayerbot.OpenGoSpell = 6477
 #
 
 # Additional randombot strategies
-# Strategies added here are applied to all randombots, in addition (or subtraction) to spec/role-based default strategies. These rules are processed after the defaults.
-# Example: "+threat,-potions"
-AiPlayerbot.RandomBotCombatStrategies = ""
+# Strategies added here are applied to all randombots, in addition (or subtraction) to spec-based default strategies. These rules are processed after the defaults.
+AiPlayerbot.RandomBotCombatStrategies = "+dps,+dps assist,-threat"
 AiPlayerbot.RandomBotNonCombatStrategies = ""
 
 # Additional altbot strategies
-# Strategies added here are applied to all altbots, in addition (or subtraction) to spec/role-based default strategies. These rules are processed after the defaults.
+# Strategies added here are applied to all altbots, in addition (or subtraction) to spec-based default strategies. These rules are processed after the defaults.
 AiPlayerbot.CombatStrategies = ""
 AiPlayerbot.NonCombatStrategies = ""
 
@@ -1118,7 +1177,7 @@ AiPlayerbot.DeleteRandomBotArenaTeams = 0
 AiPlayerbot.PvpProhibitedZoneIds = "2255,656,2361,2362,2363,976,35,2268,3425,392,541,1446,3828,3712,3738,3565,3539,3623,4152,3988,4658,4284,4418,4436,4275,4323,4395,3703,4298,3951"
 
 # PvP Restricted Areas (bots don't pvp)
-AiPlayerbot.PvpProhibitedAreaIds = "976,35,392,2268,4161,4010,4317,4312,3649,3887,3958,3724,4080,3938,3754"
+AiPlayerbot.PvpProhibitedAreaIds = "976,35,392,2268,4161,4010,4317,4312,3649,3887,3958,3724,4080"
 
 # Improve reaction speeds in battlegrounds and arenas (may cause lag)
 AiPlayerbot.FastReactInBG = 1

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -150,10 +150,8 @@ bool PlayerbotAIConfig::Initialize()
                                            "2255,656,2361,2362,2363,976,35,2268,3425,392,541,1446,3828,3712,3738,3565,"
                                            "3539,3623,4152,3988,4658,4284,4418,4436,4275,4323,4395,3703,4298,3951"),
         pvpProhibitedZoneIds);
-    LoadList<std::vector<uint32>>(
-        sConfigMgr->GetOption<std::string>("AiPlayerbot.PvpProhibitedAreaIds",
-                                           "976,35,392,2268,4161,4010,4317,4312,3649,3887,3958,3724,4080,3938,3754"),
-        pvpProhibitedAreaIds);
+    LoadList<std::vector<uint32>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.PvpProhibitedAreaIds", "976,35"),
+                                  pvpProhibitedAreaIds);
     fastReactInBG = sConfigMgr->GetOption<bool>("AiPlayerbot.FastReactInBG", true);
     LoadList<std::vector<uint32>>(
         sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotQuestIds", "7848,3802,5505,6502,7761"),
@@ -375,7 +373,7 @@ bool PlayerbotAIConfig::Initialize()
 
     randomChangeMultiplier = sConfigMgr->GetOption<float>("AiPlayerbot.RandomChangeMultiplier", 1.0);
 
-    randomBotCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotCombatStrategies", "");
+    randomBotCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotCombatStrategies", "-threat");
     randomBotNonCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotNonCombatStrategies", "");
     combatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.CombatStrategies", "+custom::say");
     nonCombatStrategies = sConfigMgr->GetOption<std::string>("AiPlayerbot.NonCombatStrategies", "+custom::say,+return");
@@ -462,13 +460,11 @@ bool PlayerbotAIConfig::Initialize()
     }
 
     botCheats.clear();
-    LoadListString<std::vector<std::string>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.BotCheats", "food,taxi,raid"),
+    LoadListString<std::vector<std::string>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.BotCheats", "taxi,raid"),
                                              botCheats);
 
     botCheatMask = 0;
 
-    if (std::find(botCheats.begin(), botCheats.end(), "food") != botCheats.end())
-        botCheatMask |= (uint32)BotCheatMask::food;
     if (std::find(botCheats.begin(), botCheats.end(), "taxi") != botCheats.end())
         botCheatMask |= (uint32)BotCheatMask::taxi;
     if (std::find(botCheats.begin(), botCheats.end(), "gold") != botCheats.end())
@@ -575,6 +571,13 @@ bool PlayerbotAIConfig::Initialize()
     autoPickReward = sConfigMgr->GetOption<std::string>("AiPlayerbot.AutoPickReward", "yes");
     autoEquipUpgradeLoot = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoEquipUpgradeLoot", true);
     equipUpgradeThreshold = sConfigMgr->GetOption<float>("AiPlayerbot.EquipUpgradeThreshold", 1.1f);
+    allowBoENeedIfUpgrade = sConfigMgr->GetOption<bool>("AiPlayerbot.Roll.AllowBoENeedIfUpgrade", false);
+    allowBoUNeedIfUpgrade = sConfigMgr->GetOption<bool>("AiPlayerbot.Roll.AllowBoUNeedIfUpgrade", false);
+    crossArmorExtraMargin = sConfigMgr->GetOption<float>("AiPlayerbot.Roll.CrossArmorExtraMargin", 1.15f);
+    useDEButton = sConfigMgr->GetOption<bool>("AiPlayerbot.Roll.UseDEButton", true);
+    tokenILevelMargin = sConfigMgr->GetOption<float>("AiPlayerbot.Roll.TokenILevelMargin", 0.0f);
+	announceLootRollsToMaster = sConfigMgr->GetOption<bool>("AiPlayerbot.Roll.AnnounceToMaster", true);
+	smartNeedBySpec = sConfigMgr->GetOption<bool>("AiPlayerbot.Roll.SmartNeedBySpec", true);
     twoRoundsGearInit = sConfigMgr->GetOption<bool>("AiPlayerbot.TwoRoundsGearInit", false);
     syncQuestWithPlayer = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncQuestWithPlayer", true);
     syncQuestForPlayer = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncQuestForPlayer", false);
@@ -600,6 +603,7 @@ bool PlayerbotAIConfig::Initialize()
     RpgStatusProbWeight[RPG_REST] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.Rest", 5);
 
     syncLevelWithPlayers = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncLevelWithPlayers", false);
+    freeFood = sConfigMgr->GetOption<bool>("AiPlayerbot.FreeFood", true);
     randomBotGroupNearby = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotGroupNearby", true);
 
     // arena

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -23,8 +23,7 @@ enum class BotCheatMask : uint32
     mana = 8,
     power = 16,
     raid = 32,
-    food = 64,
-    maxMask = 128
+    maxMask = 64
 };
 
 enum class HealingManaEfficiency : uint8
@@ -326,6 +325,13 @@ public:
     std::string autoPickReward;
     bool autoEquipUpgradeLoot;
     float equipUpgradeThreshold;
+    bool allowBoENeedIfUpgrade; // Loot roll fine-tuning
+	bool allowBoUNeedIfUpgrade; // Allow NEED on BoU if upgrade
+    float crossArmorExtraMargin;
+    bool useDEButton; // Allow "Disenchant" on NBG if available
+    float tokenILevelMargin; // ilvl threshold to consider the token an upgrade
+	bool announceLootRollsToMaster; // ANotify the bot’s master of the roll choice
+    bool smartNeedBySpec; // Intelligent NEED (based on stats/spec)
     bool twoRoundsGearInit;
     bool syncQuestWithPlayer;
     bool syncQuestForPlayer;
@@ -341,6 +347,7 @@ public:
     bool enableNewRpgStrategy;
     std::unordered_map<NewRpgStatus, uint32> RpgStatusProbWeight;
     bool syncLevelWithPlayers;
+    bool freeFood;
     bool autoLearnQuestSpells;
     bool autoTeleportForLevel;
     bool randomBotGroupNearby;

--- a/src/strategy/actions/LootRollAction.cpp
+++ b/src/strategy/actions/LootRollAction.cpp
@@ -12,6 +12,284 @@
 #include "ObjectMgr.h"
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
+#include "Player.h"
+#include "StatsWeightCalculator.h"
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <cctype>
+#include "SharedDefines.h"
+#include "AiFactory.h"
+#include <initializer_list>
+#include <vector>
+
+// Local helper: not a class member
+static bool HasAnyStat(ItemTemplate const* proto,
+                       std::initializer_list<ItemModType> mods)
+{
+    if (!proto) return false;
+    for (uint32 i = 0; i < MAX_ITEM_PROTO_STATS; ++i)
+    {
+        if (!proto->ItemStat[i].ItemStatValue) continue;
+        ItemModType t = ItemModType(proto->ItemStat[i].ItemStatType);
+        for (auto m : mods)
+            if (t == m) return true;
+    }
+    return false;
+}
+
+static bool IsPrimaryForSpec(Player* bot, ItemTemplate const* proto)
+{
+    if (!bot || !proto) return false;
+
+    // Jewelry/cloaks: focus mainly on the stat profile (stat set)
+    const bool isJewelry =
+        proto->InventoryType == INVTYPE_TRINKET ||
+        proto->InventoryType == INVTYPE_FINGER  ||
+        proto->InventoryType == INVTYPE_NECK    ||
+        proto->InventoryType == INVTYPE_CLOAK;
+
+    const std::string spec = AiFactory::GetPlayerSpecName(bot);
+    const uint8 cls = bot->getClass();
+
+    auto specIs = [&](char const* s){ return spec == s; };
+    auto specIn = [&](std::initializer_list<char const*> names){
+        for (auto n : names) if (spec == n) return true;
+        return false;
+    };
+
+    // Flags class/spec
+    const bool isPureCasterClass = (cls == CLASS_MAGE || cls == CLASS_WARLOCK || cls == CLASS_PRIEST);
+    const bool isHolyPal = (cls == CLASS_PALADIN && spec == "holy");
+    const bool isProtPal = (cls == CLASS_PALADIN && (specIs("prot") || specIs("protection")));
+    const bool isRetPal  = (cls == CLASS_PALADIN && (specIs("retrib") || specIs("ret") || specIs("retribution")));
+
+    const bool isDK      = (cls == CLASS_DEATH_KNIGHT);
+    const bool isDKBlood = (isDK && specIs("blood"));
+    const bool isDKFrost = (isDK && specIs("frost"));
+    const bool isDKUH    = (isDK && (specIs("unholy") || specIs("uh")));
+    const bool isDKTank  = (isDKBlood || isDKFrost) && !isDKUH; // DK tank heuristic (Blood/Frost)
+
+    const bool isWarrior = (cls == CLASS_WARRIOR);
+    const bool isWarProt = (isWarrior && (specIs("prot") || specIs("protection")));
+
+    const bool isHunter  = (cls == CLASS_HUNTER); // // BM/MM/SV -> physical DPS
+    const bool isRogue   = (cls == CLASS_ROGUE);  // Assassination/Combat/Subtlety -> physical DPS
+
+    const bool isShaman  = (cls == CLASS_SHAMAN);
+    const bool isEleSham = (isShaman && specIs("elemental"));
+    const bool isRestoSh = (isShaman && (specIs("resto") || specIs("restoration")));
+    const bool isEnhSham = (isShaman && (specIs("enhance") || specIs("enhancement")));
+
+    const bool isDruid   = (cls == CLASS_DRUID);
+    const bool isBalance = (isDruid && specIs("balance"));
+    const bool isRestoDr = (isDruid && (specIs("resto") || specIs("restoration")));
+    const bool isFeralTk = (isDruid && (specIs("feraltank") || specIs("bear")));
+    const bool isFeralDps= (isDruid && (specIs("feraldps")  || specIs("cat")  || specIs("kitty")));
+
+    const bool isCasterSpec   = isPureCasterClass || isHolyPal || isEleSham || isRestoSh || isBalance || isRestoDr;
+    const bool isTankLikeSpec = isProtPal || isWarProt || isFeralTk || isDKTank;
+    const bool isPhysicalSpec = !isCasterSpec; // Everything that is not a caster -> physical profiles (DK/War/Rogue/Hunter/Ret/Enh/Feral/Prot…)
+
+    // Loot Stats
+    const bool hasINT   = HasAnyStat(proto, { ITEM_MOD_INTELLECT });
+    const bool hasSPI   = HasAnyStat(proto, { ITEM_MOD_SPIRIT });
+    const bool hasMP5   = HasAnyStat(proto, { ITEM_MOD_MANA_REGENERATION });
+    const bool hasSP    = HasAnyStat(proto, { ITEM_MOD_SPELL_POWER });
+    const bool hasSTR   = HasAnyStat(proto, { ITEM_MOD_STRENGTH });
+    const bool hasAGI   = HasAnyStat(proto, { ITEM_MOD_AGILITY });
+    const bool hasSTA   = HasAnyStat(proto, { ITEM_MOD_STAMINA });
+    const bool hasAP    = HasAnyStat(proto, { ITEM_MOD_ATTACK_POWER, ITEM_MOD_RANGED_ATTACK_POWER });
+    const bool hasARP   = HasAnyStat(proto, { ITEM_MOD_ARMOR_PENETRATION_RATING });
+    const bool hasEXP   = HasAnyStat(proto, { ITEM_MOD_EXPERTISE_RATING });
+    const bool hasHIT   = HasAnyStat(proto, { ITEM_MOD_HIT_RATING });
+    const bool hasHASTE = HasAnyStat(proto, { ITEM_MOD_HASTE_RATING });
+    const bool hasCRIT  = HasAnyStat(proto, { ITEM_MOD_CRIT_RATING });
+    const bool hasDef   = HasAnyStat(proto, { ITEM_MOD_DEFENSE_SKILL_RATING });
+    const bool hasAvoid = HasAnyStat(proto, { ITEM_MOD_DODGE_RATING, ITEM_MOD_PARRY_RATING, ITEM_MOD_BLOCK_RATING });
+
+    /// Quick profiles
+    const bool looksCaster   = hasSP || hasSPI || hasMP5 || (hasINT && !hasSTR && !hasAGI && !hasAP);
+    const bool looksPhysical = hasSTR || hasAGI || hasAP || hasARP || hasEXP;
+    const bool hasDpsRatings = hasHIT || hasHASTE || hasCRIT; // Common to all DPS (physical & casters)
+
+    // Generic rules by role/family
+    if (isPhysicalSpec)
+    {
+        // (1) All physicals/tanks: never Spell Power/Spirit/MP5 (even if plate/mail)
+        if (looksCaster)
+            return false;
+        // (2) Weapon/shield with Spell Power: always off-spec for DK/War/Rogue/Hunter/Ret/Enh/Feral/Prot
+        if ((proto->Class == ITEM_CLASS_WEAPON || (proto->Class == ITEM_CLASS_ARMOR && proto->SubClass == ITEM_SUBCLASS_ARMOR_SHIELD))
+            && hasSP)
+            return false;
+        // (3) Jewelry/cloaks with caster stats (SP/SPI/MP5/pure INT) -> off-spec
+        if (isJewelry && looksCaster)
+            return false;
+    }
+    else // Caster/Healer
+    {
+        // (1) Casters/healers should not NEED pure melee items (STR/AP/ARP/EXP) without INT/SP
+        if (looksPhysical && !hasSP && !hasINT)
+            return false;
+        // (2) Melee jewelry (AP/ARP/EXP/STR/AGI) without INT/SP -> off-spec
+        if (isJewelry && looksPhysical && !hasSP && !hasINT)
+            return false;
+        // Paladin Holy (plate INT+SP/MP5), Shaman Elemental/Restoration (mail INT+SP/MP5),
+        // Druid Balance/Restoration (leather/cloth caster) → OK
+    }
+
+    // Class/spec specific adjustments (readable)
+    // DK Unholy (DPS): allows STR/HIT/HASTE/CRIT/ARP; rejects all caster items
+    if (isDKUH)
+    {
+        if (looksCaster) return false;
+    }
+    // DK Blood/Frost tanks: DEF/AVOID/STA/STR are useful; reject caster items
+    if (isDKTank)
+    {
+        if (looksCaster) return false;
+        // Pure caster DPS rings/trinkets already filtered above.
+    }
+    // Hunter (BM/MM/SV): agi/hit/haste/AP/crit/arp → OK; avoid STR-only or caster items
+    if (isHunter)
+    {
+        if (looksCaster) return false;
+        // Avoid rings with "pure STR" without AGI/AP/DPS ratings
+        if (isJewelry && hasSTR && !hasAGI && !hasAP && !hasDpsRatings)
+            return false;
+    }
+    // Rogue (all specs): same strict physical filter (no caster items)
+    if (isRogue)
+    {
+        if (looksCaster) return false;
+    }
+    // Warrior Arms/Fury : no caster items
+    if (isWarrior && !isWarProt)
+    {
+        if (looksCaster) return false;
+    }
+    // Warrior Protection: DEF/AVOID/STA/STR are useful; no caster items
+    if (isWarProt)
+    {
+        if (looksCaster) return false;
+    }
+    // Shaman Enhancement: no Spell Power weapons/shields, no pure INT/SP items
+    if (isEnhSham)
+    {
+        if (looksCaster) return false;
+        if ((proto->Class == ITEM_CLASS_WEAPON || (proto->Class == ITEM_CLASS_ARMOR && proto->SubClass == ITEM_SUBCLASS_ARMOR_SHIELD))
+            && hasSP)
+            return false;
+    }
+    // Druid Feral (tank/DPS): AGI/STA/AVOID/ARP/EXP → OK; no caster items
+    if (isFeralTk || isFeralDps)
+    {
+        if (looksCaster) return false;
+    }
+
+    // Let the cross-armor rules (CrossArmorExtraMargin) decide for major off-armor upgrades.
+    return true;
+}
+
+
+// Local mini-helper: maps an InventoryType (INVTYPE_*) to an EquipmentSlot (EQUIPMENT_SLOT_*)
+// Only covers the slots relevant for T7-T10 tokens (head/shoulders/chest/hands/legs).
+static uint8 EquipmentSlotByInvTypeSafe(uint8 invType)
+{
+    switch (invType)
+    {
+        case INVTYPE_HEAD:       return EQUIPMENT_SLOT_HEAD;
+        case INVTYPE_SHOULDERS:  return EQUIPMENT_SLOT_SHOULDERS;
+        case INVTYPE_CHEST:
+        case INVTYPE_ROBE:       return EQUIPMENT_SLOT_CHEST;
+        case INVTYPE_HANDS:      return EQUIPMENT_SLOT_HANDS;
+        case INVTYPE_LEGS:       return EQUIPMENT_SLOT_LEGS;
+        default:                 return EQUIPMENT_SLOT_END; // inconnu/nonnull
+    }
+}
+
+// All equippable items -> corresponding slots
+static void GetEquipSlotsForInvType(uint8 invType, std::vector<uint8>& out)
+{
+    out.clear();
+    switch (invType)
+    {
+        case INVTYPE_HEAD:         out = {EQUIPMENT_SLOT_HEAD}; break;
+        case INVTYPE_NECK:         out = {EQUIPMENT_SLOT_NECK}; break;
+        case INVTYPE_SHOULDERS:    out = {EQUIPMENT_SLOT_SHOULDERS}; break;
+        case INVTYPE_BODY:         /* shirt, ignore */ break;
+        case INVTYPE_CHEST:
+        case INVTYPE_ROBE:         out = {EQUIPMENT_SLOT_CHEST}; break;
+        case INVTYPE_WAIST:        out = {EQUIPMENT_SLOT_WAIST}; break;
+        case INVTYPE_LEGS:         out = {EQUIPMENT_SLOT_LEGS}; break;
+        case INVTYPE_FEET:         out = {EQUIPMENT_SLOT_FEET}; break;
+        case INVTYPE_WRISTS:       out = {EQUIPMENT_SLOT_WRISTS}; break;
+        case INVTYPE_HANDS:        out = {EQUIPMENT_SLOT_HANDS}; break;
+        case INVTYPE_FINGER:       out = {EQUIPMENT_SLOT_FINGER1,  EQUIPMENT_SLOT_FINGER2}; break;
+        case INVTYPE_TRINKET:      out = {EQUIPMENT_SLOT_TRINKET1, EQUIPMENT_SLOT_TRINKET2}; break;
+        case INVTYPE_CLOAK:        out = {EQUIPMENT_SLOT_BACK}; break;
+        case INVTYPE_WEAPON:       out = {EQUIPMENT_SLOT_MAINHAND, EQUIPMENT_SLOT_OFFHAND}; break;
+        case INVTYPE_2HWEAPON:     out = {EQUIPMENT_SLOT_MAINHAND}; break;
+        case INVTYPE_SHIELD:       out = {EQUIPMENT_SLOT_OFFHAND}; break;
+        case INVTYPE_WEAPONMAINHAND: out = {EQUIPMENT_SLOT_MAINHAND}; break;
+        case INVTYPE_WEAPONOFFHAND:  out = {EQUIPMENT_SLOT_OFFHAND}; break;
+        case INVTYPE_HOLDABLE:     out = {EQUIPMENT_SLOT_OFFHAND}; break;  // tome/orb
+        case INVTYPE_RANGED:
+        case INVTYPE_THROWN:
+        case INVTYPE_RANGEDRIGHT:  out = {EQUIPMENT_SLOT_RANGED}; break;
+        case INVTYPE_RELIC:        out = {EQUIPMENT_SLOT_RANGED}; break;  // totem/idol/sigil/libram
+        case INVTYPE_TABARD:
+        case INVTYPE_BAG:
+        case INVTYPE_AMMO:
+        case INVTYPE_QUIVER:
+        default: break; // not relevant for gear
+    }
+}
+
+// Internal prototypes
+static bool CanBotUseToken(ItemTemplate const* proto, Player* bot);
+static bool RollUniqueCheck(ItemTemplate const* proto, Player* bot);
+
+// Internal helpers
+// Deduces the target slot from the token's name.
+// Returns an expected InventoryType (HEAD/SHOULDERS/CHEST/HANDS/LEGS) or -1 if unknown.
+static int8 TokenSlotFromName(ItemTemplate const* proto)
+{
+    if (!proto) return -1;
+    std::string n = std::string(proto->Name1);
+    std::transform(n.begin(), n.end(), n.begin(),
+        [](unsigned char c){
+            return static_cast<char>(std::tolower(c));
+        });
+    if (n.find("helm") != std::string::npos || n.find("head") != std::string::npos)
+        return INVTYPE_HEAD;
+    if (n.find("shoulder") != std::string::npos || n.find("mantle") != std::string::npos || n.find("spauld") != std::string::npos)
+        return INVTYPE_SHOULDERS;
+    if (n.find("chest") != std::string::npos || n.find("tunic") != std::string::npos || n.find("robe") != std::string::npos || n.find("breastplate") != std::string::npos || n.find("chestguard") != std::string::npos)
+        return INVTYPE_CHEST;
+    if (n.find("glove") != std::string::npos || n.find("handguard") != std::string::npos || n.find("gauntlet") != std::string::npos)
+        return INVTYPE_HANDS;
+    if (n.find("leg") != std::string::npos || n.find("pant") != std::string::npos || n.find("trouser") != std::string::npos)
+        return INVTYPE_LEGS;
+    return -1;
+}
+
+// Upgrade heuristic for a token: if the slot is known,
+// consider it a "likely upgrade" if ilvl(token) >= ilvl(best equipped item in that slot) + margin.
+static bool IsTokenLikelyUpgrade(ItemTemplate const* token, uint8 invTypeSlot, Player* bot)
+{
+    if (!token || !bot) return false;
+    uint8 eq = EquipmentSlotByInvTypeSafe(invTypeSlot);
+    if (eq >= EQUIPMENT_SLOT_END)
+        return true; // unknown slot -> do not block Need
+    Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, eq);
+    if (!oldItem) return true; // empty slot -> guaranteed upgrade
+    ItemTemplate const* oldProto = oldItem->GetTemplate();
+    if (!oldProto) return true;
+    float margin = sPlayerbotAIConfig->tokenILevelMargin; // configurable
+    return (float)token->ItemLevel >= (float)oldProto->ItemLevel + margin;
+}
 
 bool LootRollAction::Execute(Event event)
 {
@@ -27,7 +305,6 @@ bool LootRollAction::Execute(Event event)
             continue;
         }
         ObjectGuid guid = roll->itemGUID;
-        uint32 slot = roll->itemSlot;
         uint32 itemId = roll->itemid;
         int32 randomProperty = 0;
         if (roll->itemRandomPropId)
@@ -35,12 +312,13 @@ bool LootRollAction::Execute(Event event)
         else if (roll->itemRandomSuffix)
             randomProperty = -((int)roll->itemRandomSuffix);
 
-        RollVote vote = PASS;
         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
         if (!proto)
             continue;
-        
+
+        RollVote vote = PASS;
         std::string itemUsageParam;
+		
         if (randomProperty != 0) {
             itemUsageParam = std::to_string(itemId) + "," + std::to_string(randomProperty);
         } else {
@@ -48,39 +326,47 @@ bool LootRollAction::Execute(Event event)
         }
         ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
         
-        // Armor Tokens are classed as MISC JUNK (Class 15, Subclass 0), luckily no other items I found have class bits and epic quality.
+        // Armor Tokens are classed as MISC JUNK (Class 15, Subclass 0), but no other items have class bits and epic quality.
+        // - CanBotUseToken(proto, bot) => NEED
+        // - else => GREED
         if (proto->Class == ITEM_CLASS_MISC && proto->SubClass == ITEM_SUBCLASS_JUNK && proto->Quality == ITEM_QUALITY_EPIC)
         {
             if (CanBotUseToken(proto, bot))
             {
-                vote = NEED; // Eligible for "Need"
+                // vote = NEED; // Eligible for Need
+                // Token mainspec: NEED only if the corresponding slot piece would be a real upgrade
+                int8 tokenSlot = TokenSlotFromName(proto);
+                if (tokenSlot >= 0)
+                {
+                    if (IsTokenLikelyUpgrade(proto, (uint8)tokenSlot, bot))
+                        vote = NEED;
+                    else
+                        vote = GREED;
+                }
+                else
+                {
+                    // Unknown slot (e.g. T10 sanctification tokens)
+                    vote = GREED;
+                }
             }
             else
             {
-                vote = GREED; // Not eligible, so "Greed"
+                vote = GREED; // Not eligible, so Greed
             }
         }
         else
         {
-            switch (proto->Class)
-            {
-                case ITEM_CLASS_WEAPON:
-                case ITEM_CLASS_ARMOR:
-                    if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
-                    {
-                        vote = NEED;
-                    }
-                    else if (usage != ITEM_USAGE_NONE)
-                    {
-                        vote = GREED;
-                    }
-                    break;
-                default:
-                    if (StoreLootAction::IsLootAllowed(itemId, botAI))
-                        vote = CalculateRollVote(proto); // Ensure correct Need/Greed behavior
-                    break;
-            }
+            // Let CalculateRollVote decide (includes SmartNeedBySpec, BoE/BoU, unique, cross-armor)
+            vote = CalculateRollVote(proto, randomProperty);
         }
+		
+        // Disenchant button (Need-Before-Greed): if useful for DE, prefer DE over Greed
+        if (vote == GREED && usage == ITEM_USAGE_DISENCHANT && sPlayerbotAIConfig->useDEButton)
+        {
+            if (group && group->GetLootMethod() == NEED_BEFORE_GREED)
+                vote = DISENCHANT;
+        }
+
         if (sPlayerbotAIConfig->lootRollLevel == 0)
         {
             vote = PASS;
@@ -103,16 +389,12 @@ bool LootRollAction::Execute(Event event)
                 vote = PASS;
             }
         }
-        switch (group->GetLootMethod())
-        {
-            case MASTER_LOOT:
-            case FREE_FOR_ALL:
-                group->CountRollVote(bot->GetGUID(), guid, PASS);
-                break;
-            default:
-                group->CountRollVote(bot->GetGUID(), guid, vote);
-                break;
-        }
+        // Announce + send the roll vote (if ML/FFA => PASS)
+        RollVote sent = vote;
+        if (group->GetLootMethod() == MASTER_LOOT || group->GetLootMethod() == FREE_FOR_ALL)
+            sent = PASS;
+        AnnounceRollChoice(sent, itemId);
+        group->CountRollVote(bot->GetGUID(), guid, sent);
         // One item at a time
         return true;
     }
@@ -121,34 +403,167 @@ bool LootRollAction::Execute(Event event)
 }
 
 
-RollVote LootRollAction::CalculateRollVote(ItemTemplate const* proto)
+RollVote LootRollAction::CalculateRollVote(ItemTemplate const* proto, int32 randomProperty)
 {
+    // Player mimic: upgrade => NEED; useful => GREED; otherwise => PASS
     std::ostringstream out;
-    out << proto->ItemId;
+    if (randomProperty != 0)
+        out << proto->ItemId << "," << randomProperty;
+    else
+        out << proto->ItemId;
     ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", out.str());
 
-    RollVote needVote = PASS;
+	RollVote vote = PASS;
     switch (usage)
     {
         case ITEM_USAGE_EQUIP:
         case ITEM_USAGE_REPLACE:
-        case ITEM_USAGE_GUILD_TASK:
+           vote = NEED;
+           // Downgrade to GREED if the item does not match the main spec
+           if (sPlayerbotAIConfig->smartNeedBySpec && !IsPrimaryForSpec(bot, proto))
+               vote = GREED;
+           break;
         case ITEM_USAGE_BAD_EQUIP:
-            needVote = NEED;
-            break;
+        case ITEM_USAGE_GUILD_TASK:
         case ITEM_USAGE_SKILL:
         case ITEM_USAGE_USE:
         case ITEM_USAGE_DISENCHANT:
         case ITEM_USAGE_AH:
         case ITEM_USAGE_VENDOR:
-            needVote = GREED;
+        case ITEM_USAGE_KEEP:
+        case ITEM_USAGE_AMMO:
+            vote = GREED;
             break;
         default:
+            vote = PASS;
             break;
     }
+    // VETO “physical -> caster” (safety net):
+    // even if ItemUsage returned EQUIP/REPLACE, a physical character should never NEED a caster-profile item.
+    if (vote == NEED && sPlayerbotAIConfig->smartNeedBySpec)
+    {
+        const std::string spec = AiFactory::GetPlayerSpecName(bot);
+        const uint8 cls = bot->getClass();
+        auto specIs = [&](char const* s){ return spec == s; };
+        const bool isPhysicalSpec =
+            !(cls == CLASS_MAGE || cls == CLASS_WARLOCK || cls == CLASS_PRIEST) &&
+            !(cls == CLASS_PALADIN && spec == "holy") &&
+            !(cls == CLASS_SHAMAN  && (specIs("elemental") || specIs("resto") || specIs("restoration"))) &&
+            !(cls == CLASS_DRUID   && (specIs("balance")   || specIs("resto") || specIs("restoration")));
 
-    return StoreLootAction::IsLootAllowed(proto->ItemId, GET_PLAYERBOT_AI(bot)) ? needVote : PASS;
+        const bool hasINT   = HasAnyStat(proto, { ITEM_MOD_INTELLECT });
+        const bool hasSPI   = HasAnyStat(proto, { ITEM_MOD_SPIRIT });
+        const bool hasMP5   = HasAnyStat(proto, { ITEM_MOD_MANA_REGENERATION });
+        const bool hasSP    = HasAnyStat(proto, { ITEM_MOD_SPELL_POWER });
+        const bool hasMelee = HasAnyStat(proto, { ITEM_MOD_STRENGTH, ITEM_MOD_AGILITY,
+                                                  ITEM_MOD_ATTACK_POWER, ITEM_MOD_RANGED_ATTACK_POWER });
+        const bool looksCaster = hasSP || hasSPI || hasMP5 || (hasINT && !hasMelee);
+
+        if (isPhysicalSpec && looksCaster)
+            vote = GREED; // force GREED for rogue/hunter/warrior/DK/retribution/enhancement/feral/protection, etc.
+    }
+
+    // Generic BoP rule: if the item is BoP, equippable, matches the spec
+    // AND at least one relevant slot is empty -> allow NEED
+    constexpr uint32 BIND_WHEN_PICKED_UP = 1;
+    if (vote != NEED && proto->Bonding == BIND_WHEN_PICKED_UP)
+    {
+        std::vector<uint8> slots; GetEquipSlotsForInvType(proto->InventoryType, slots);
+        if (!slots.empty())
+        {
+            const bool specOk = !sPlayerbotAIConfig->smartNeedBySpec || IsPrimaryForSpec(bot, proto);
+            if (specOk)
+            {
+                for (uint8 s : slots)
+                {
+                    if (!bot->GetItemByPos(INVENTORY_SLOT_BAG_0, s))
+                    {
+                        vote = NEED; // fills an empty slot -> NEED
+                        break;
+                    }
+                }
+            }
+        }
+    }
+	
+    // BoE/BoU rule: by default, avoid NEED on Bind-on-Equip / Bind-on-Use (raid etiquette)
+    constexpr uint32 BIND_WHEN_EQUIPPED = 2; // BoE
+    constexpr uint32 BIND_WHEN_USE      = 3; // BoU
+    if (vote == NEED && proto->Bonding == BIND_WHEN_EQUIPPED && !sPlayerbotAIConfig->allowBoENeedIfUpgrade)
+    {
+        vote = GREED;
+    }
+    if (vote == NEED && proto->Bonding == BIND_WHEN_USE && !sPlayerbotAIConfig->allowBoUNeedIfUpgrade)
+    {
+        vote = GREED;
+    }
+
+    // Unique-equip: never NEED a duplicate (already equipped/owned)
+    if (vote == NEED && RollUniqueCheck(proto, bot))
+    {
+        vote = PASS;
+    }
+
+    // Cross-armor: if BAD_EQUIP (e.g. cloth for paladin), allow NEED only if it's a massive upgrade
+    if (vote == GREED && usage == ITEM_USAGE_BAD_EQUIP && proto->Class == ITEM_CLASS_ARMOR)
+    {
+        StatsWeightCalculator calc(bot);
+        float newScore = calc.CalculateItem(proto->ItemId);
+        float bestOld = 0.0f;
+        // Find the best currently equipped item of the same InventoryType
+        for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+        {
+            Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+            if (!oldItem) continue;
+            ItemTemplate const* oldProto = oldItem->GetTemplate();
+            if (!oldProto) continue;
+            if (oldProto->Class != ITEM_CLASS_ARMOR) continue;
+            if (oldProto->InventoryType != proto->InventoryType) continue;
+            float oldScore = calc.CalculateItem(oldProto->ItemId, oldItem->GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID));
+            if (oldScore > bestOld) bestOld = oldScore;
+        }
+        if (bestOld > 0.0f && newScore >= bestOld * sPlayerbotAIConfig->crossArmorExtraMargin)
+            vote = NEED;
+    }
+
+    // Final filter: loot strategy
+    return StoreLootAction::IsLootAllowed(proto->ItemId, GET_PLAYERBOT_AI(bot)) ? vote : PASS;
 }
+
+// Helpers d'annonce
+const char* LootRollAction::RollVoteToText(RollVote v) const
+{
+    switch (v)
+    {
+        case NEED:        return "NEED";
+        case GREED:       return "GREED";
+        case PASS:        return "PASS";
+        case DISENCHANT:  return "DISENCHANT";
+        default:          return "PASS";
+    }
+}
+
+void LootRollAction::AnnounceRollChoice(RollVote vote, uint32 itemId)
+{
+    if (!sPlayerbotAIConfig->announceLootRollsToMaster)
+        return;
+
+    Player* master = botAI->GetMaster();
+    if (!master)
+        return;
+
+    std::ostringstream ss;
+    if (ItemTemplate const* ip = sObjectMgr->GetItemTemplate(itemId))
+        ss << "[Loot] " << bot->GetName() << " choisit " << RollVoteToText(vote)
+           << " sur [" << ip->Name1 << "]";
+    else
+        ss << "[Loot] " << bot->GetName() << " choisit " << RollVoteToText(vote)
+           << " sur item " << itemId;
+
+    // Message to Master
+    botAI->TellMaster(ss.str());
+}
+
 
 bool MasterLootRollAction::isUseful() { return !botAI->HasActivePlayerMaster(); }
 
@@ -168,7 +583,7 @@ bool MasterLootRollAction::Execute(Event event)
 
     p.rpos(0);              // reset packet pointer
     p >> creatureGuid;      // creature guid what we're looting
-    p >> mapId;             /// 3.3.3 mapid
+    p >> mapId;             // 3.3.3 mapid
     p >> itemSlot;          // the itemEntryId for the item that shall be rolled for
     p >> itemId;            // the itemEntryId for the item that shall be rolled for
     p >> randomSuffix;      // randomSuffix
@@ -184,13 +599,47 @@ bool MasterLootRollAction::Execute(Event event)
     if (!group)
         return false;
 
-    RollVote vote = CalculateRollVote(proto);
-    group->CountRollVote(bot->GetGUID(), creatureGuid, CalculateRollVote(proto));
+    // 1) Token heuristic: ONLY NEED if the target slot is a likely upgrade
+    RollVote vote = PASS;
+    if (proto->Class == ITEM_CLASS_MISC && proto->SubClass == ITEM_SUBCLASS_JUNK && proto->Quality == ITEM_QUALITY_EPIC)
+    {
+        if (CanBotUseToken(proto, bot))
+        {
+            int8 tokenSlot = TokenSlotFromName(proto); // Internal helper
+            if (tokenSlot >= 0)
+                vote = IsTokenLikelyUpgrade(proto, (uint8)tokenSlot, bot) ? NEED : GREED;
+            else
+                vote = GREED; // Unknow slot
+        }
+        else
+        {
+            vote = GREED;
+        }
+    }
+    else
+    {
+        vote = CalculateRollVote(proto, randomPropertyId ? (int32)randomPropertyId : (randomSuffix ? -(int32)randomSuffix : 0));
+    }
+
+    // 2) Disenchant button in Need-Before-Greed if the usage is "DISENCHANT"
+    if (vote == GREED && sPlayerbotAIConfig->useDEButton && group->GetLootMethod() == NEED_BEFORE_GREED)
+    {
+        std::ostringstream out; out << itemId;
+        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", out.str());
+        if (usage == ITEM_USAGE_DISENCHANT)
+            vote = DISENCHANT;
+    }
+
+    RollVote sent = vote;
+    if (group->GetLootMethod() == MASTER_LOOT || group->GetLootMethod() == FREE_FOR_ALL)
+        sent = PASS;
+    AnnounceRollChoice(sent, itemId);
+    group->CountRollVote(bot->GetGUID(), creatureGuid, sent);
 
     return true;
 }
 
-bool CanBotUseToken(ItemTemplate const* proto, Player* bot)
+static bool CanBotUseToken(ItemTemplate const* proto, Player* bot)
 {
     // Get the bitmask for the bot's class
     uint32 botClassMask = (1 << (bot->getClass() - 1));
@@ -204,7 +653,7 @@ bool CanBotUseToken(ItemTemplate const* proto, Player* bot)
     return false; // Bot's class cannot use this token
 }
 
-bool RollUniqueCheck(ItemTemplate const* proto, Player* bot)
+static bool RollUniqueCheck(ItemTemplate const* proto, Player* bot)
 {
     // Count the total number of the item (equipped + in bags)
     uint32 totalItemCount = bot->GetItemCount(proto->ItemId, true);
@@ -251,7 +700,8 @@ bool RollAction::Execute(Event event)
     {
         case ITEM_CLASS_WEAPON:
         case ITEM_CLASS_ARMOR:
-        if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
+        //if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
+        if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE)
         {
             bot->DoRandomRoll(0,100);
         }

--- a/src/strategy/actions/LootRollAction.h
+++ b/src/strategy/actions/LootRollAction.h
@@ -7,6 +7,7 @@
 #define _PLAYERBOT_LOOTROLLACTION_H
 
 #include "QueryItemUsageAction.h"
+#include "ItemTemplate.h"
 
 class PlayerbotAI;
 
@@ -22,11 +23,32 @@ public:
     bool Execute(Event event) override;
 
 protected:
-    RollVote CalculateRollVote(ItemTemplate const* proto);
+    /**
+     * Default roll rule (outside Master Loot & outside tokens):
+     * - NEED if direct upgrade (ItemUsage = EQUIP/REPLACE)
+     * - GREED if useful but not an upgrade (BAD_EQUIP, USE, SKILL, DISENCHANT, AH, VENDOR, KEEP, AMMO)
+     * - PASS otherwise
+     *
+     * Safeguards:
+     *   - SmartNeedBySpec: downgrade NEED->GREED if the item does not match the bot's main spec
+     *   - BoP: if at least one relevant slot is empty, allow NEED (if spec is valid)
+     *   - BoE/BoU: NEED blocked unless explicitly allowed by config (AllowBoENeedIfUpgrade / AllowBoUNeedIfUpgrade)
+     *   - Cross-armor: BAD_EQUIP can become NEED only if newScore >= bestScore * CrossArmorExtraMargin
+     *
+     * Specific cases:
+     *   - Tokens: NEED only if the targeted slot is a likely upgrade (ilvl heuristic),
+     *             otherwise GREED (tokens with unknown slot remain GREED by default)
+     *   - Disenchant (NBG): if ItemUsage = DISENCHANT and config enabled, vote DISENCHANT
+     *                       (the core enforces if the DE button is actually available)
+     */
+     
+    // randomProperty: 0 (none) ; >0 = itemRandomPropId ; <0 = -itemRandomSuffix
+    RollVote CalculateRollVote(ItemTemplate const* proto, int32 randomProperty = 0);
+    
+    // Announce the roll choice to the bot's master (if enabled in config)
+    void AnnounceRollChoice(RollVote vote, uint32 itemId);
+    const char* RollVoteToText(RollVote v) const;
 };
-
-bool CanBotUseToken(ItemTemplate const* proto, Player* bot);
-bool RollUniqueCheck(ItemTemplate const* proto, Player* bot);
 
 class MasterLootRollAction : public LootRollAction
 {


### PR DESCRIPTION
### Summary

This PR improves the loot roll decision-making for Playerbots.

This update introduces spec-aware, stat-aware, and etiquette-friendly rules to better mimic real player behavior.

### Key Changes

**Smart NEED by spec & stats**

- New SmartNeedBySpec system checks whether an item’s stats align with the bot’s main specialization.
- Physical classes (warriors, rogues, hunters, DKs, ferals, ret, enh, prot) never NEED caster gear (SP/INT/SPI/MP5).
- Casters/healers never NEED pure melee DPS gear (STR/AP/ARP/EXP without SP/INT).
- Edge cases (jewelry, trinkets, off-armor) are filtered accordingly.

**Cross-armor upgrade logic**

- NEED on off-armor pieces (cloth for paladin, leather for hunter, etc.) only allowed if the new score is significantly higher (CrossArmorExtraMargin).

**BoP / BoE / BoU etiquette**

- BoP: allow NEED if the item fills an empty slot and matches spec.
- BoE / BoU: default to GREED, unless explicitly enabled in config.

**Token handling (T7–T10)**

- Bots NEED tokens only if they represent a likely upgrade (ilvl + configurable margin).
- Otherwise, they GREED. Unknown-slot tokens default to GREED.

**Unique-equip items**

- Bots never NEED duplicates if already equipped or in bags.

**Disenchant button (Need Before Greed)**

- If enabled, bots will choose DE instead of GREED when appropriate.

**Roll choice announcement**

- Optional whisper to master (AnnounceToMaster) to see each bot’s roll decision.

### New Config Options (with recommended defaults)
```
# NEED only if the item matches bot's main spec (stats & armor/weapon type).
# Recommended: 1
AiPlayerbot.Roll.SmartNeedBySpec = 1

# By default, GREED on Bind-on-Equip unless enabled.
# Recommended: 0
AiPlayerbot.Roll.AllowBoENeedIfUpgrade = 0

# By default, GREED on Bind-on-Use unless enabled.
# Recommended: 0
AiPlayerbot.Roll.AllowBoUNeedIfUpgrade = 0

# Cross-armor NEED allowed only if newScore >= oldScore * margin.
# Recommended: 1.20 (conservative). Use 9.99 to forbid off-armor NEED.
AiPlayerbot.Roll.CrossArmorExtraMargin = 1.20

# If item is DE-only and NBG is active, bots use DE button.
# Recommended: 1
AiPlayerbot.Roll.UseDEButton = 1

# ilvl margin to treat a token as a likely upgrade.
# Recommended: 0.1 (prevents NEED on same-tier duplicates).
AiPlayerbot.Roll.TokenILevelMargin = 0.1

# Whisper each bot's roll choice to its master.
# Recommended: 0
AiPlayerbot.Roll.AnnounceToMaster = 0

```

### Why This Is Better

- Bots now respect class/spec gear logic, reducing frustration when farming with AI.
- More realistic raid etiquette: avoids bots ninja-needing BoEs, caster trinkets, or off-armor.
- Configurable thresholds let admins tune behavior between strict raid-style or lenient casual.
- Improves fairness, immersion, and reduces overhead handling loot drama with bots.