### PR TITLE
Fix typo in RandomPlayerbotMgr.cpp

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -494,7 +494,7 @@ AiPlayerbot.AutoGearScoreLimit = 0
 # Enable/Disable cheats for bots
 # "food" (bots eat or drink without using food or drinks from their inventory)
 # "gold" (bots have infinite gold)
-# "health" (bots have infinite health)
+# "health" (bots immediately regenerate lost health)
 # "mana" (bots have infinite mana)
 # "power" (bots have infinite energy, rage, and runic power)
 # "taxi" (bots may use all flight paths, though they will not actually learn them) 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -897,7 +897,7 @@ void RandomPlayerbotMgr::LoadBattleMastersCache()
 {
     BattleMastersCache.clear();
 
-    LOG_INFO("playerbots", "Loading BattleMasters Cache...");
+    LOG_INFO("playerbots", "Loading Battlemasters Cache...");
 
     QueryResult result = WorldDatabase.Query("SELECT `entry`,`bg_template` FROM `battlemaster_entry`");
 
@@ -940,7 +940,7 @@ void RandomPlayerbotMgr::LoadBattleMastersCache()
 
         BattleMastersCache[bmTeam][BattlegroundTypeId(bgTypeId)].insert(
             BattleMastersCache[bmTeam][BattlegroundTypeId(bgTypeId)].end(), entry);
-        LOG_DEBUG("playerbots", "Cached Battmemaster #{} for BG Type {} ({})", entry, bgTypeId,
+        LOG_DEBUG("playerbots", "Cached Battlemaster #{} for BG Type {} ({})", entry, bgTypeId,
                   bmTeam == TEAM_ALLIANCE ? "Alliance"
                   : bmTeam == TEAM_HORDE  ? "Horde"
                                           : "Neutral");


### PR DESCRIPTION
These entries print at the beginning of every debug log. I don't know if we need this info to be logged at all by default, but I'm just fixing the text.