### PR TITLE
FIX: Allow following master's mount state regardless of group leader

### DIFF
--- a/src/strategy/actions/CheckMountStateAction.cpp
+++ b/src/strategy/actions/CheckMountStateAction.cpp
@@ -152,13 +152,9 @@ bool CheckMountStateAction::Execute(Event /*event*/)
 
     bool inBattleground = bot->InBattleground();
 
-    // If there is a master and bot not in BG
+    // If there is a master and bot not in BG, follow master's mount state regardless of group leader
     if (master && !inBattleground)
     {
-        Group* group = bot->GetGroup();
-        if (!group || group->GetLeaderGUID() != master->GetGUID())
-            return false;
-
         if (ShouldFollowMasterMountState(master, noAttackers, shouldMount))
             return Mount();
 


### PR DESCRIPTION
Closes: #905 

The problem this change addresses is described in the mentioned issue. 
In short, bots only mount up with the master if the master is the party leader.

This pull request adjusts the logic in the `CheckMountStateAction::Execute` method by ensuring that the bot follows the master's mount state, even (or specifically) when the master is not the group leader.

--- 

How to Test:

1. Log in to a player account
2. Use `.playerbots bot addclass mage`
3. Invite the bot to your group (if not automatically added)
4. Invite a second player character (different account) to the same group
5. Mount up, the mage bot mounts up too
6. dismount (bot does too, as expected)
7. Give the party lead to the other player character
8. Mount up again and verify that the bot is also using his mount as desired
