### PR TITLE
Fix thresholds for LimitEnchantExpansion

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -659,7 +659,7 @@ AiPlayerbot.RandomGearScoreLimit = 0
 # Default: 1 (enabled)
 AiPlayerbot.IncrementalGearInit = 1
 
-# Set minimum level of bots that will enchant their equipment (Maxlevel + 1 to disable)
+# Set minimum level of bots that will enchant their equipment (if greater than RandomBotMaxlevel, bots will not enchant equipment)
 # Default: 60
 AiPlayerbot.MinEnchantingBotLevel = 60
 

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -126,6 +126,9 @@ void PlayerbotFactory::Init()
         if (id == 15463 || id == 15490) // Legendary Arcane Amalgamation
             continue;
 
+        if (id == 29467 || id == 29475 || id == 29480 || id == 29483) // Naxx40 Sapphiron Shoulder Enchants
+            continue;
+
         SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(id);
         if (!spellInfo)
             continue;
@@ -4362,10 +4365,10 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destoryOld)
             }
 
             // disable next expansion enchantments
-            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 60 && enchantSpell >= 25072)
+            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 60 && enchantSpell >= 27899)
                 continue;
 
-            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 70 && enchantSpell > 48557)
+            if (sPlayerbotAIConfig->limitEnchantExpansion && bot->GetLevel() <= 70 && enchantSpell >= 44483)
                 continue;
 
             for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)


### PR DESCRIPTION
The thresholds for LimitEnchantExpansion are wrong. I noticed that bots were applying 23 agility to gloves at level 70, and that is a WotLK enchant. The source determines which enchants to limit by spell ID thresholds and calls enchants with spell ID < 25072 as being Vanilla enchants and enchants with spell ID <= 48577 as being WotLK enchants. This results in too wide of a window for TBC—there are Vanilla enchants excluded from level 60 and below bots, and there are WotLK enchants available to level 61 through 70 bots.

The lowest spell ID for a TBC enchant is 27899 (Enchant Bracer – Brawn). No Vanilla enchants have a greater spell ID. See the following filtered search results:

- No Vanilla enchants with >= 27900 spell ID: https://www.wowhead.com/wotlk/spells/professions/enchanting?filter=16:14;1:2;0:27900
- No TBC enchants with < 27899 spell ID: https://www.wowhead.com/wotlk/spells/professions/enchanting?filter=16:14;2:5;0:27899

The lowest spell ID for a WotLK enchant is 44483 (Enchant Cloak – Superior Frost Resistance). There are three TBC enchants with a greater spell ID that need to be accounted for individually. See the following filtered search results:

- No WotLK enchants with < 44483 spell ID: https://www.wowhead.com/wotlk/spells/professions/enchanting?filter=16:14;3:5;0:44483
- Three TBC enchants with >= 44483 spell ID: https://www.wowhead.com/wotlk/spells/professions/enchanting?filter=16:14;2:2;0:44483 

I don't know if any bots would actually apply any of the three TBC enchants with spell ID >= 44483, but to be technically correct, I have excluded them specifically from the level 70 limit.

- Enchant Weapon – Deathfrost (46578)
- Enchant Chest – Defense (46594)
- Enchant Cloak – Steelweave (47051)

I also cleaned up what I thought was a very confusing comment in the config (the existing language makes it sound like setting MinEnchantingBotLevel to be greater than the maximum allowable bot level would somehow disable any minimum level requirement for bots to enchant their equipment, when really it prevents bots from enchanting their equipment at all).