### PR TITLE
Fixe issue #1700

### DIFF
--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -3855,7 +3855,6 @@ bool BGTactics::atFlag(std::vector<BattleBotPath*> const& vPaths, std::vector<ui
                     }
 
                     // Pick up dropped flag
-                        bot->GetName(), go->GetGUID().ToString());
                     WorldPacket data(CMSG_GAMEOBJ_USE);
                     data << go->GetGUID();
                     bot->GetSession()->HandleGameObjectUseOpcode(data);


### PR DESCRIPTION
Fix EotS center flag pickup: cast instead of instant use
Bots were picking up the Eye of the Storm center flag instantly, skipping the required capture cast. This change makes bots cast SPELL_CAPTURE_BANNER when the flag is at the spawn  and avoids GAMEOBJ_USE in that case. For dropped flags, GAMEOBJ_USE remains unchanged. The wait time follows the spell timing from SpellInfo (channeled duration or calculated cast time).

Fixes #1700.