### PR TITLE
Refactor GossipHelloAction with overload

### DIFF
--- a/src/strategy/actions/GossipHelloAction.cpp
+++ b/src/strategy/actions/GossipHelloAction.cpp
@@ -26,55 +26,12 @@ bool GossipHelloAction::Execute(Event event)
         p >> guid;
     }
 
-    if (!guid)
-        return false;
-
-    Creature* pCreature = bot->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_NONE);
-    if (!pCreature)
-    {
-        LOG_DEBUG("playerbots",
-                  "[PlayerbotMgr]: HandleMasterIncomingPacket - Received  CMSG_GOSSIP_HELLO {} not found or you can't "
-                  "interact with him.",
-                  guid.ToString().c_str());
-        return false;
-    }
-
-    GossipMenuItemsMapBounds pMenuItemBounds =
-        sObjectMgr->GetGossipMenuItemsMapBounds(pCreature->GetCreatureTemplate()->GossipMenuId);
-    if (pMenuItemBounds.first == pMenuItemBounds.second)
-        return false;
-
     std::string const text = event.getParam();
     int32 menuToSelect = -1;
-    if (text.empty())
-    {
-        WorldPacket p1;
-        p1 << guid;
-        bot->GetSession()->HandleGossipHelloOpcode(p1);
-        bot->SetFacingToObject(pCreature);
-
-        std::ostringstream out;
-        out << "--- " << pCreature->GetName() << " ---";
-        botAI->TellMasterNoFacing(out.str());
-
-        TellGossipMenus();
-    }
-    else if (!bot->PlayerTalkClass)
-    {
-        botAI->TellError("I need to talk first");
-        return false;
-    }
-    else
-    {
+    if (!text.empty())
         menuToSelect = atoi(text.c_str());
-        // if (menuToSelect > 0)
-        //     menuToSelect--;
 
-        ProcessGossip(menuToSelect);
-    }
-
-    bot->TalkedToCreature(pCreature->GetEntry(), pCreature->GetGUID());
-    return true;
+    return Execute(guid, menuToSelect, false);
 }
 
 void GossipHelloAction::TellGossipText(uint32 textId)
@@ -120,16 +77,16 @@ void GossipHelloAction::TellGossipMenus()
     }
 }
 
-bool GossipHelloAction::ProcessGossip(int32 menuToSelect)
+bool GossipHelloAction::ProcessGossip(int32 menuToSelect, bool silent)
 {
     GossipMenu& menu = bot->PlayerTalkClass->GetGossipMenu();
     if (menuToSelect != -1 && !menu.GetItem(menuToSelect))
     {
-        botAI->TellError("Unknown gossip option");
+        if (!silent)
+            botAI->TellError("Unknown gossip option");
         return false;
     }
 
-    // GossipMenuItem const* item = menu.GetItem(menuToSelect); //not used, line marked for removal.
     WorldPacket p;
     std::string code;
     p << GetMaster()->GetTarget();
@@ -137,19 +94,26 @@ bool GossipHelloAction::ProcessGossip(int32 menuToSelect)
     p << code;
     bot->GetSession()->HandleGossipSelectOptionOpcode(p);
 
-    TellGossipMenus();
+    if (!silent)
+        TellGossipMenus();
 
     return true;
 }
 
-bool GossipHelloAction::Execute(ObjectGuid guid, int32 menuToSelect)
+bool GossipHelloAction::Execute(ObjectGuid guid, int32 menuToSelect, bool silent)
 {
     if (!guid)
         return false;
 
     Creature* pCreature = bot->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_NONE);
     if (!pCreature)
+    {
+        LOG_DEBUG("playerbots",
+                  "[PlayerbotMgr]: HandleMasterIncomingPacket - Received  CMSG_GOSSIP_HELLO {} not found or you can't "
+                  "interact with him.",
+                  guid.ToString().c_str());
         return false;
+    }
 
     GossipMenuItemsMapBounds pMenuItemBounds =
         sObjectMgr->GetGossipMenuItemsMapBounds(pCreature->GetCreatureTemplate()->GossipMenuId);
@@ -162,12 +126,24 @@ bool GossipHelloAction::Execute(ObjectGuid guid, int32 menuToSelect)
         p1 << guid;
         bot->GetSession()->HandleGossipHelloOpcode(p1);
         bot->SetFacingToObject(pCreature);
+
+        if (!silent)
+        {
+            std::ostringstream out;
+            out << "--- " << pCreature->GetName() << " ---";
+            botAI->TellMasterNoFacing(out.str());
+            TellGossipMenus();
+        }
+    }
+    else if (!bot->PlayerTalkClass)
+    {
+        if (!silent)
+            botAI->TellError("I need to talk first");
+        return false;
     }
     else
     {
-        if (!bot->PlayerTalkClass)
-            return false;
-        if (!ProcessGossip(menuToSelect))
+        if (!ProcessGossip(menuToSelect, silent))
             return false;
     }
 

--- a/src/strategy/actions/GossipHelloAction.h
+++ b/src/strategy/actions/GossipHelloAction.h
@@ -16,11 +16,12 @@ public:
     GossipHelloAction(PlayerbotAI* botAI) : Action(botAI, "gossip hello") {}
 
     bool Execute(Event event) override;
-    bool Execute(ObjectGuid guid, int32 menuToSelect = -1);
+    // Overload for direct usage
+    bool Execute(ObjectGuid guid, int32 menuToSelect, bool silent = false);
 
 private:
     void TellGossipMenus();
-    bool ProcessGossip(int32 menuToSelect);
+    bool ProcessGossip(int32 menuToSelect, bool silent);
     void TellGossipText(uint32 textId);
 };
 


### PR DESCRIPTION
This just allows `GossipHelloAction::Execute` to also be used silently with a specified guid and menu option from code instead of needing packets or reporting anything to a master. It is in addition to the existing method, so the current one still works as usual.

I'm using it to have bots interact with a nearby NPC at specific waypoints based on table values in the dungeon pathing I'm working on, but it could be used in other cases as well, so I thought it worth submitting on its own.