### PR TITLE
Fix wrong cast spell action passed to the PullPowerSparkAction constructor

### DIFF
--- a/src/strategy/raids/eyeofeternity/RaidEoEActions.h
+++ b/src/strategy/raids/eyeofeternity/RaidEoEActions.h
@@ -30,7 +30,7 @@ class PullPowerSparkAction : public CastSpellAction
 {
 public:
     PullPowerSparkAction(PlayerbotAI* botAI, std::string const name = "pull power spark")
-        : CastSpellAction(botAI, "death grip") {}
+        : CastSpellAction(botAI, name) {}
     bool Execute(Event event) override;
     bool isPossible() override;
     bool isUseful() override;


### PR DESCRIPTION
Seems like someone is used this constructor for testing and forget to change it back. Anyway, this also fixes warning: unused parameter 'name' [-Wunused-parameter].