### PR TITLE
Fix: Prevent priests in Spirit of Redemption form from using mana

### DIFF
--- a/src/strategy/values/StatsValues.cpp
+++ b/src/strategy/values/StatsValues.cpp
@@ -7,10 +7,6 @@
 #include "Playerbots.h"
 #include "ServerFacade.h"
 
-namespace {
-    constexpr uint32 PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID = 20711u; 
-}
-
 Unit* HealthValue::GetTarget()
 {
     AiObjectContext* ctx = AiObject::context;
@@ -122,7 +118,8 @@ bool HasManaValue::Calculate()
     Unit* target = GetTarget();
     if (!target)
         return false;
-    
+
+    constexpr uint32 PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID = 20711u;
     if (target->HasAura(PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID))
         return false;
 

--- a/src/strategy/values/StatsValues.cpp
+++ b/src/strategy/values/StatsValues.cpp
@@ -4,9 +4,12 @@
  */
 
 #include "StatsValues.h"
-
 #include "Playerbots.h"
 #include "ServerFacade.h"
+
+namespace {
+    constexpr uint32 PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID = 20711u; 
+}
 
 Unit* HealthValue::GetTarget()
 {
@@ -120,7 +123,7 @@ bool HasManaValue::Calculate()
     if (!target)
         return false;
     
-    if (target->HasAura(20711)) // Spirit of Redemption
+    if (target->HasAura(PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID))
         return false;
 
     return target->GetPower(POWER_MANA);

--- a/src/strategy/values/StatsValues.cpp
+++ b/src/strategy/values/StatsValues.cpp
@@ -119,6 +119,9 @@ bool HasManaValue::Calculate()
     Unit* target = GetTarget();
     if (!target)
         return false;
+    
+    if (target->HasAura(20711)) // Spirit of Redemption
+        return false;
 
     return target->GetPower(POWER_MANA);
 }


### PR DESCRIPTION
This change modifies the `HasManaValue::Calculate()` function in `src/strategy/values/StatsValues.cpp`.

Previously, priests in Spirit of Redemption form (angel form when dead) could still attempt to use mana-restoring actions like drinking water, which is illogical since they cannot use mana in that form.

This fix adds a check for the Spirit of Redemption aura (spell ID 20711) to prevent mana usage:
- If the target has the Spirit of Redemption aura, the function returns false
- This prevents priests in angel form from attempting to drink water or use other mana-restoring actions
- Improves bot behavior realism by respecting the limitations of the Spirit of Redemption form

This change works in conjunction with the previous fix that prevents non-mana-using classes from attempting to restore mana, creating a more comprehensive solution for mana management.