### PR TITLE
Fix for 2025_09_17_00_paladin_buff_reagent_texts

### DIFF
--- a/data/sql/playerbots/updates/2025_09_17_00_paladin_buff_reagent_texts.sql
+++ b/data/sql/playerbots/updates/2025_09_17_00_paladin_buff_reagent_texts.sql
@@ -14,19 +14,19 @@ WHERE name IN (
   'rp_missing_reagent_generic'
 );
 
-INSERT INTO ai_playerbot_texts (name, text, say_type, reply_type, text_loc2) VALUES
+INSERT INTO ai_playerbot_texts (name, text, say_type, reply_type, text_loc1, text_loc2, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES
   ('rp_missing_reagent_greater_blessing',
     'By the Light... I forgot my Symbols of Kings. We’ll make do with %base_spell!', 0, 0,
-    'Par la Lumière... J''ai oublié mes Symboles du roi. On se contentera de %base_spell !'),
+    '', 'Par la Lumière... J''ai oublié mes Symboles du roi. On se contentera de %base_spell !', '', '', '', '', '', ''),
   ('rp_missing_reagent_gift_of_the_wild',
     'Nature is generous, my bags are not... out of herbs for %group_spell. Take %base_spell for now!', 0, 0,
-    'La nature est généreuse, pas mes sacs... plus d''herbes pour %group_spell. Prenez %base_spell pour l''instant !'),
+    '', 'La nature est généreuse, pas mes sacs... plus d''herbes pour %group_spell. Prenez %base_spell pour l''instant !', '', '', '', '', '', ''),
   ('rp_missing_reagent_arcane_brilliance',
     'Out of Arcane Powder... %group_spell will have to wait. Casting %base_spell!', 0, 0,
-    'Plus de poudre des arcanes... %group_spell attendra. Je lance %base_spell !'),
+    '', 'Plus de poudre des arcanes... %group_spell attendra. Je lance %base_spell !', '', '', '', '', '', ''),
   ('rp_missing_reagent_generic',
     'Oops, I’m out of components for %group_spell. We’ll go with %base_spell!', 0, 0,
-    'Oups, je n''ai plus de composants pour %group_spell. On fera avec %base_spell !');
+    '', 'Oups, je n''ai plus de composants pour %group_spell. On fera avec %base_spell !', '', '', '', '', '', '');
 
 INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES
   ('rp_missing_reagent_greater_blessing', 100),


### PR DESCRIPTION
Fix for:
I got the following error at server start after compiling the server.

Updating Playerbots database...
>> Applying update "2025_09_17_00_paladin_buff_reagent_texts.sql" 'B780AE6'...
ERROR 1364 (HY000) at line 17 in file: '/mnt/raid0/wow_server/azerothcore-playerbots/modules/mod-playerbots/data/sql/playerbots/updates/2025_09_17_00_paladin_buff_reagent_texts.sql': Field 'text_loc3' doesn't have a default value

Applying of file '/mnt/raid0/wow_server/azerothcore-playerbots/modules/mod-playerbots/data/sql/playerbots/updates/2025_09_17_00_paladin_buff_reagent_texts.sql' to database 'acore_playerbots' failed! If you are a user, please pull the latest revision from the repository. Also make sure you have not applied any of the databases with your sql client. You cannot use auto-update system and import sql files from AzerothCore repository with your sql client. If you are a developer, please fix your sql query.

Could not update the Playerbots database, see log for details.
Closing down DatabasePool 'acore_playerbots'. Waiting for 0 queries to finish...
Asynchronous connections on DatabasePool 'acore_playerbots' terminated. Proceeding with synchronous connections.
All connections on DatabasePool 'acore_playerbots' closed.