### PR TITLE
Maintenance config for altbots

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -489,21 +489,21 @@ AiPlayerbot.RPWarningCooldown = 30
 AiPlayerbot.MaintenanceCommand = 1
 
 # Enable/Disable specific maintenance command functionality for alt bots
-# Disable to prevent players from giving free bags, spells, skill levels, etc to their Altbots
+# Disable to prevent players from giving free bags, spells, skill levels etc to their alt bots
 # Default: 1 (enabled)
 AiPlayerbot.AltMaintenanceAmmo = 1
 AiPlayerbot.AltMaintenanceFood = 1
+AiPlayerbot.AltMaintenanceReagents = 1
 AiPlayerbot.AltMaintenanceConsumables = 1
 AiPlayerbot.AltMaintenancePotions = 1
-AiPlayerbot.AltMaintenanceReagents = 1
 
 AiPlayerbot.AltMaintenanceBags = 1
 AiPlayerbot.AltMaintenanceMounts = 1
+AiPlayerbot.AltMaintenanceSkills = 1
 
 AiPlayerbot.AltMaintenanceClassSpells = 1	# Spells from quests (tame/summon pets, totems, druid forms, etc)
 AiPlayerbot.AltMaintenanceAvailableSpells = 1	# Spells learnable from trainer
 AiPlayerbot.AltMaintenanceSpecialSpells = 1	# Leave DK starting area
-AiPlayerbot.AltMaintenanceSkills = 1
 AiPlayerbot.AltMaintenanceTalentTree = 1
 AiPlayerbot.AltMaintenanceGlyphs = 1
 AiPlayerbot.AltMaintenanceGemsEnchants = 1

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -554,26 +554,26 @@ bool PlayerbotAIConfig::Initialize()
     addClassAccountPoolSize = sConfigMgr->GetOption<int32>("AiPlayerbot.AddClassAccountPoolSize", 50);
     maintenanceCommand = sConfigMgr->GetOption<int32>("AiPlayerbot.MaintenanceCommand", 1);
 
+    altMaintenanceAttunementQs = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceAttunementQuests", true);
+    altMaintenanceBags = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceBags", true);
     altMaintenanceAmmo = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceAmmo", true);
     altMaintenanceFood = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceFood", true);
+    altMaintenanceReagents = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceReagents", true);
     altMaintenanceConsumables = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceConsumables", true);
     altMaintenancePotions = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenancePotions", true);
-    altMaintenanceReagents = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceReagents", true);
-    altMaintenanceBags = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceBags", true);
-    altMaintenanceMounts = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceMounts", true);
-    altMaintenanceClassSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceClassSpells", true);
-    altMaintenanceAvailableSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceAvailableSpells", true);
-    altMaintenanceSpecialSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceSpecialSpells", true);
-    altMaintenanceSkills = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceSkills", true);
     altMaintenanceTalentTree = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceTalentTree", true);
-    altMaintenanceGlyphs = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceGlyphs", true);
-    altMaintenanceGemsEnchants = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceGemsEnchants", true);
     altMaintenancePet = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenancePet", true);
     altMaintenancePetTalents = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenancePetTalents", true);
+    altMaintenanceClassSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceClassSpells", true);
+    altMaintenanceAvailableSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceAvailableSpells", true);
+    altMaintenanceSkills = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceSkills", true);
     altMaintenanceReputation = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceReputation", true);
-    altMaintenanceAttunementQs = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceAttunementQuests", true); 
+    altMaintenanceSpecialSpells = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceSpecialSpells", true);
+    altMaintenanceMounts = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceMounts", true);
+    altMaintenanceGlyphs = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceGlyphs", true);
     altMaintenanceKeyring = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceKeyring", true);
-    
+    altMaintenanceGemsEnchants = sConfigMgr->GetOption<bool>("AiPlayerbot.AltMaintenanceGemsEnchants", true);
+
     autoGearCommand = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearCommand", 1);
     autoGearCommandAltBots = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearCommandAltBots", 1);
     autoGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.AutoGearQualityLimit", 3);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -393,26 +393,25 @@ public:
     int32 addClassCommand;
     int32 addClassAccountPoolSize;
     int32 maintenanceCommand;
-    bool    altMaintenanceAmmo,
+    bool altMaintenanceAttunementQs,
+            altMaintenanceBags,
+            altMaintenanceAmmo,
             altMaintenanceFood,
+            altMaintenanceReagents,
             altMaintenanceConsumables,
             altMaintenancePotions,
-            altMaintenanceReagents,
-            altMaintenanceBags,
-            altMaintenanceMounts,
-            altMaintenanceClassSpells,
-            altMaintenanceAvailableSpells,
-            altMaintenanceSpecialSpells,
-            altMaintenanceSkills,
             altMaintenanceTalentTree,
-            altMaintenanceGlyphs,
-            altMaintenanceGemsEnchants,
             altMaintenancePet,
             altMaintenancePetTalents,
+            altMaintenanceClassSpells,
+            altMaintenanceAvailableSpells,
+            altMaintenanceSkills,
             altMaintenanceReputation,
-            altMaintenanceAttunementQs,
-            altMaintenanceKeyring;
-            
+            altMaintenanceSpecialSpells,
+            altMaintenanceMounts,
+            altMaintenanceGlyphs,
+            altMaintenanceKeyring,
+            altMaintenanceGemsEnchants;
     int32 autoGearCommand, autoGearCommandAltBots, autoGearQualityLimit, autoGearScoreLimit;
 
     uint32 useGroundMountAtMinLevel;

--- a/src/strategy/actions/TrainerAction.cpp
+++ b/src/strategy/actions/TrainerAction.cpp
@@ -173,38 +173,43 @@ bool MaintenanceAction::Execute(Event event)
 
     if (!botAI->IsAlt())
     {    
+        factory.InitAttunementQuests();
+        factory.InitBags(false);
         factory.InitAmmo();
         factory.InitFood();
+        factory.InitReagents();
         factory.InitConsumables();
         factory.InitPotions();
-        factory.InitReagents();
-
-        factory.InitBags(false);
-        factory.InitMounts();
-
-        factory.InitClassSpells();
-        factory.InitAvailableSpells();
-        factory.InitSpecialSpells();
-        factory.InitSkills();
         factory.InitTalentsTree(true);
-        factory.InitGlyphs(false);
-        if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
-            factory.ApplyEnchantAndGemsNew();
-
         factory.InitPet();
         factory.InitPetTalents();
-
+        factory.InitClassSpells();
+        factory.InitAvailableSpells();
+        factory.InitSkills();
         factory.InitReputation();
-        factory.InitAttunementQuests();
+        factory.InitSpecialSpells();
+        factory.InitMounts();
+        factory.InitGlyphs(false);
         factory.InitKeyring();
+        if (bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
+            factory.ApplyEnchantAndGemsNew();
     }
     else 
     {
+        if (sPlayerbotAIConfig->altMaintenanceAttunementQs)
+            factory.InitAttunementQuests();
+
+        if (sPlayerbotAIConfig->altMaintenanceBags)
+            factory.InitBags(false);
+
         if (sPlayerbotAIConfig->altMaintenanceAmmo)
             factory.InitAmmo();
 
         if (sPlayerbotAIConfig->altMaintenanceFood)
             factory.InitFood();
+
+        if (sPlayerbotAIConfig->altMaintenanceReagents)
+            factory.InitReagents();
 
         if (sPlayerbotAIConfig->altMaintenanceConsumables)
             factory.InitConsumables();
@@ -212,38 +217,8 @@ bool MaintenanceAction::Execute(Event event)
         if (sPlayerbotAIConfig->altMaintenancePotions)
             factory.InitPotions();
 
-        if (sPlayerbotAIConfig->altMaintenanceReagents)
-            factory.InitReagents();
-
-
-        if (sPlayerbotAIConfig->altMaintenanceBags)
-            factory.InitBags(false);
-
-        if (sPlayerbotAIConfig->altMaintenanceMounts)
-            factory.InitMounts();
-
-
-        if (sPlayerbotAIConfig->altMaintenanceClassSpells)
-            factory.InitClassSpells();
-
-        if (sPlayerbotAIConfig->altMaintenanceAvailableSpells)
-            factory.InitAvailableSpells();        
-
-        if (sPlayerbotAIConfig->altMaintenanceSpecialSpells)
-            factory.InitSpecialSpells();
-
-        if (sPlayerbotAIConfig->altMaintenanceSkills)
-            factory.InitSkills();
-
         if (sPlayerbotAIConfig->altMaintenanceTalentTree)
             factory.InitTalentsTree(true);
-
-        if (sPlayerbotAIConfig->altMaintenanceGlyphs)
-            factory.InitGlyphs(false);
-
-        if (sPlayerbotAIConfig->altMaintenanceGemsEnchants && bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
-            factory.ApplyEnchantAndGemsNew();
-
 
         if (sPlayerbotAIConfig->altMaintenancePet)
             factory.InitPet();
@@ -251,15 +226,32 @@ bool MaintenanceAction::Execute(Event event)
         if (sPlayerbotAIConfig->altMaintenancePetTalents)
             factory.InitPetTalents();
 
+        if (sPlayerbotAIConfig->altMaintenanceClassSpells)
+            factory.InitClassSpells();
+
+        if (sPlayerbotAIConfig->altMaintenanceAvailableSpells)
+            factory.InitAvailableSpells();
+
+        if (sPlayerbotAIConfig->altMaintenanceSkills)
+            factory.InitSkills();
 
         if (sPlayerbotAIConfig->altMaintenanceReputation)
             factory.InitReputation();
 
-        if (sPlayerbotAIConfig->altMaintenanceAttunementQs)
-            factory.InitAttunementQuests();
-        
+        if (sPlayerbotAIConfig->altMaintenanceSpecialSpells)
+            factory.InitSpecialSpells();
+
+        if (sPlayerbotAIConfig->altMaintenanceMounts)
+            factory.InitMounts();
+
+        if (sPlayerbotAIConfig->altMaintenanceGlyphs)
+            factory.InitGlyphs(false);
+
         if (sPlayerbotAIConfig->altMaintenanceKeyring)
             factory.InitKeyring();
+
+        if (sPlayerbotAIConfig->altMaintenanceGemsEnchants && bot->GetLevel() >= sPlayerbotAIConfig->minEnchantingBotLevel)
+            factory.ApplyEnchantAndGemsNew();
     }
 
     bot->DurabilityRepairAll(false, 1.0f, false);


### PR DESCRIPTION
Adds some boolean options to configure how the maintenance command affects altBots.

Stops players from skipping tradeskills, buying spells, working for bags, crafting and trading for glyphs, potions, consumables, etc

All options disabled by default, enable them to make life easier.