### PR TITLE
Fixes Issue #1695

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -38,6 +38,7 @@
 #include "WorldSessionMgr.h"
 #include "DatabaseEnv.h"        // Added for gender choice
 #include <algorithm>            // Added for gender choice
+#include "Group.h"
 
 class BotInitGuard
 {
@@ -512,10 +513,16 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
             }
         }
 
-        if (!groupValid)
+    if (!groupValid)
+    {
+        if (Group* g = bot->GetGroup())
         {
-            bot->RemoveFromGroup();
+            if (g->IsMember(bot->GetGUID()))
+            {
+                bot->RemoveFromGroup();
+            }
         }
+    }
     }
 
     group = bot->GetGroup();

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -53,6 +53,7 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "World.h"
+#include "Group.h"
 
 struct GuidClassRaceInfo
 {
@@ -1636,8 +1637,17 @@ bool RandomPlayerbotMgr::ProcessBot(Player* player)
     Group* group = player->GetGroup();
     if (group && !group->isLFGGroup() && IsRandomBot(group->GetLeader()))
     {
-        player->RemoveFromGroup();
-        LOG_INFO("playerbots", "Bot {} remove from group since leader is random bot.", player->GetName().c_str());
+        if (group->IsMember(player->GetGUID()))
+        {
+            LOG_DEBUG("playerbots", "RandomPlayerbotMgr: {} leaving group (leader is random bot, members before: {}).",
+                     player->GetName().c_str(), uint32(group->GetMembersCount()));
+            player->RemoveFromGroup();
+            LOG_DEBUG("playerbots", "RandomPlayerbotMgr: {} left group successfully.", player->GetName().c_str());
+        }
+        else
+        {
+            LOG_DEBUG("playerbots", "RandomPlayerbotMgr: {} not a member anymore, skip removal.", player->GetName().c_str());
+        }
     }
 
     // only randomize and teleport idle bots
@@ -2540,8 +2550,13 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
     if (GET_PLAYERBOT_AI(bot))
         GET_PLAYERBOT_AI(bot)->Reset(true);
 
-    if (bot->GetGroup())
-        bot->RemoveFromGroup();
+    if (Group* g = bot->GetGroup())
+    {
+        if (g->IsMember(bot->GetGUID()))
+        {
+            bot->RemoveFromGroup();
+        }
+    }
 
     if (pmo)
         pmo->finish();
@@ -2581,8 +2596,13 @@ void RandomPlayerbotMgr::RandomizeMin(Player* bot)
     if (GET_PLAYERBOT_AI(bot))
         GET_PLAYERBOT_AI(bot)->Reset(true);
 
-    if (bot->GetGroup())
-        bot->RemoveFromGroup();
+    if (Group* g = bot->GetGroup())
+    {
+        if (g->IsMember(bot->GetGUID()))
+        {
+            bot->RemoveFromGroup();
+        }
+    }
 
     if (pmo)
         pmo->finish();
@@ -2663,8 +2683,13 @@ void RandomPlayerbotMgr::Refresh(Player* bot)
     uint32 money = bot->GetMoney();
     bot->SetMoney(money + 500 * sqrt(urand(1, bot->GetLevel() * 5)));
 
-    if (bot->GetGroup())
-        bot->RemoveFromGroup();
+    if (Group* g = bot->GetGroup())
+    {
+        if (g->IsMember(bot->GetGUID()))
+        {
+            bot->RemoveFromGroup();
+        }
+    }
 
     if (pmo)
         pmo->finish();

--- a/src/strategy/actions/LeaveGroupAction.cpp
+++ b/src/strategy/actions/LeaveGroupAction.cpp
@@ -8,6 +8,7 @@
 #include "Event.h"
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
+#include "Group.h"
 
 bool LeaveGroupAction::Execute(Event event)
 {
@@ -84,7 +85,13 @@ bool LeaveGroupAction::Leave(Player* player)
     bool shouldStay = randomBot && bot->GetGroup() && player == bot;
     if (!shouldStay)
     {
-        bot->RemoveFromGroup();
+        if (Group* g = bot->GetGroup())
+        {
+            if (g->IsMember(bot->GetGUID()))
+            {
+                bot->RemoveFromGroup();
+            }
+        }
     }
 
     if (randomBot)


### PR DESCRIPTION
Fix: Guard RemoveFromGroup() calls to prevent crashes

This PR adds lightweight guards around all Player::RemoveFromGroup() calls in the module (e.g., LeaveGroupAction, RandomPlayerbotMgr, PlayerbotMgr).
Before removing a bot from a group, we now verify:

Group* g = X->GetGroup() is not null, and

g->IsMember(X->GetGUID()) is true.


I see  issue #1695 reporting frequent crashes when bots leave groups.
In servers with many bots, group membership can change between decision and execution (or be touched by other threads). Calling RemoveFromGroup() on a non-member or a stale group can corrupt internal group state and lead to crashes in the core .


No behavior change when the bot is actually in a valid group.
If the bot is already not a member (or has no group), we skip the removal safely.

Fixes #1695.