### PR TITLE
Fix wrong prepared statement used for the PlayerbotDbStore::Reset issue #1172

### DIFF
--- a/src/PlayerbotDbStore.cpp
+++ b/src/PlayerbotDbStore.cpp
@@ -82,7 +82,7 @@ void PlayerbotDbStore::Reset(PlayerbotAI* botAI)
 {
     ObjectGuid::LowType guid = botAI->GetBot()->GetGUID().GetCounter();
 
-    PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_CUSTOM_STRATEGY);
+    PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_DB_STORE);
     stmt->SetData(0, guid);
     PlayerbotsDatabase.Execute(stmt);
 }


### PR DESCRIPTION
PlayerbotDbStore has nothing to do with playerbots' custom strategies. Use the properly prepared statement PLAYERBOTS_DEL_DB_STORE.