### PR TITLE
Implement Gruul's Lair strategy

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -1513,19 +1513,22 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
     switch (mapId)
     {
         case 249:
-            strategyName = "onyxia";
+			strategyName = "onyxia";  // Onyxia's Lair
             break;
         case 409:
-            strategyName = "mc";
+			strategyName = "mc";  // Molten Core
             break;
         case 469:
-            strategyName = "bwl";
+			strategyName = "bwl";  // Blackwing Lair
             break;
         case 509:
-            strategyName = "aq20";
+			strategyName = "aq20";  // Ruins of Ahn'Qiraj
             break;
         case 533:
-            strategyName = "naxx";
+			strategyName = "naxx";  // Naxxramas
+            break;
+        case 565:
+            strategyName = "gruulslair";  // Gruul's Lair
             break;
         case 574:
             strategyName = "wotlk-uk";  // Utgarde Keep

--- a/src/strategy/AiObjectContext.cpp
+++ b/src/strategy/AiObjectContext.cpp
@@ -33,22 +33,24 @@
 #include "raids/RaidStrategyContext.h"
 #include "raids/aq20/RaidAq20ActionContext.h"
 #include "raids/aq20/RaidAq20TriggerContext.h"
-#include "raids/blackwinglair/RaidBwlActionContext.h"
-#include "raids/blackwinglair/RaidBwlTriggerContext.h"
-#include "raids/eyeofeternity/RaidEoEActionContext.h"
-#include "raids/eyeofeternity/RaidEoETriggerContext.h"
-#include "raids/icecrown/RaidIccActionContext.h"
-#include "raids/icecrown/RaidIccTriggerContext.h"
 #include "raids/moltencore/RaidMcActionContext.h"
 #include "raids/moltencore/RaidMcTriggerContext.h"
+#include "raids/blackwinglair/RaidBwlActionContext.h"
+#include "raids/blackwinglair/RaidBwlTriggerContext.h"
+#include "raids/gruulslair/RaidGruulsLairActionContext.h"
+#include "raids/gruulslair/RaidGruulsLairTriggerContext.h"
 #include "raids/naxxramas/RaidNaxxActionContext.h"
 #include "raids/naxxramas/RaidNaxxTriggerContext.h"
+#include "raids/eyeofeternity/RaidEoEActionContext.h"
+#include "raids/eyeofeternity/RaidEoETriggerContext.h"
+#include "raids/vaultofarchavon/RaidVoAActionContext.h"
+#include "raids/vaultofarchavon/RaidVoATriggerContext.h"
 #include "raids/obsidiansanctum/RaidOsActionContext.h"
 #include "raids/obsidiansanctum/RaidOsTriggerContext.h"
 #include "raids/onyxia/RaidOnyxiaActionContext.h"
 #include "raids/onyxia/RaidOnyxiaTriggerContext.h"
-#include "raids/vaultofarchavon/RaidVoAActionContext.h"
-#include "raids/vaultofarchavon/RaidVoATriggerContext.h"
+#include "raids/icecrown/RaidIccActionContext.h"
+#include "raids/icecrown/RaidIccTriggerContext.h"
 
 SharedNamedObjectContextList<Strategy> AiObjectContext::sharedStrategyContexts;
 SharedNamedObjectContextList<Action> AiObjectContext::sharedActionContexts;
@@ -96,8 +98,8 @@ void AiObjectContext::BuildSharedStrategyContexts(SharedNamedObjectContextList<S
     strategyContexts.Add(new MovementStrategyContext());
     strategyContexts.Add(new AssistStrategyContext());
     strategyContexts.Add(new QuestStrategyContext());
-    strategyContexts.Add(new RaidStrategyContext());
     strategyContexts.Add(new DungeonStrategyContext());
+    strategyContexts.Add(new RaidStrategyContext());
 }
 
 void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Action>& actionContexts)
@@ -105,15 +107,16 @@ void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Act
     actionContexts.Add(new ActionContext());
     actionContexts.Add(new ChatActionContext());
     actionContexts.Add(new WorldPacketActionContext());
+    actionContexts.Add(new RaidAq20ActionContext());
     actionContexts.Add(new RaidMcActionContext());
     actionContexts.Add(new RaidBwlActionContext());
-    actionContexts.Add(new RaidOnyxiaActionContext());
-    actionContexts.Add(new RaidAq20ActionContext());
+    actionContexts.Add(new RaidGruulsLairActionContext());
     actionContexts.Add(new RaidNaxxActionContext());
     actionContexts.Add(new RaidOsActionContext());
     actionContexts.Add(new RaidEoEActionContext());
     actionContexts.Add(new RaidVoAActionContext());
     actionContexts.Add(new RaidUlduarActionContext());
+    actionContexts.Add(new RaidOnyxiaActionContext());
     actionContexts.Add(new RaidIccActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
     actionContexts.Add(new WotlkDungeonNexActionContext());
@@ -137,16 +140,6 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new TriggerContext());
     triggerContexts.Add(new ChatTriggerContext());
     triggerContexts.Add(new WorldPacketTriggerContext());
-    triggerContexts.Add(new RaidMcTriggerContext());
-    triggerContexts.Add(new RaidBwlTriggerContext());
-    triggerContexts.Add(new RaidOnyxiaTriggerContext());
-    triggerContexts.Add(new RaidAq20TriggerContext());
-    triggerContexts.Add(new RaidNaxxTriggerContext());
-    triggerContexts.Add(new RaidOsTriggerContext());
-    triggerContexts.Add(new RaidEoETriggerContext());
-    triggerContexts.Add(new RaidVoATriggerContext());
-    triggerContexts.Add(new RaidUlduarTriggerContext());
-    triggerContexts.Add(new RaidIccTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());
     triggerContexts.Add(new WotlkDungeonNexTriggerContext());
     triggerContexts.Add(new WotlkDungeonANTriggerContext());
@@ -162,6 +155,17 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new WotlkDungeonFoSTriggerContext());
     triggerContexts.Add(new WotlkDungeonPoSTriggerContext());
     triggerContexts.Add(new WotlkDungeonToCTriggerContext());
+    triggerContexts.Add(new RaidAq20TriggerContext());
+    triggerContexts.Add(new RaidMcTriggerContext());
+    triggerContexts.Add(new RaidBwlTriggerContext());
+    triggerContexts.Add(new RaidGruulsLairTriggerContext());
+    triggerContexts.Add(new RaidNaxxTriggerContext());
+    triggerContexts.Add(new RaidOsTriggerContext());
+    triggerContexts.Add(new RaidEoETriggerContext());
+    triggerContexts.Add(new RaidVoATriggerContext());
+    triggerContexts.Add(new RaidUlduarTriggerContext());
+    triggerContexts.Add(new RaidOnyxiaTriggerContext());
+    triggerContexts.Add(new RaidIccTriggerContext());
 }
 
 void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<UntypedValue>& valueContexts)

--- a/src/strategy/raids/RaidStrategyContext.h
+++ b/src/strategy/raids/RaidStrategyContext.h
@@ -1,49 +1,49 @@
 #ifndef _PLAYERBOT_RAIDSTRATEGYCONTEXT_H_
 #define _PLAYERBOT_RAIDSTRATEGYCONTEXT_H_
 
-#include "RaidOnyxiaStrategy.h"
-#include "RaidUlduarStrategy.h"
 #include "Strategy.h"
+#include "RaidAq20Strategy.h"
+#include "RaidMcStrategy.h"
 #include "RaidBwlStrategy.h"
+#include "RaidGruulsLairStrategy.h"
 #include "RaidNaxxStrategy.h"
 #include "RaidOsStrategy.h"
 #include "RaidEoEStrategy.h"
-#include "RaidMcStrategy.h"
-#include "RaidAq20Strategy.h"
-#include "RaidIccStrategy.h"
 #include "RaidVoAStrategy.h"
+#include "RaidUlduarStrategy.h"
+#include "RaidOnyxiaStrategy.h"
+#include "RaidIccStrategy.h"
 
 class RaidStrategyContext : public NamedObjectContext<Strategy>
 {
 public:
     RaidStrategyContext() : NamedObjectContext<Strategy>(false, true)
     {
-        // TODO should we give these prefixes (eg: "naxx" -> "raid naxx")? because if we don't it's going to end up
-        // very crowded (with possible conflicts) once we have strats for all raids and some dungeons
-        // (mc already very similiar to nc)
+        creators["aq20"] = &RaidStrategyContext::aq20;
         creators["mc"] = &RaidStrategyContext::mc;
         creators["bwl"] = &RaidStrategyContext::bwl;
-        creators["aq20"] = &RaidStrategyContext::aq20;
+        creators["gruulslair"] = &RaidStrategyContext::gruulslair;
         creators["naxx"] = &RaidStrategyContext::naxx;
         creators["wotlk-os"] = &RaidStrategyContext::wotlk_os;
         creators["wotlk-eoe"] = &RaidStrategyContext::wotlk_eoe;
         creators["voa"] = &RaidStrategyContext::voa;
         creators["uld"] = &RaidStrategyContext::uld;
-        creators["icc"] = &RaidStrategyContext::icc;
         creators["onyxia"] = &RaidStrategyContext::onyxia;
+        creators["icc"] = &RaidStrategyContext::icc;
     }
 
 private:
+    static Strategy* aq20(PlayerbotAI* botAI) { return new RaidAq20Strategy(botAI); }
     static Strategy* mc(PlayerbotAI* botAI) { return new RaidMcStrategy(botAI); }
     static Strategy* bwl(PlayerbotAI* botAI) { return new RaidBwlStrategy(botAI); }
-    static Strategy* aq20(PlayerbotAI* botAI) { return new RaidAq20Strategy(botAI); }
+    static Strategy* gruulslair(PlayerbotAI* botAI) { return new RaidGruulsLairStrategy(botAI); }
     static Strategy* naxx(PlayerbotAI* botAI) { return new RaidNaxxStrategy(botAI); }
     static Strategy* wotlk_os(PlayerbotAI* botAI) { return new RaidOsStrategy(botAI); }
     static Strategy* wotlk_eoe(PlayerbotAI* botAI) { return new RaidEoEStrategy(botAI); }
     static Strategy* voa(PlayerbotAI* botAI) { return new RaidVoAStrategy(botAI); }
+    static Strategy* onyxia(PlayerbotAI* botAI) { return new RaidOnyxiaStrategy(botAI); }
     static Strategy* uld(PlayerbotAI* botAI) { return new RaidUlduarStrategy(botAI); }
     static Strategy* icc(PlayerbotAI* botAI) { return new RaidIccStrategy(botAI); }
-    static Strategy* onyxia(PlayerbotAI* botAI) { return new RaidOnyxiaStrategy(botAI); }
 };
 
 #endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairActionContext.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairActionContext.h
@@ -1,0 +1,51 @@
+#ifndef _PLAYERBOT_RAIDGRUULSLAIRACTIONCONTEXT_H
+#define _PLAYERBOT_RAIDGRUULSLAIRACTIONCONTEXT_H
+
+#include "RaidGruulsLairActions.h"
+#include "NamedObjectContext.h"
+
+class RaidGruulsLairActionContext : public NamedObjectContext<Action>
+{
+public:
+    RaidGruulsLairActionContext()
+    {
+        // High King Maulgar
+        creators["high king maulgar remove tank assist"] = &RaidGruulsLairActionContext::high_king_maulgar_remove_tank_assist;
+        creators["high king maulgar maulgar tank"] = &RaidGruulsLairActionContext::high_king_maulgar_maulgar_tank;
+        creators["high king maulgar olm tank"] = &RaidGruulsLairActionContext::high_king_maulgar_olm_tank;
+        creators["high king maulgar blindeye tank"] = &RaidGruulsLairActionContext::high_king_maulgar_blindeye_tank;
+        creators["high king maulgar mage tank"] = &RaidGruulsLairActionContext::high_king_maulgar_mage_tank;
+        creators["high king maulgar moonkin tank"] = &RaidGruulsLairActionContext::high_king_maulgar_moonkin_tank;
+        creators["high king maulgar melee dps"] = &RaidGruulsLairActionContext::high_king_maulgar_melee_dps;
+        creators["high king maulgar ranged dps"] = &RaidGruulsLairActionContext::high_king_maulgar_ranged_dps;
+        creators["high king maulgar healer avoidance"] = &RaidGruulsLairActionContext::high_king_maulgar_healer_avoidance;
+        creators["high king maulgar banish felstalker"] = &RaidGruulsLairActionContext::high_king_maulgar_banish_felstalker;
+        creators["high king maulgar hunter misdirection"] = &RaidGruulsLairActionContext::high_king_maulgar_hunter_misdirection;
+
+        // Gruul the Dragonkiller
+        creators["gruul the dragonkiller position boss"] = &RaidGruulsLairActionContext::gruul_the_dragonkiller_position_boss;
+        creators["gruul the dragonkiller spread ranged"] = &RaidGruulsLairActionContext::gruul_the_dragonkiller_spread_ranged;
+        creators["gruul the dragonkiller shatter spread"] = &RaidGruulsLairActionContext::gruul_the_dragonkiller_shatter_spread;
+    }
+
+private:
+    // High King Maulgar
+    static Action* high_king_maulgar_remove_tank_assist(PlayerbotAI* botAI) { return new HighKingMaulgarRemoveTankAssistAction(botAI); }
+    static Action* high_king_maulgar_maulgar_tank(PlayerbotAI* botAI) { return new HighKingMaulgarMaulgarTankAction(botAI); }
+    static Action* high_king_maulgar_olm_tank(PlayerbotAI* botAI) { return new HighKingMaulgarOlmTankAction(botAI); }
+    static Action* high_king_maulgar_blindeye_tank(PlayerbotAI* botAI) { return new HighKingMaulgarBlindeyeTankAction(botAI); }
+    static Action* high_king_maulgar_mage_tank(PlayerbotAI* botAI) { return new HighKingMaulgarMageTankAction(botAI); }
+    static Action* high_king_maulgar_moonkin_tank(PlayerbotAI* botAI) { return new HighKingMaulgarMoonkinTankAction(botAI); }
+    static Action* high_king_maulgar_melee_dps(PlayerbotAI* botAI) { return new HighKingMaulgarMeleeDPSAction(botAI); }
+    static Action* high_king_maulgar_ranged_dps(PlayerbotAI* botAI) { return new HighKingMaulgarRangedDPSAction(botAI); }
+    static Action* high_king_maulgar_healer_avoidance(PlayerbotAI* botAI) { return new HighKingMaulgarHealerAvoidanceAction(botAI); }
+    static Action* high_king_maulgar_banish_felstalker(PlayerbotAI* botAI) { return new HighKingMaulgarBanishFelstalkerAction(botAI); }
+    static Action* high_king_maulgar_hunter_misdirection(PlayerbotAI* botAI) { return new HighKingMaulgarHunterMisdirectionAction(botAI); }
+
+    // Gruul the Dragonkiller
+    static Action* gruul_the_dragonkiller_position_boss(PlayerbotAI* botAI) { return new GruulTheDragonkillerPositionBossAction(botAI); }
+    static Action* gruul_the_dragonkiller_spread_ranged(PlayerbotAI* botAI) { return new GruulTheDragonkillerSpreadRangedAction(botAI); }
+    static Action* gruul_the_dragonkiller_shatter_spread(PlayerbotAI* botAI) { return new GruulTheDragonkillerShatterSpreadAction(botAI); }
+};
+
+#endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairActions.cpp
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairActions.cpp
@@ -1,0 +1,1066 @@
+#include "RaidGruulsLairActions.h"
+#include "RaidGruulsLairHelpers.h"
+#include "PlayerbotAI.h"
+#include "SpellAuras.h"
+#include "Unit.h"
+
+bool HighKingMaulgarRemoveTankAssistAction::Execute(Event event)
+{
+    if (!botAI->IsTank(bot))
+    {
+        return false;
+    }
+
+    Unit* maulgar  = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    Unit* kiggler  = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    Unit* krosh    = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    Unit* olm      = AI_VALUE2(Unit*, "find target", "olm the summoner");
+    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+
+    bool maulgarEncounterActive = (maulgar  && maulgar->IsInCombat()) ||
+                                  (kiggler  && kiggler->IsInCombat()) ||
+                                  (krosh    && krosh->IsInCombat()) ||
+                                  (olm      && olm->IsInCombat()) ||
+                                  (blindeye && blindeye->IsInCombat());
+
+    if (maulgarEncounterActive && botAI->HasStrategy("tank assist", BOT_STATE_COMBAT))
+    {
+        botAI->ChangeStrategy("-tank assist", BOT_STATE_COMBAT);
+        {
+        return true;
+        }
+    }
+    return false;
+}
+
+bool HighKingMaulgarMaulgarTankAction::Execute(Event event)
+{
+    if (!IsMaulgarTank(botAI, bot))
+    {
+        return false;
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    if (!maulgar || !maulgar->IsAlive())
+    {
+        return false;
+    }
+
+    ObjectGuid currentIconGuid = group->GetTargetIcon(squareIcon);
+    if (currentIconGuid.IsEmpty() || currentIconGuid != maulgar->GetGUID())
+    {
+        group->SetTargetIcon(squareIcon, bot->GetGUID(), maulgar->GetGUID());
+    }
+
+    if (botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != "square" && 
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get() != maulgar)
+    {
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("square");
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(maulgar);
+    }
+
+    if (bot->GetVictim() != maulgar)
+    {
+        Attack(maulgar);
+
+        if (!bot->IsWithinMeleeRange(maulgar))
+        {
+            return MoveTo(maulgar->GetMapId(), maulgar->GetPositionX(), maulgar->GetPositionY(), maulgar->GetPositionZ());
+        }
+    }
+
+    if (maulgar->GetVictim() == bot)
+    {
+        const TankSpot& spot = GruulsLairTankSpots::Maulgar;
+        const float maxDistance = 3.0f;
+        float distanceToMaulgar = maulgar->GetExactDist2d(spot.x, spot.y);
+        
+        if (distanceToMaulgar > maxDistance)
+        {
+            float dX = spot.x - maulgar->GetPositionX();
+            float dY = spot.y - maulgar->GetPositionY();
+            float moveX = spot.x + (dX / distanceToMaulgar) * maxDistance;
+            float moveY = spot.y + (dY / distanceToMaulgar) * maxDistance;
+            return MoveTo(bot->GetMapId(), moveX, moveY, spot.z, false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+        }
+        
+        float orientation = atan2(maulgar->GetPositionY() - bot->GetPositionY(), maulgar->GetPositionX() - bot->GetPositionX());
+        bot->SetFacingTo(orientation);
+        return false;
+    }
+
+    else if (!bot->IsWithinMeleeRange(maulgar))
+    {
+        return MoveTo(maulgar->GetMapId(), maulgar->GetPositionX(), maulgar->GetPositionY(), maulgar->GetPositionZ());
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarOlmTankAction::Execute(Event event)
+{
+    if (!IsOlmTank(botAI, bot))
+    {
+        return false;
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
+    if (!olm || !olm->IsAlive())
+    {
+        return false;
+    }
+
+    ObjectGuid currentIconGuid = group->GetTargetIcon(circleIcon);
+    if (currentIconGuid.IsEmpty() || currentIconGuid != olm->GetGUID())
+    {
+        group->SetTargetIcon(circleIcon, bot->GetGUID(), olm->GetGUID());
+    }
+
+    if (botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != "circle" && 
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get() != olm)
+    {
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("circle");
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(olm);
+    }
+
+    if (bot->GetVictim() != olm || olm->IsNonMeleeSpellCast(false))
+    {
+        Attack(olm);
+        
+        if (!bot->IsWithinMeleeRange(olm))
+        {
+            return MoveTo(olm->GetMapId(), olm->GetPositionX(), olm->GetPositionY(), olm->GetPositionZ());
+        }
+    }
+
+    if (olm->GetVictim() == bot && !olm->IsNonMeleeSpellCast(false))
+    {
+        const TankSpot& spot = GruulsLairTankSpots::Olm;
+        const float maxDistance = 3.0f;
+        float distanceToOlm = olm->GetExactDist2d(spot.x, spot.y);
+
+        if (distanceToOlm > maxDistance)
+        {
+            float dX = spot.x - olm->GetPositionX();
+            float dY = spot.y - olm->GetPositionY();
+            float moveX = spot.x + (dX / distanceToOlm) * maxDistance;
+            float moveY = spot.y + (dY / distanceToOlm) * maxDistance;
+            return MoveTo(bot->GetMapId(), moveX, moveY, spot.z, false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+        }
+
+        float orientation = atan2(olm->GetPositionY() - bot->GetPositionY(), olm->GetPositionX() - bot->GetPositionX());
+        bot->SetFacingTo(orientation);
+        return false;
+    }
+
+    else if (!bot->IsWithinMeleeRange(olm))
+    {
+        return MoveTo(olm->GetMapId(), olm->GetPositionX(), olm->GetPositionY(), olm->GetPositionZ());
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarBlindeyeTankAction::Execute(Event event)
+{
+    if (!IsBlindeyeTank(botAI, bot))
+    {
+        return false;
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+    if (!blindeye || !blindeye->IsAlive())
+    {
+        return false;
+    }
+
+    ObjectGuid currentIconGuid = group->GetTargetIcon(starIcon);
+    if (currentIconGuid.IsEmpty() || currentIconGuid != blindeye->GetGUID())
+    {
+        group->SetTargetIcon(starIcon, bot->GetGUID(), blindeye->GetGUID());
+    }
+
+    if (botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != "star" && 
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get() != blindeye)
+    {
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("star");
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(blindeye);
+    }
+
+    if (bot->GetVictim() != blindeye)
+    {
+        Attack(blindeye);
+        
+        if (!bot->IsWithinMeleeRange(blindeye))
+        {
+            return MoveTo(blindeye->GetMapId(), blindeye->GetPositionX(), blindeye->GetPositionY(), blindeye->GetPositionZ());
+        }
+    }
+
+    if (blindeye->GetVictim() == bot && !blindeye->IsNonMeleeSpellCast(false))
+    {
+        const TankSpot& spot = GruulsLairTankSpots::Blindeye;
+        const float maxDistance = 3.0f;
+        float distanceToBlindeye = blindeye->GetExactDist2d(spot.x, spot.y);
+
+        if (distanceToBlindeye > maxDistance)
+        {
+            float dX = spot.x - blindeye->GetPositionX();
+            float dY = spot.y - blindeye->GetPositionY();
+            float moveX = spot.x + (dX / distanceToBlindeye) * maxDistance;
+            float moveY = spot.y + (dY / distanceToBlindeye) * maxDistance;
+            return MoveTo(bot->GetMapId(), moveX, moveY, spot.z, false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+        }
+
+        float orientation = atan2(blindeye->GetPositionY() - bot->GetPositionY(), blindeye->GetPositionX() - bot->GetPositionX());
+        bot->SetFacingTo(orientation);
+        return false;
+    }
+
+    else if (!bot->IsWithinMeleeRange(blindeye))
+    {
+        return MoveTo(blindeye->GetMapId(), blindeye->GetPositionX(), blindeye->GetPositionY(), blindeye->GetPositionZ());
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarMageTankAction::Execute(Event event)
+{
+    if (!IsMageTank(botAI, bot))
+    {
+        return false;
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    if (!krosh || !krosh->IsAlive())
+    {
+        return false;
+    }
+
+    ObjectGuid currentIconGuid = group->GetTargetIcon(triangleIcon);
+    if (currentIconGuid.IsEmpty() || currentIconGuid != krosh->GetGUID())
+    {
+        group->SetTargetIcon(triangleIcon, bot->GetGUID(), krosh->GetGUID());
+    }
+
+    if (botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != "triangle" && 
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get() != krosh)
+    {
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("triangle");
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(krosh);
+    }
+
+    if (krosh->HasAura(SPELL_AURA_SPELL_SHIELD) && botAI->CanCastSpell(SPELL_SPELLSTEAL, krosh, true))
+    {
+        botAI->CastSpell(SPELL_SPELLSTEAL, krosh);
+    }
+
+    if (!bot->HasAura(SPELL_AURA_SPELL_SHIELD))
+    {
+        botAI->CastSpell("fire ward", bot);
+    }
+
+    if (bot->GetVictim() != krosh)
+    {
+        Attack(krosh);
+    }
+
+    float const OPTIMAL_RANGED_DISTANCE = 27.0f;
+    float const MIN_RANGE = OPTIMAL_RANGED_DISTANCE - 2.0f;
+    float const MAX_RANGE = OPTIMAL_RANGED_DISTANCE + 2.0f;
+
+    if (bot->IsWithinRange(krosh, MIN_RANGE) || !bot->IsWithinRange(krosh, MAX_RANGE) || 
+        !IsPositionSafe(botAI, bot, bot->GetPosition()))
+    {
+        Position safePos = FindSafePosition(botAI, bot, krosh, OPTIMAL_RANGED_DISTANCE);
+        return MoveTo(krosh->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarMoonkinTankAction::Execute(Event event)
+{
+    if (!IsMoonkinTank(botAI, bot))
+    {
+        return false;
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    if (!kiggler || !kiggler->IsAlive())
+    {
+        return false;
+    }
+
+    ObjectGuid currentIconGuid = group->GetTargetIcon(diamondIcon);
+    if (currentIconGuid.IsEmpty() || currentIconGuid != kiggler->GetGUID())
+    {
+        group->SetTargetIcon(diamondIcon, bot->GetGUID(), kiggler->GetGUID());
+    }
+
+    if (botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != "diamond" && 
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get() != kiggler)
+    {
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("diamond");
+        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(kiggler);
+    }
+
+    if (bot->GetVictim() != kiggler)
+    {
+        Attack(kiggler);
+    }
+
+    float const OPTIMAL_RANGED_DISTANCE = 29.0f;
+    float const MIN_RANGE = OPTIMAL_RANGED_DISTANCE - 1.0f;
+    float const MAX_RANGE = OPTIMAL_RANGED_DISTANCE + 1.0f;
+
+    if (bot->IsWithinRange(kiggler, MIN_RANGE) || !bot->IsWithinRange(kiggler, MAX_RANGE) || 
+        !IsPositionSafe(botAI, bot, bot->GetPosition()))
+    {
+        Position safePos = FindSafePosition(botAI, bot, kiggler, OPTIMAL_RANGED_DISTANCE);
+        return MoveTo(kiggler->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarMeleeDPSAction::Execute(Event event)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
+    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+
+    if (!botAI->IsMelee(bot) || 
+        (IsMaulgarTank(botAI, bot) && maulgar && maulgar->IsAlive()) || 
+        (IsOlmTank(botAI, bot) && olm && olm->IsAlive()) || 
+        (IsBlindeyeTank(botAI, bot) && blindeye && blindeye->IsAlive()))
+        {
+            return false;
+        }
+
+    // Target priority 1: Blindeye
+    if (blindeye && blindeye->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+
+        if (rtiValue != "star" || rtiTarget != blindeye)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("star");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(blindeye);
+        }
+
+        if (bot->GetVictim() != blindeye)
+        {
+            Attack(blindeye);
+        }
+
+        if (!bot->IsWithinMeleeRange(blindeye) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, blindeye, 5.0f);
+            return MoveTo(blindeye->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+
+        return false;
+    }
+
+    // Target priority 2: Olm
+    if (olm && olm->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "circle" || rtiTarget != olm)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("circle");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(olm);
+        }
+
+        if (bot->GetVictim() != olm)
+        {
+            Attack(olm);
+        }
+        
+        if (!bot->IsWithinMeleeRange(olm) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, olm, 5.0f);
+            return MoveTo(olm->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+
+        return false;
+    }
+
+    // Target priority 3: Kiggler
+    if (kiggler && kiggler->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+
+        if (rtiValue != "diamond" || rtiTarget != kiggler)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("diamond");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(kiggler);
+        }
+
+        if (bot->GetVictim() != kiggler)
+        {
+            Attack(kiggler);
+        }
+
+        if (!bot->IsWithinMeleeRange(kiggler) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, kiggler, 5.0f);
+            return MoveTo(kiggler->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+
+        return false;
+    }
+
+    // Target priority 4: Maulgar
+    if (maulgar && maulgar->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "square" || rtiTarget != maulgar)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("square");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(maulgar);
+        }
+
+        if (bot->GetVictim() != maulgar)
+        {
+            Attack(maulgar);
+        }
+        
+        if (!bot->IsWithinMeleeRange(maulgar) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, maulgar, 5.0f);
+            return MoveTo(maulgar->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarRangedDPSAction::Execute(Event event)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
+    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+
+    if (!botAI->IsRanged(bot) || 
+        (IsMageTank(botAI, bot) && krosh && krosh->IsAlive()) || 
+        (IsMoonkinTank(botAI, bot) && kiggler && kiggler->IsAlive()) || 
+        botAI->IsHeal(bot))
+        {
+            return false;
+        }
+
+    float const OPTIMAL_RANGED_DISTANCE = 25.0f;
+    float const MIN_RANGE = OPTIMAL_RANGED_DISTANCE - 4.0f;
+    float const MAX_RANGE = OPTIMAL_RANGED_DISTANCE + 4.0f;
+
+    // Target priority 1: Blindeye
+    if (blindeye && blindeye->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "star" || rtiTarget != blindeye)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("star");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(blindeye);
+        }
+
+        if (bot->GetVictim() != blindeye)
+        {
+            Attack(blindeye);
+        }
+
+        if (bot->IsWithinRange(blindeye, MIN_RANGE) || 
+            !bot->IsWithinRange(blindeye, MAX_RANGE) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, blindeye, OPTIMAL_RANGED_DISTANCE);
+            return MoveTo(blindeye->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+
+        return false;
+    }
+
+    // Target priority 2: Olm
+    if (olm && olm->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "circle" || rtiTarget != olm)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("circle");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(olm);
+        }
+
+        if (bot->GetVictim() != olm)
+        {
+            Attack(olm);
+        }
+        
+        if (bot->IsWithinRange(olm, MIN_RANGE) || 
+            !bot->IsWithinRange(olm, MAX_RANGE) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, olm, OPTIMAL_RANGED_DISTANCE);
+            return MoveTo(olm->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+        
+        return false;
+    }
+
+    // Target priority 3: Krosh
+    if (krosh && krosh->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "triangle" || rtiTarget != krosh)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("triangle");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(krosh);
+        }
+
+        if (bot->GetVictim() != krosh)
+        {
+            Attack(krosh);
+        }
+        
+        if (bot->IsWithinRange(krosh, MIN_RANGE) || 
+            !bot->IsWithinRange(krosh, MAX_RANGE) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, krosh, OPTIMAL_RANGED_DISTANCE);
+            return MoveTo(krosh->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+        
+        return false;
+    }
+
+    // Target priority 4: Kiggler
+    if (kiggler && kiggler->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "diamond" || rtiTarget != kiggler)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("diamond");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(kiggler);
+        }
+
+        if (bot->GetVictim() != kiggler)
+        {
+            Attack(kiggler);
+        }
+        
+        if (bot->IsWithinRange(kiggler, MIN_RANGE) || 
+            !bot->IsWithinRange(kiggler, MAX_RANGE) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, kiggler, OPTIMAL_RANGED_DISTANCE);
+            return MoveTo(kiggler->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+        
+        return false;
+    }
+
+    // Target priority 5: Maulgar
+    if (maulgar && maulgar->IsAlive())
+    {
+        Unit* rtiTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
+        std::string rtiValue = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+        
+        if (rtiValue != "square" || rtiTarget != maulgar)
+        {
+            botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set("square");
+            botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(maulgar);
+        }
+
+        if (bot->GetVictim() != maulgar)
+        {
+            Attack(maulgar);
+        }
+        
+        if (bot->IsWithinRange(maulgar, MIN_RANGE) || 
+            !bot->IsWithinRange(maulgar, MAX_RANGE) || 
+            !IsPositionSafe(botAI, bot, bot->GetPosition()))
+        {
+            Position safePos = FindSafePosition(botAI, bot, maulgar, OPTIMAL_RANGED_DISTANCE);
+            return MoveTo(maulgar->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarHealerAvoidanceAction::Execute(Event event)
+{
+    if (!botAI->IsHeal(bot))
+    {
+        return false;
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    
+    bool needToMove = !IsPositionSafe(botAI, bot, bot->GetPosition());
+    if (kiggler && kiggler->IsAlive())
+    {
+        float distanceToKiggler = bot->GetDistance(kiggler);
+        if (distanceToKiggler < 30.0f)
+        {
+            needToMove = true;
+        }
+    }
+    
+    if (needToMove)
+    {
+        float centerX = 0, centerY = 0, centerZ = 0;
+        uint32 count = 0;
+        
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || !member->IsAlive() || member == bot) 
+            {
+                continue;
+            }
+            centerX += member->GetPositionX();
+            centerY += member->GetPositionY();
+            centerZ += member->GetPositionZ();
+            count++;
+        }
+        
+        if (count == 0)
+        {
+            return false;
+        }
+
+        centerX /= count;
+        centerY /= count;
+        centerZ /= count;
+        Player* centerPlayer = nullptr;
+        float minDistToCenter = 9999.0f;
+        
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || !member->IsAlive() || member == bot)
+            {
+                continue;
+            }
+
+            float dist = sqrt(pow(member->GetPositionX() - centerX, 2) +
+                             pow(member->GetPositionY() - centerY, 2) +
+                             pow(member->GetPositionZ() - centerZ, 2));
+                             
+            if (dist < minDistToCenter)
+            {
+                minDistToCenter = dist;
+                centerPlayer = member;
+            }
+        }
+        
+        if (centerPlayer)
+        {
+            Position safePos = FindSafePosition(botAI, bot, centerPlayer, 30.0f);
+            
+            if (kiggler && kiggler->IsAlive())
+            {
+                float safeDistToKiggler = sqrt(pow(safePos.GetPositionX() - kiggler->GetPositionX(), 2) +
+                                             pow(safePos.GetPositionY() - kiggler->GetPositionY(), 2));
+                
+                if (safeDistToKiggler < 31.0f)
+                {
+                    float dx = safePos.GetPositionX() - kiggler->GetPositionX();
+                    float dy = safePos.GetPositionY() - kiggler->GetPositionY();
+                    float distance = sqrt(dx*dx + dy*dy);
+
+                    if (distance < 0.001f)
+                    {
+                        dx = 1.0f;
+                        dy = 0.0f;
+                        distance = 1.0f;
+                    }
+                    
+                    dx /= distance;
+                    dy /= distance;
+                    float newX = kiggler->GetPositionX() + dx * 30.0f;
+                    float newY = kiggler->GetPositionY() + dy * 30.0f;
+                    safePos.m_positionX = newX;
+                    safePos.m_positionY = newY;
+                }
+            }
+            
+            return MoveTo(bot->GetMapId(), safePos.m_positionX, safePos.m_positionY, safePos.m_positionZ);
+        }
+    }
+    
+    return false;
+}
+
+bool HighKingMaulgarBanishFelstalkerAction::Execute(Event event)
+{
+    Unit* felStalker = AI_VALUE2(Unit*, "find target", "wild fel stalker");
+
+    if (botAI->CanCastSpell("banish", felStalker))
+    {
+        return botAI->CastSpell("banish", felStalker);
+    }
+
+    return false;
+}
+
+bool HighKingMaulgarBanishFelstalkerAction::isUseful()
+{
+    Unit* felStalker = AI_VALUE2(Unit*, "find target", "wild fel stalker");
+
+    return felStalker && felStalker->IsAlive() && bot->getClass() == CLASS_WARLOCK;
+}
+
+bool HighKingMaulgarHunterMisdirectionAction::Execute(Event event)
+{
+    Group* group = bot->GetGroup();
+    if (!group || bot->getClass() != CLASS_HUNTER)
+    {
+        return false;
+    }
+
+    std::vector<Player*> hunters;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (member && member->IsAlive() && member->getClass() == CLASS_HUNTER)
+            hunters.push_back(member);
+    }
+
+    int hunterIndex = -1;
+    for (size_t i = 0; i < hunters.size(); ++i)
+    {
+        if (hunters[i] == bot)
+        {
+            hunterIndex = static_cast<int>(i);
+            break;
+        }
+    }
+    if (hunterIndex == -1 || hunterIndex > 1)
+    {
+        return false;
+    }
+
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    Player* moonkinTank = nullptr;
+    Player* mageTank = nullptr;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || !member->IsAlive())
+        {
+            continue;
+        }
+        if (IsMoonkinTank(botAI, member)) moonkinTank = member;
+        if (IsMageTank(botAI, member)) mageTank = member;
+    }
+
+    switch (hunterIndex)
+    {
+        case 0:
+        if (kiggler && kiggler->GetHealth() > 0.98f * kiggler->GetMaxHealth() && moonkinTank && moonkinTank->IsAlive())
+        {
+            if (botAI->CanCastSpell("misdirection", moonkinTank))
+            {
+                botAI->CastSpell("misdirection", moonkinTank);
+            }
+
+            if (!bot->HasAura(SPELL_AURA_MISDIRECTION))
+            {
+                return false;
+            }
+
+            botAI->CastSpell("steady shot", kiggler);
+            return true;
+        }
+        break;
+
+        case 1:
+            if (krosh && krosh->IsAlive() && krosh->GetHealth() > 0.98f * krosh->GetMaxHealth() && mageTank && mageTank->IsAlive())
+            {
+                if (botAI->CanCastSpell("misdirection", mageTank))
+                    botAI->CastSpell("misdirection", mageTank);
+
+                if (!bot->HasAura(SPELL_AURA_MISDIRECTION))
+                    return false;
+
+                botAI->CastSpell("steady shot", krosh);
+                return true;
+            }
+            break;
+            
+        default:
+            break;
+    }
+
+    return false;
+}
+
+bool GruulTheDragonkillerPositionBossAction::Execute(Event event)
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    
+    const TankSpot& tankSpot = GruulsLairTankSpots::Gruul;
+    const float maxDistance = 5.0f;
+    float distanceToTankSpot = gruul->GetExactDist2d(tankSpot.x, tankSpot.y);
+
+    if (distanceToTankSpot > maxDistance)
+    {
+        float dX = tankSpot.x - gruul->GetPositionX();
+        float dY = tankSpot.y - gruul->GetPositionY();
+        float moveX = tankSpot.x + (dX / distanceToTankSpot) * maxDistance;
+        float moveY = tankSpot.y + (dY / distanceToTankSpot) * maxDistance;
+
+        float moveDistance = bot->GetExactDist2d(moveX, moveY);
+        if (moveDistance < 0.5f)
+        {
+            return false;
+        }
+
+        return MoveTo(bot->GetMapId(), moveX, moveY, tankSpot.z, false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+    }
+    
+    float desiredOrientation = atan2(gruul->GetPositionY() - bot->GetPositionY(), gruul->GetPositionX() - bot->GetPositionX());
+    float currentOrientation = bot->GetOrientation();
+    float delta = desiredOrientation - currentOrientation;
+    while (delta > M_PI)
+        delta -= 2 * M_PI;
+    while (delta < -M_PI)
+        delta += 2 * M_PI;
+    float orientationDifference = fabs(static_cast<double>(delta));
+
+    const float orientationLeeway = 30.0f * M_PI / 180.0f;
+    if (orientationDifference > orientationLeeway)
+    {
+        bot->SetFacingTo(desiredOrientation);
+    }
+
+    return false;   
+}
+
+bool GruulTheDragonkillerPositionBossAction::isUseful()
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+
+    return gruul && gruul->IsAlive() && botAI->IsTank(bot) && botAI->HasAggro(gruul) && gruul->GetVictim() == bot;
+}
+
+bool GruulTheDragonkillerSpreadRangedAction::Execute(Event event)
+{
+    static std::unordered_map<ObjectGuid, Position> initialPositions;
+    static std::unordered_map<ObjectGuid, bool> hasReachedInitialPosition;
+
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    if (gruul && gruul->IsAlive() && gruul->GetHealth() == gruul->GetMaxHealth())
+    {
+        initialPositions.clear();
+        hasReachedInitialPosition.clear();
+    }
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    static const TankSpot& tankSpot = GruulsLairTankSpots::Gruul;
+
+    if (initialPositions.find(bot->GetGUID()) == initialPositions.end())
+    {
+        float centerX = tankSpot.x;
+        float centerY = tankSpot.y;
+        float centerZ = bot->GetPositionZ();
+        float minRadius = 25.0f;
+        float maxRadius = 40.0f;
+
+        uint32 count = 0;
+        uint32 botIndex = 0;
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || !member->IsAlive() || !botAI->IsRanged(member))
+            {
+                continue;
+            }
+            if (member == bot)
+            {
+                botIndex = count;
+            }
+            count++;
+        }
+
+        if (count == 0)
+        {
+            return false;
+        }
+
+        float angle = 2 * M_PI * botIndex / count;
+        float radius = minRadius + static_cast<float>(rand()) / RAND_MAX * (maxRadius - minRadius);
+        float targetX = centerX + radius * cos(angle);
+        float targetY = centerY + radius * sin(angle);
+
+        initialPositions[bot->GetGUID()] = Position(targetX, targetY, centerZ);
+        hasReachedInitialPosition[bot->GetGUID()] = false;
+    }
+
+    Position targetPosition = initialPositions[bot->GetGUID()];
+    if (!hasReachedInitialPosition[bot->GetGUID()])
+    {
+        if (!bot->IsWithinDist2d(targetPosition.GetPositionX(), targetPosition.GetPositionY(), 2.0f))
+        {
+            return MoveTo(bot->GetMapId(), targetPosition.GetPositionX(), targetPosition.GetPositionY(), targetPosition.GetPositionZ());
+        }
+
+        hasReachedInitialPosition[bot->GetGUID()] = true;
+    }
+
+    float gruulRangedRadius = 25.0f;
+    float minSpreadDistance = 10.0f;
+    float movementThreshold = 2.0f;
+    Unit* closestMember = nullptr;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+
+        if (!member || !member->IsAlive() || member == bot || !botAI->IsRanged(member))
+        {
+            continue;
+        }
+
+        if (!closestMember || bot->GetExactDist2d(member) < bot->GetExactDist2d(closestMember))
+        {
+            closestMember = member;
+        }
+    }
+
+    if (closestMember && bot->GetExactDist2d(closestMember) < minSpreadDistance - movementThreshold)
+    {
+        return MoveAway(closestMember, minSpreadDistance);
+    }
+
+    float distanceToGruul = bot->GetExactDist2d(tankSpot.x, tankSpot.y);
+    
+    if (distanceToGruul < gruulRangedRadius - 3.0f - movementThreshold)
+    {
+        return MoveTo(bot->GetMapId(), tankSpot.x, tankSpot.y, tankSpot.z);
+    }
+
+    return false;
+}
+
+bool GruulTheDragonkillerSpreadRangedAction::isUseful()
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+
+    return gruul && gruul->IsAlive() && botAI->IsRanged(bot);
+}
+
+bool GruulTheDragonkillerShatterSpreadAction::Execute(Event event)
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+
+    float radius = 22.0f;
+    Unit* closestMember = nullptr;
+
+    GuidVector members = AI_VALUE(GuidVector, "group members");
+    for (auto& member : members)
+    {
+        Unit* unit = botAI->GetUnit(member);
+
+        if (!unit || bot->GetGUID() == member)
+        {
+            continue;
+        }
+
+        if (!closestMember || bot->GetExactDist2d(unit) < bot->GetExactDist2d(closestMember))
+        {
+            closestMember = unit;
+        }
+
+        return MoveAway(closestMember, 6.0f);
+    }
+    
+    return false;
+}
+
+bool GruulTheDragonkillerShatterSpreadAction::isUseful()
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+
+    return gruul && gruul->IsAlive() && 
+           (bot->HasAura(SPELL_AURA_GROUND_SLAM_1) || bot->HasAura(SPELL_AURA_GROUND_SLAM_2));
+}

--- a/src/strategy/raids/gruulslair/RaidGruulsLairActions.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairActions.h
@@ -1,0 +1,124 @@
+#ifndef _PLAYERBOT_RAIDGRUULSLAIRACTIONS_H
+#define _PLAYERBOT_RAIDGRUULSLAIRACTIONS_H
+
+#include "Action.h"
+#include "AttackAction.h"
+#include "MovementActions.h"
+
+class HighKingMaulgarRemoveTankAssistAction : public Action
+{
+public:
+    HighKingMaulgarRemoveTankAssistAction(PlayerbotAI* botAI, std::string const name = "high king maulgar remove tank assist") : Action(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarMaulgarTankAction : public AttackAction
+{
+public:
+    HighKingMaulgarMaulgarTankAction(PlayerbotAI* botAI, std::string const name = "high king maulgar maulgar tank") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarOlmTankAction : public AttackAction
+{
+public:
+    HighKingMaulgarOlmTankAction(PlayerbotAI* botAI, std::string const name = "high king maulgar olm tank") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarBlindeyeTankAction : public AttackAction
+{
+public:
+    HighKingMaulgarBlindeyeTankAction(PlayerbotAI* botAI, std::string const name = "high king maulgar blindeye tank") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarMageTankAction : public AttackAction
+{
+public:
+    HighKingMaulgarMageTankAction(PlayerbotAI* botAI, std::string const name = "high king maulgar mage tank") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarMoonkinTankAction : public AttackAction
+{
+public:
+    HighKingMaulgarMoonkinTankAction(PlayerbotAI* botAI, std::string const name = "high king maulgar moonkin tank") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarMeleeDPSAction : public AttackAction
+{
+public:
+    HighKingMaulgarMeleeDPSAction(PlayerbotAI* botAI, std::string const name = "high king maulgar melee dps") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarRangedDPSAction : public AttackAction
+{
+public:
+    HighKingMaulgarRangedDPSAction(PlayerbotAI* botAI, std::string const name = "high king maulgar ranged dps") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarHealerAvoidanceAction : public MovementAction
+{
+public:
+    HighKingMaulgarHealerAvoidanceAction(PlayerbotAI* botAI, std::string const name = "high king maulgar healer avoidance") : MovementAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarBanishFelstalkerAction : public AttackAction
+{
+public:
+    HighKingMaulgarBanishFelstalkerAction(PlayerbotAI* botAI, std::string const name = "high king maulgar banish felstalker") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+    bool isUseful();
+};
+
+class HighKingMaulgarHunterMisdirectionAction : public AttackAction
+{
+public:
+    HighKingMaulgarHunterMisdirectionAction(PlayerbotAI* botAI, std::string const name = "high king maulgar hunter misdirection") : AttackAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+};
+
+class GruulTheDragonkillerPositionBossAction : public MovementAction
+{
+public:
+    GruulTheDragonkillerPositionBossAction(PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller position boss") : MovementAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+    bool isUseful();
+};
+
+class GruulTheDragonkillerSpreadRangedAction : public MovementAction
+{
+public:
+    GruulTheDragonkillerSpreadRangedAction(PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller spread ranged") : MovementAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+    bool isUseful();
+};
+
+class GruulTheDragonkillerShatterSpreadAction : public MovementAction
+{
+public:
+    GruulTheDragonkillerShatterSpreadAction(PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller shatter spread") : MovementAction(botAI, name) {};
+
+    bool Execute(Event event) override;
+    bool isUseful();
+};
+
+#endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairHelpers.cpp
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairHelpers.cpp
@@ -1,0 +1,251 @@
+#include "RaidGruulsLairHelpers.h"
+#include "AiFactory.h"
+#include "PlayerbotAI.h"
+#include "Group.h"
+#include "GroupReference.h"
+#include "Unit.h"
+
+bool IsMageTank(PlayerbotAI* botAI, Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Player* highestHpMage = nullptr;
+    uint32 highestHp = 0;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member)
+        {
+            continue;
+        }
+        if (member->getClass() == CLASS_MAGE)
+        {
+            uint32 hp = member->GetMaxHealth();
+            if (!highestHpMage || hp > highestHp)
+            {
+                highestHpMage = member;
+                highestHp = hp;
+            }
+        }
+    }
+    return highestHpMage == bot;
+}
+
+bool IsMoonkinTank(PlayerbotAI* botAI, Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        return false;
+    }
+
+    Player* highestHpMoonkin = nullptr;
+    uint32 highestHp = 0;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member)
+        {
+            continue;
+        }
+
+        if (member->getClass() == CLASS_DRUID)
+        {
+            int tab = AiFactory::GetPlayerSpecTab(member);
+            if (tab == DRUID_TAB_BALANCE)
+            {
+                uint32 hp = member->GetMaxHealth();
+                if (!highestHpMoonkin || hp > highestHp)
+                {
+                    highestHpMoonkin = member;
+                    highestHp = hp;
+                }
+            }
+        }
+    }
+    return highestHpMoonkin == bot;
+}
+
+bool IsMaulgarTank(PlayerbotAI* botAI, Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group || !botAI->IsTank(bot))
+    {
+        return false;
+    }
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member) continue;
+        if (botAI->IsTank(member))
+        {
+            return member == bot;
+        }
+    }
+    return false;
+}
+
+bool IsOlmTank(PlayerbotAI* botAI, Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group || !botAI->IsTank(bot))
+    {
+        return false;
+    }
+    int tankIndex = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member) continue;
+        if (botAI->IsTank(member))
+        {
+            if (tankIndex == 1)
+            {
+                return member == bot;
+            }
+            ++tankIndex;
+        }
+    }
+    return false;
+}
+
+bool IsBlindeyeTank(PlayerbotAI* botAI, Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group || !botAI->IsTank(bot))
+    {
+        return false;
+    }
+    int tankIndex = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member) continue;
+        if (botAI->IsTank(member))
+        {
+            if (tankIndex == 2)
+            {
+                return member == bot;
+            }
+            ++tankIndex;
+        }
+    }
+    return false;
+}
+
+bool IsPositionSafe(PlayerbotAI* botAI, Unit* bot, Position pos)
+{
+    const float KROSH_SAFE_DISTANCE = 21.0f;
+    const float MAULGAR_WHIRLWIND_DISTANCE = 10.0f;
+    bool isSafe = true;
+
+    Unit* krosh = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "krosh firehand")->Get();
+    if (krosh && krosh->IsAlive())
+    {
+        float dist = sqrt(pow(pos.GetPositionX() - krosh->GetPositionX(), 2) + 
+                          pow(pos.GetPositionY() - krosh->GetPositionY(), 2));
+        if (dist < KROSH_SAFE_DISTANCE)
+        {
+            isSafe = false;
+        }
+    }
+    Unit* maulgar = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "high king maulgar")->Get();
+    if (maulgar && maulgar->IsAlive() && maulgar->HasAura(SPELL_AURA_WHIRLWIND))
+    {
+        float dist = sqrt(pow(pos.GetPositionX() - maulgar->GetPositionX(), 2) + 
+                          pow(pos.GetPositionY() - maulgar->GetPositionY(), 2));
+
+        if (dist < MAULGAR_WHIRLWIND_DISTANCE)
+        {
+            isSafe = false;
+        }
+    }
+    
+    return isSafe;
+}
+
+Position FindSafePosition(PlayerbotAI* botAI, Unit* bot, Unit* target, float optimalDistance)
+{
+    Position bestPos;
+    bestPos.m_positionX = bot->GetPositionX();
+    bestPos.m_positionY = bot->GetPositionY();
+    bestPos.m_positionZ = bot->GetPositionZ();
+    
+    Unit* krosh = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "krosh firehand")->Get();
+    Unit* maulgar = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "high king maulgar")->Get();
+
+    bool dangerousKrosh = krosh && krosh->IsAlive();
+    bool dangerousMaulgar = maulgar && maulgar->IsAlive() && maulgar->HasAura(SPELL_AURA_WHIRLWIND);
+    
+    if (!dangerousKrosh && !dangerousMaulgar)
+    {
+        return bestPos;
+    }
+
+    if (IsPositionSafe(botAI, bot, bestPos))
+    {
+        return bestPos;
+    }
+
+    const int NUM_POSITIONS = 32;
+    float bestScore = 99999.0f;
+    bool foundSafeSpot = false;
+    
+    for (int i = 0; i < NUM_POSITIONS; i++)
+    {
+        float angle = 2 * M_PI * i / NUM_POSITIONS;
+        Position candidatePos;
+        candidatePos.m_positionX = target->GetPositionX() + optimalDistance * cos(angle);
+        candidatePos.m_positionY = target->GetPositionY() + optimalDistance * sin(angle);
+        candidatePos.m_positionZ = target->GetPositionZ();
+        
+        if (IsPositionSafe(botAI, bot, candidatePos))
+        {
+            float movementDistance = sqrt(pow(candidatePos.GetPositionX() - bot->GetPositionX(), 2) + 
+                                         pow(candidatePos.GetPositionY() - bot->GetPositionY(), 2));
+            
+            if (movementDistance < bestScore)
+            {
+                bestScore = movementDistance;
+                bestPos = candidatePos;
+                foundSafeSpot = true;
+            }
+        }
+    }
+
+    if (foundSafeSpot)
+    {
+        return bestPos;
+    }
+
+    float dx = 0, dy = 0;
+
+    if (dangerousKrosh && bot->GetDistance(krosh) < 30.0f)
+    {
+        dx += bot->GetPositionX() - krosh->GetPositionX();
+        dy += bot->GetPositionY() - krosh->GetPositionY();
+    }
+    
+    if (dangerousMaulgar && bot->GetDistance(maulgar) < 50.0f)
+    {
+        dx += bot->GetPositionX() - maulgar->GetPositionX();
+        dy += bot->GetPositionY() - maulgar->GetPositionY();
+    }
+
+    float dist = sqrt(dx*dx + dy*dy);
+    if (dist > 0.1f)
+    {
+        float escapeDistance = 20.0f;
+        bestPos.m_positionX = bot->GetPositionX() + (dx/dist) * escapeDistance;
+        bestPos.m_positionY = bot->GetPositionY() + (dy/dist) * escapeDistance;
+        bestPos.m_positionZ = bot->GetPositionZ();
+    }
+
+    return bestPos;
+}

--- a/src/strategy/raids/gruulslair/RaidGruulsLairHelpers.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairHelpers.h
@@ -1,0 +1,57 @@
+#ifndef RAID_GRUULSLAIR_HELPERS_H
+#define RAID_GRUULSLAIR_HELPERS_H
+
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "RtiTargetValue.h"
+
+enum GruulsLairSpells
+{
+	// High King Maulgar
+	SPELL_AURA_WHIRLWIND = 33238,
+
+	// Krosh Firehand
+	SPELL_AURA_SPELL_SHIELD = 33054,
+
+	// Hunter
+	SPELL_AURA_MISDIRECTION = 34477,
+
+	// Mage
+	SPELL_SPELLSTEAL = 30449,
+
+	// Gruul the Dragonkiller
+	SPELL_AURA_GROUND_SLAM_1 = 33525,
+	SPELL_AURA_GROUND_SLAM_2 = 39187,
+};
+
+// Define constants for RTI indexes
+inline constexpr int8 squareIcon = RtiTargetValue::squareIndex;
+inline constexpr int8 starIcon = RtiTargetValue::starIndex;
+inline constexpr int8 circleIcon = RtiTargetValue::circleIndex;
+inline constexpr int8 diamondIcon = RtiTargetValue::diamondIndex;
+inline constexpr int8 triangleIcon = RtiTargetValue::triangleIndex;
+
+bool IsMaulgarTank(PlayerbotAI* botAI, Player* bot);
+bool IsOlmTank(PlayerbotAI* botAI, Player* bot);
+bool IsBlindeyeTank(PlayerbotAI* botAI, Player* bot);
+bool IsMageTank(PlayerbotAI* botAI, Player* bot);
+bool IsMoonkinTank(PlayerbotAI* botAI, Player* bot);
+bool IsPositionSafe(PlayerbotAI* botAI, Unit* bot, Position pos);
+Position FindSafePosition(PlayerbotAI* botAI, Unit* bot, Unit* target, float optimalDistance);
+
+// Gruul's Lair tanking spots (X, Y, Z)
+struct TankSpot 
+{
+	float x, y, z;
+	float orientation;
+};
+
+namespace GruulsLairTankSpots 
+{
+	static const TankSpot Maulgar  = { 90.686f, 167.047f, -13.234f, 3.009f };
+	static const TankSpot Olm      = { 99.392f, 192.834f, -10.883f, 6.265f };
+	static const TankSpot Blindeye = { 100.728f, 206.389f, -10.514f, 6.218f };
+	static const TankSpot Gruul    = { 241.238f, 365.025f, -4.220f, 4.071f};
+}
+
+#endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairMultipliers.cpp
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairMultipliers.cpp
@@ -1,0 +1,83 @@
+#include "RaidGruulsLairMultipliers.h"
+#include "RaidGruulsLairActions.h"
+#include "RaidGruulsLairHelpers.h"
+#include "GenericSpellActions.h"
+#include "DruidBearActions.h"
+#include "DruidCatActions.h"
+#include "HunterActions.h"
+#include "MageActions.h"
+#include "WarriorActions.h"
+
+static bool IsChargeAction(Action* action)
+{
+    return dynamic_cast<CastChargeAction*>(action) ||
+           dynamic_cast<CastInterceptAction*>(action) ||
+           dynamic_cast<CastFeralChargeBearAction*>(action) ||
+           dynamic_cast<CastFeralChargeCatAction*>(action);
+}
+
+float HighKingMaulgarMultiplier::GetValue(Action* action)
+{
+    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    if (maulgar && maulgar->HasAura(SPELL_AURA_WHIRLWIND) && IsChargeAction(action))
+    {
+        return 0.0f;
+    }
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (krosh && target && target->GetGUID() == krosh->GetGUID())
+    {
+        if (dynamic_cast<CastArcaneShotAction*>(action))
+        {
+            return 0.0f;
+        }
+        if (dynamic_cast<CastEvocationAction*>(action))
+        {
+            if (IsMageTank(botAI, bot) && krosh->GetVictim() && krosh->GetVictim()->GetGUID() == bot->GetGUID())
+                return 0.0f;
+        }
+    }
+
+    return 1.0f;
+}
+
+float GruulTheDragonkillerMultiplier::GetValue(Action* action)
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    if (!gruul) 
+    {
+        return 1.0f;
+    }
+
+    if (bot->HasAura(SPELL_AURA_GROUND_SLAM_1) || bot->HasAura(SPELL_AURA_GROUND_SLAM_2))
+    {
+        if ((dynamic_cast<MovementAction*>(action) && !dynamic_cast<GruulTheDragonkillerShatterSpreadAction*>(action)) ||
+            IsChargeAction(action))
+        {
+            return 0.0f;
+        }
+    }
+
+    const TankSpot& tankSpot = GruulsLairTankSpots::Gruul;
+    const float positionThreshold = 3.0f;
+    const float orientationLeeway = 30.0f * M_PI / 180.0f;
+
+    float distanceToTankSpot = bot->GetExactDist2d(tankSpot.x, tankSpot.y);
+    float desiredOrientation = atan2(gruul->GetPositionY() - bot->GetPositionY(), gruul->GetPositionX() - bot->GetPositionX());
+    float currentOrientation = bot->GetOrientation();
+    float delta = desiredOrientation - currentOrientation;
+    while (delta > M_PI) delta -= 2 * M_PI;
+    while (delta < -M_PI) delta += 2 * M_PI;
+    float orientationDifference = fabs(delta);
+
+    if (botAI->IsTank(bot) && botAI->HasAggro(gruul) && gruul->GetVictim() == bot &&
+        distanceToTankSpot < positionThreshold && orientationDifference < orientationLeeway)
+    {
+        if (dynamic_cast<MovementAction*>(action))
+        {
+            return 0.0f;
+        }
+    }
+
+    return 1.0f;
+}

--- a/src/strategy/raids/gruulslair/RaidGruulsLairMultipliers.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairMultipliers.h
@@ -1,0 +1,20 @@
+#ifndef _PLAYERBOT_RAIDGRUULSLAIRMULTIPLIERS_H
+#define _PLAYERBOT_RAIDGRUULSLAIRMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class HighKingMaulgarMultiplier : public Multiplier
+{
+public:
+    HighKingMaulgarMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar multiplier") {}
+    virtual float GetValue(Action* action);
+};
+
+class GruulTheDragonkillerMultiplier : public Multiplier
+{
+public:
+    GruulTheDragonkillerMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller multiplier") {}
+    virtual float GetValue(Action* action);
+};
+
+#endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairStrategy.cpp
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairStrategy.cpp
@@ -1,0 +1,31 @@
+#include "RaidGruulsLairStrategy.h"
+#include "RaidGruulsLairMultipliers.h"
+
+void RaidGruulsLairStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("high king maulgar", NextAction::array(0,
+        new NextAction("high king maulgar remove tank assist", ACTION_RAID + 3),
+        new NextAction("high king maulgar hunter misdirection", ACTION_RAID + 3),
+        new NextAction("high king maulgar banish felstalker", ACTION_RAID + 3),
+        new NextAction("high king maulgar maulgar tank", ACTION_RAID + 2),
+        new NextAction("high king maulgar olm tank", ACTION_RAID + 2),
+        new NextAction("high king maulgar blindeye tank", ACTION_RAID + 2),
+        new NextAction("high king maulgar mage tank", ACTION_RAID + 2),
+        new NextAction("high king maulgar moonkin tank", ACTION_RAID + 2),
+        new NextAction("high king maulgar melee dps", ACTION_RAID + 2),
+        new NextAction("high king maulgar ranged dps", ACTION_RAID + 2),
+        new NextAction("high king maulgar healer avoidance", ACTION_RAID + 2),
+        nullptr)));
+
+    triggers.push_back(new TriggerNode("gruul the dragonkiller", NextAction::array(0,
+        new NextAction("gruul the dragonkiller shatter spread", ACTION_EMERGENCY + 6),
+        new NextAction("gruul the dragonkiller position boss", ACTION_RAID + 1),
+        new NextAction("gruul the dragonkiller spread ranged", ACTION_RAID + 1),
+        nullptr)));
+}
+
+void RaidGruulsLairStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new HighKingMaulgarMultiplier(botAI));
+    multipliers.push_back(new GruulTheDragonkillerMultiplier(botAI));
+}

--- a/src/strategy/raids/gruulslair/RaidGruulsLairStrategy.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairStrategy.h
@@ -1,0 +1,18 @@
+#ifndef _PLAYERBOT_RAIDGRUULSLAIRSTRATEGY_H
+#define _PLAYERBOT_RAIDGRUULSLAIRSTRATEGY_H
+
+#include "Strategy.h"
+#include "Multiplier.h"
+
+class RaidGruulsLairStrategy : public Strategy
+{
+public:
+    RaidGruulsLairStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+    
+    std::string const getName() override { return "gruulslair"; }
+
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+};
+
+#endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairTriggerContext.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairTriggerContext.h
@@ -1,0 +1,21 @@
+#ifndef _PLAYERBOT_RAIDGRUULSLAIRTRIGGERCONTEXT_H
+#define _PLAYERBOT_RAIDGRUULSLAIRTRIGGERCONTEXT_H
+
+#include "RaidGruulsLairTriggers.h"
+#include "AiObjectContext.h"
+
+class RaidGruulsLairTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    RaidGruulsLairTriggerContext() : NamedObjectContext<Trigger>()
+    {
+        creators["high king maulgar"] = &RaidGruulsLairTriggerContext::high_king_maulgar;
+        creators["gruul the dragonkiller"] = &RaidGruulsLairTriggerContext::gruul_the_dragonkiller;
+    }
+
+private:
+    static Trigger* high_king_maulgar(PlayerbotAI* botAI) { return new HighKingMaulgarTrigger(botAI); }
+    static Trigger* gruul_the_dragonkiller(PlayerbotAI* botAI) { return new GruulTheDragonkillerTrigger(botAI); }
+};
+
+#endif

--- a/src/strategy/raids/gruulslair/RaidGruulsLairTriggers.cpp
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairTriggers.cpp
@@ -1,0 +1,34 @@
+#include "RaidGruulsLairTriggers.h"
+#include "Playerbots.h"
+
+bool HighKingMaulgarTrigger::IsActive()
+{
+
+    float originalSightDistance = sPlayerbotAIConfig->sightDistance;
+    
+    sPlayerbotAIConfig->sightDistance = 150.0f;
+    
+    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
+    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+    
+    bool foundBosses = (maulgar && maulgar->IsAlive()) ||
+                      (kiggler && kiggler->IsAlive()) ||
+                      (krosh && krosh->IsAlive()) ||
+                      (olm && olm->IsAlive()) ||
+                      (blindeye && blindeye->IsAlive());
+
+    if (!foundBosses)
+        sPlayerbotAIConfig->sightDistance = originalSightDistance;
+    
+    return foundBosses;
+}
+
+bool GruulTheDragonkillerTrigger::IsActive()
+{
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    
+    return gruul && gruul->IsAlive();
+}

--- a/src/strategy/raids/gruulslair/RaidGruulsLairTriggers.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairTriggers.h
@@ -1,0 +1,20 @@
+#ifndef _PLAYERBOT_RAIDGRUULSLAIRTRIGGERS_H
+#define _PLAYERBOT_RAIDGRUULSLAIRTRIGGERS_H
+
+#include "Trigger.h"
+
+class HighKingMaulgarTrigger : public Trigger
+{
+public:
+    HighKingMaulgarTrigger(PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar") {}
+    bool IsActive() override;
+};
+
+class GruulTheDragonkillerTrigger : public Trigger
+{
+public:
+    GruulTheDragonkillerTrigger(PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller") {}
+    bool IsActive() override;
+};
+
+#endif


### PR DESCRIPTION
This PR implements strategies for the two boss encounters in Gruul’s Lair: High King Maulgar and Gruul the Dragonkiller. I put together these strategies playing with 50% damage and 60% healing (via Individual Progression) and also after reverting the patch 3.0.2 30% HP nerfs to TBC raid mobs. Like Karazhan, I'm marking this as a draft for testing purposes, even though there is nothing further I am intending to do at this time.

### High King Maulgar:

**Overview**: This fight is, to put it lightly, a pain in the ass. It’s an easy fight that is won or lost on the pull, and it’s pretty messy getting bots to set it up properly, even with a strategy, considering that they cannot be manually positioned on an individual basis like real players (at least not by coded strategies). I think this fight is probably doable without strategies if you have really good DPS, as you can probably burn down a couple of the adds quickly to get away with a messy pull. I do not think it is doable without strategies if you adjust the numbers to create a more authentic 2007 experience. You will have bots that get one-shot, so without a strategy it’s a pure race.

**Strategies**:

_Standard Tanks_: This fight requires three traditional tanks (i.e., warrior, bear, or paladin). They are selected by the standard GetFirstMember logic (the final tank that joined your raid will be the first-selected tank and will tank Maulgar, the second-to-last tank that joined your raid will tank Olm, and the third-to-last tank that joined your raid will tank Blindeye). The Maulgar tank will drag Maulgar to the back wall near the entrance of the room. The Olm and Blindeye tanks will drag their respective targets to the back wall but closer to the exit of the room (out of range of Maulgar). Moving Olm is kind of finicky as he tends to want to just keep casting and refuse to chase the tank. I wasn’t able to come up with a smoother way of doing it, but as long as he’s out of range of Krosh and Maulgar, it’s not the end of the world.

_Moonkin Tank_: Kiggler will be tanked by the Moonkin Druid in your raid with the highest max HP (if you’re crazy enough to have more than one Moonkin Druid). There is no designated spot for Kiggler—ideally the Druid just tanks him where he stands, but he doesn’t always end up in the same spot. If you have no Moonkin Druid, you will need to figure out how to tank Kiggler on your own (basically any two ranged DPS can do it, or potentially a bear if you’re feeling lucky).

_Mage Tank_: This is the most important role in the fight and will be your Mage with the highest max HP (9K+ at a minimum not to get one shot, but ideally more). There is no specified location in the strategy; ideally Krosh is tanked where he stands, and in practice that’s generally how it works. The Mage tank will Spellsteal Krosh’s Spell Shield, which will reduce the damage of Krosh’s Greater Fireballs by 75%. There will be a gap between the Spell Shield’s expiration on the Mage tank and Krosh generating a new Spell Shield to be stolen; the Mage will apply Fire Ward on themselves at that time to try to survive the hit without the Spell Shield.

_DPS Priorities_: There is significant variance in kill order strategies—the only universally agreed-upon strategy is that all DPS should kill Blindeye first and Maulgar will die last. In this strategy, melee DPS will follow the kill order of Blindeye, Olm, Kiggler, and Maulgar. Ranged DPS will follow the kill order of Blindeye, Olm, Krosh, Kiggler (if melee has not killed him already), and Maulgar. As adds die, the respective tanks will join the melee/ranged DPS logic (as applicable). I understand that Kiggler casts Arcane Explosion, but it’s only every 30 seconds, and it does piss for damage. I find it more effective for melee to kill him than for melee to move directly to Maulgar after Olm.

_General Avoidance_: Bots will attempt to stay out of Krosh’s Blast Wave radius, Kiggler’s Arcane Explosion radius (when not attacking), and Maulgar’s Whirlwind (only while being channeled). Healers will attempt to stay near the center of the raid.

_Wild Fel Stalkers_: The intended strategy was for Warlocks to enslave the Wild Fel Stalkers and have them tank Olm (who casts a stacking debuff that, back in 2007 anyway, made it difficult for a traditional tank to remain on Olm). Unfortunately, after banging my head on my keyboard for hours, I realized that bots are not able to control enslaved demons. That is a gap in the general playerbots logic. So instead, Warlocks will banish Fel Stalkers as they are summoned.

_Misdirection_: The last Hunter that joined your party will cast Misdirection on your Moonkin tank and direct threat from Kiggler. The second-to-last Hunter that joined your party will cast Misdirection on your Mage tank and direct threat from Krosh. I discovered that Misdirection does not place an aura on the character on which Misdirection is cast so that it is not possible to cast Misdirection before the pull and have the bots attack the correct target. This was the best compromise I could come to.

### Gruul the Dragonkiller: 

**Overview**: This guy is kind of a giant piñata, and I’m certain no strategy is needed if you’re playing the base 3.3.5 version. But since the whole point of the fight is that it gets more difficult over time due to him gaining 15% damage with Growth every 30 seconds, any nerfs will compound the difficulty on this fight, so I think some strategies do make a big difference if you want to have a more authentic experience. But even with the nerfs I played with (which I believe result in feasible numbers), the bots could take down Gruul in under 10 Growth stacks. Back in the day, it was not uncommon for guilds to end up at 15+ stacks (players were just not as knowledgeable and therefore not as effective back then).

**Strategies**: 

_Tanking Location_: The tank with aggro will move Gruul to the center of the room. This is particularly important after Shatters, when Gruul will chase the tank to their post-Shatter location. I prefer using the tank with aggro in the strategies, even though Playerbots does recognize the main tank set in the UI, because some players might not be aware of the ability to actually set a main tank and therefore the strategy would fail for them.

_Spreading Ranged:_ At the beginning of the fight, ranged bots will fan out around Gruul. This is just so that they start spread through the room (spreading immediately takes them forever, and they end up not utilizing the whole space. This makes it much less likely that bots will end up stacked when Shatter hits.

_Shatter_: Bots will attempt to spread out after a Ground Slam. There is only so much that can be done though based on where the bots are thrown (the spreading of ranged in advance is really the key part of the fight). You will get some weird errors in WorldServer complaining about velocity <0.01f during this action. I do not know what causes this, but it doesn't appear to have any adverse effect. I see that one of the recent PRs that was reverted attempted to address this issue.

Good luck with getting a Dragonspine Trophy!