### PR TITLE
Added null check to Queue::findHighestRelevanceBasket()

### DIFF
--- a/src/strategy/Queue.cpp
+++ b/src/strategy/Queue.cpp
@@ -88,6 +88,11 @@ ActionBasket* Queue::findHighestRelevanceBasket() const
 
     for (ActionBasket* basket : actions)
     {
+        if (!basket)
+        {
+            continue;
+        }
+
         if (basket->getRelevance() > maxRelevance)
         {
             maxRelevance = basket->getRelevance();


### PR DESCRIPTION
Segmentation fault when accessing `basket->getRelevance()` in `Queue::findHighestRelevanceBasket()`

Added null check. 

[gdb_20250930.txt](https://github.com/user-attachments/files/22611764/gdb_20250930.txt)
