### PR TITLE
Random bot guild totals fix

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -877,7 +877,7 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
 
     // Check how many randomBot guilds are in the guild table in the characterDB
     uint32 guildNumber = 0;
-    QueryResult guildTableResults = CharacterDatabase.Query("SELECT guildid, leaderguid FROM guid");
+    QueryResult guildTableResults = CharacterDatabase.Query("SELECT guildid, leaderguid FROM guild");
     if (guildTableResults)
     {
         do
@@ -887,7 +887,7 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
             uint32 leaderGuid = fields[1].Get<uint32>();
 
             // check the accountID of the guild leader against the list of randomBot accounts to determine if this is a player guild or a bot guild
-            QueryResult charactersTableResults = CharacterDatabase.Query("SELECT account FROM characters WHERE guid = ({})", leaderGuid);
+            QueryResult charactersTableResults = CharacterDatabase.Query("SELECT account FROM characters WHERE guid = {}", leaderGuid);
             if (charactersTableResults)
             {
                 Field* fields2 = charactersTableResults->Fetch();

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -902,6 +902,18 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
         } while (guildTableResults->NextRow());
     }
 
+    // Is it worth continuing?
+    LOG_INFO("playerbots", "{}/{} random bot guilds exist in guild table)", guildNumber, sPlayerbotAIConfig->randomBotGuildCount);
+    if (guildNumber >= sPlayerbotAIConfig->randomBotGuildCount)
+    {
+        LOG_INFO("playerbots", "No new random guilds required");
+        return;
+    }
+    else
+    {
+        LOG_INFO("playerbots", "Creating {} new random guilds...", sPlayerbotAIConfig->randomBotGuildCount - guildNumber);
+    }
+
     // Get a list of bots that are logged in and available to lead new guilds
     GuidVector availableLeaders;
     for (std::vector<uint32>::iterator i = randomBots.begin(); i != randomBots.end(); ++i)
@@ -918,7 +930,7 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
                 availableLeaders.push_back(leader);
         }
     }
-    LOG_INFO("playerbots", "randomBotGuilds - {} available leaders for new guilds found", availableLeaders.size());
+    LOG_INFO("playerbots", "{} available leaders for new guilds found", availableLeaders.size());
 
     // Create up to randomBotGuildCount by counting only EFFECTIVE creations
     uint32 createdThisRun = 0;
@@ -1008,8 +1020,7 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
     }
 
     // Shows the true total and how many were created during this run
-    LOG_INFO("playerbots", "{} random bot guilds available (created this run: {})",
-             uint32(sPlayerbotAIConfig->randomBotGuilds.size()), createdThisRun);
+    LOG_INFO("playerbots", "{} random bot guilds created this run)", createdThisRun);
 }
 
 std::string const RandomPlayerbotFactory::CreateRandomGuildName()


### PR DESCRIPTION
### **Issue:**
#1667 
-Bot guilds would keep being created on server restarts, eventually running out of guild names and hitting an infinite loop.

Suspect this was from the logic where random bot guilds would be tallied by running through a list of randomBots and checking if that bot is a guild leader. I'm not familiar enough with the project to know for sure, but I guessing that the list of randomBots only includes bots that are currently active as online players.

### **Fix:**
-begin the random bot guild check/creation process by querying the guilds table in acore_characters, then determining which ones are bot guilds. This gives us an absolute total of randomBot guilds, regardless of whether or not the leaders are active.

### **Testing:**
I've tested this with 200 guilds. Numerous bot inits, and numerous server restarts both with and without AiPlayerbot.DisabledWithoutRealPlayer = 1.
guild table in acore_characters seems to reach the config defined number of guilds and not randomly grow anymore.


### **Todo:**
This needs some formatting, and potential removal of an unnecessary std::find().
I'll tidy it up at some point over the next couple of days.

Could potentially add a system to abort guild creation, when the total number of guilds reaches the number of available names in the playerbots guild names table.