### PR TITLE
Add weighted bot to banker teleport logic and config

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1014,6 +1014,20 @@ AiPlayerbot.RandomBotMaps = 0,1,530,571
 # Default: 0.25
 AiPlayerbot.ProbTeleToBankers = 0.25
 
+# Control probability weights for bots teleporting to Capital city bankers
+# Sum of weights need not be 100. Set to 0 to disable teleporting to the city.
+AiPlayerbot.EnableWeightTeleToCityBankers = 0
+AiPlayerbot.TeleToStormwindWeight = 2
+AiPlayerbot.TeleToIronforgeWeight = 1
+AiPlayerbot.TeleToDarnassusWeight = 1
+AiPlayerbot.TeleToExodarWeight = 1
+AiPlayerbot.TeleToOrgrimmarWeight = 2
+AiPlayerbot.TeleToUndercityWeight = 1
+AiPlayerbot.TeleToThunderBluffWeight = 1
+AiPlayerbot.TeleToSilvermoonCityWeight = 1
+AiPlayerbot.TeleToShattrathCityWeight = 1
+AiPlayerbot.TeleToDalaranWeight = 1
+
 # How far randombots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1016,7 +1016,7 @@ AiPlayerbot.ProbTeleToBankers = 0.25
 
 # Control probability weights for bots teleporting to Capital city bankers
 # Sum of weights need not be 100. Set to 0 to disable teleporting to the city.
-AiPlayerbot.EnableWeightTeleToCityBankers = 0
+AiPlayerbot.EnableWeightTeleToCityBankers = 1
 AiPlayerbot.TeleToStormwindWeight = 2
 AiPlayerbot.TeleToIronforgeWeight = 1
 AiPlayerbot.TeleToDarnassusWeight = 1

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -139,6 +139,17 @@ bool PlayerbotAIConfig::Initialize()
     randomBotMapsAsString = sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotMaps", "0,1,530,571");
     LoadList<std::vector<uint32>>(randomBotMapsAsString, randomBotMaps);
     probTeleToBankers = sConfigMgr->GetOption<float>("AiPlayerbot.ProbTeleToBankers", 0.25f);
+    enableWeightTeleToCityBankers = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableWeightTeleToCityBankers", false);
+    weightTeleToStormwind = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToStormwindWeight", 1);
+    weightTeleToIronforge = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToIronforgeWeight", 1);
+    weightTeleToDarnassus = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToDarnassusWeight", 1);
+    weightTeleToExodar = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToExodarWeight", 1);
+    weightTeleToOrgrimmar = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToOrgrimmarWeight", 1);
+    weightTeleToUndercity = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToUndercityWeight", 1);
+    weightTeleToThunderBluff = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToThunderBluffWeight", 1);
+    weightTeleToSilvermoonCity = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToSilvermoonCityWeight", 1);
+    weightTeleToShattrathCity = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToShattrathCityWeight", 1);
+    weightTeleToDalaran = sConfigMgr->GetOption<int>("AiPlayerbot.TeleToDalaranWeight", 1);
     LoadList<std::vector<uint32>>(
         sConfigMgr->GetOption<std::string>("AiPlayerbot.RandomBotQuestItems",
                                            "6948,5175,5176,5177,5178,16309,12382,13704,11000"),

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -102,6 +102,17 @@ public:
     bool botAutologin;
     std::string randomBotMapsAsString;
     float probTeleToBankers;
+    bool enableWeightTeleToCityBankers;
+    int weightTeleToStormwind;
+    int weightTeleToIronforge;
+    int weightTeleToDarnassus;
+    int weightTeleToExodar;
+    int weightTeleToOrgrimmar;
+    int weightTeleToUndercity;
+    int weightTeleToThunderBluff;
+    int weightTeleToSilvermoonCity;
+    int weightTeleToShattrathCity;
+    int weightTeleToDalaran;
     std::vector<uint32> randomBotMaps;
     std::vector<uint32> randomBotQuestItems;
     std::vector<uint32> randomBotAccounts;

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -183,7 +183,11 @@ public:
         bool InsideBracket(uint32 val) { return val >= low && val <= high; }
     };
     std::map<uint32, LevelBracket> zone2LevelBracket;
-    std::map<uint8, std::vector<WorldLocation>> bankerLocsPerLevelCache;
+    struct BankerLocation {
+        WorldLocation loc;
+        uint32 entry;
+    };
+    std::map<uint8, std::vector<BankerLocation>> bankerLocsPerLevelCache;
 
     // Account type management
     void AssignAccountTypes();


### PR DESCRIPTION
The other day I was trying to fiddle with the AiPlayerbot.ProbTeleToBankers setting to make cities feel more populated/immersive. I found that by increasing this value and the total # of bots I could get pretty decent results, but it bothered me that the distribution between cities was equal ('cause who actually hangs out in Exodar?).

I added a configurable list of weights for each city so now admins can sway which cities receive more bots (or disable them from the table). This should allow (I hope) a similar level of immersion while reducing the resource requirements (# of bots).