### PR TITLE
Revert "Feat: Filter bot logins by level range"

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -597,20 +597,9 @@ AiPlayerbot.RandomBotRandomPassword = 0
 # Prefix for account names to create for randombots
 AiPlayerbot.RandomBotAccountPrefix = "rndbot"
 
-# Minimum and maximum initialization levels for randombots
+# Minimum and maximum levels for randombots
 AiPlayerbot.RandomBotMinLevel = 1
 AiPlayerbot.RandomBotMaxLevel = 80
-
-# Minimum and maximum level range for randombots allowed to login
-# If level filtration is used, minRandomBots and maxRandomBots might be automatically adjusted to lower values,
-# depending on available eligible bots in the database
-# Default Min,Max: 1,80 (no level filtration)
-AiPlayerbot.RandomBotMinLoginLevel = 1
-AiPlayerbot.RandomBotMaxLoginLevel = 80
-
-# log-out randombots if they they level outside the allowed login range
-# Default: 0 (disabled)
-AiPlayerbot.RandomBotLogoutOutsideLoginRange = 0
 
 # Sync max randombot level with max level of online players
 # Default: 0 (disabled)

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -86,9 +86,6 @@ bool PlayerbotAIConfig::Initialize()
     rpWarningCooldown     = sConfigMgr->GetOption<int32>("AiPlayerbot.RPWarningCooldown", 30);
     disabledWithoutRealPlayerLoginDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.DisabledWithoutRealPlayerLoginDelay", 30);
     disabledWithoutRealPlayerLogoutDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.DisabledWithoutRealPlayerLogoutDelay", 300);
-    randomBotMinLoginLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotMinLoginLevel", 1);
-    randomBotMaxLoginLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotMaxLoginLevel", 80);
-    randomBotLogoutOutsideLoginRange = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotLogoutOutsideLoginRange", false);
 
     farDistance = sConfigMgr->GetOption<float>("AiPlayerbot.FarDistance", 20.0f);
     sightDistance = sConfigMgr->GetOption<float>("AiPlayerbot.SightDistance", 75.0f);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -247,8 +247,6 @@ public:
     std::string randomBotCombatStrategies, randomBotNonCombatStrategies;
     bool applyInstanceStrategies;
     uint32 randomBotMinLevel, randomBotMaxLevel;
-    uint32 randomBotMinLoginLevel, randomBotMaxLoginLevel;
-    bool randomBotLogoutOutsideLoginRange;
     float randomChangeMultiplier;
 
     // std::string premadeLevelSpec[MAX_CLASSES][10][91]; //lvl 10 - 100

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -87,8 +87,7 @@ public:
         PLAYERHOOK_ON_BEFORE_CRITERIA_PROGRESS,
         PLAYERHOOK_ON_BEFORE_ACHI_COMPLETE,
         PLAYERHOOK_CAN_PLAYER_USE_PRIVATE_CHAT,
-        PLAYERHOOK_ON_GIVE_EXP,
-        PLAYERHOOK_ON_LEVEL_CHANGED
+        PLAYERHOOK_ON_GIVE_EXP
     }) {}
 
     void OnPlayerLogin(Player* player) override
@@ -119,33 +118,6 @@ public:
                     "|cff00ff00Playerbots:|r bot initialization at server startup takes about '"
                     + roundedTime + "' minutes.");
             }
-        }
-    }
-
-    void OnPlayerLevelChanged(Player* player, uint8 oldLevel) override
-    {
-        // Check if feature is enabled and required objects are valid
-        if (!sPlayerbotAIConfig || !sPlayerbotAIConfig->randomBotLogoutOutsideLoginRange || !sRandomPlayerbotMgr)
-            return;
-
-        // Only apply to bots from rndBotTypeAccounts (type 1)
-        uint32 accountId = player->GetSession()->GetAccountId();
-        if (!sRandomPlayerbotMgr->IsAccountType(accountId, 1))
-            return;
-
-        uint32 newLevel = player->GetLevel();
-
-        // Check if the new level is outside the allowed login range
-        if (newLevel < sPlayerbotAIConfig->randomBotMinLoginLevel ||
-            newLevel > sPlayerbotAIConfig->randomBotMaxLoginLevel)
-        {
-            LOG_INFO("playerbots", "Bot {} changed levels from {} to {}, outside login range ({}-{}). Marking for logout",
-                    player->GetName(), oldLevel, newLevel,
-                    sPlayerbotAIConfig->randomBotMinLoginLevel, sPlayerbotAIConfig->randomBotMaxLoginLevel);
-
-            // Mark the bot for removal in the next update cycle
-            sRandomPlayerbotMgr->MarkBotForLogout(player->GetGUID().GetCounter());
-            sRandomPlayerbotMgr->ForceRecount();
         }
     }
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -13,7 +13,6 @@
 #include <ctime>
 #include <iomanip>
 #include <random>
-#include <climits>
 
 #include "AccountMgr.h"
 #include "AiFactory.h"
@@ -375,76 +374,13 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
     }*/
 
     uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
-
-    // Check if level filtering is active and populate eligible bots
-    if (!levelFilterAdjusted && IsLevelFilterActive())
+    if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig->minRandomBots ||
+                                maxAllowedBotCount > sPlayerbotAIConfig->maxRandomBots))
     {
-        PopulateEligibleBots();
-
-        // Count total eligible bots from RNDbot accounts
-        uint32 eligibleBotCount = 0;
-
-        for (uint32 accountId : rndBotTypeAccounts)
-        {
-            QueryResult result = CharacterDatabase.Query(
-                "SELECT COUNT(*) FROM characters WHERE account = {} AND level >= {} AND level <= {}",
-                accountId, sPlayerbotAIConfig->randomBotMinLoginLevel, sPlayerbotAIConfig->randomBotMaxLoginLevel
-            );
-
-            if (result)
-            {
-                Field* fields = result->Fetch();
-                eligibleBotCount += fields[0].Get<uint32>();
-            }
-        }
-
-        if (eligibleBotCount > 0)
-        {
-            // Cap eligible bots by maxRandomBots
-            uint32 effectiveMaxBots = std::min(eligibleBotCount, sPlayerbotAIConfig->maxRandomBots);
-
-            LOG_INFO("playerbots", "Level filter active: {} eligible bots found in range {}-{}. Effective maximum: {} bots.",
-                    eligibleBotCount, sPlayerbotAIConfig->randomBotMinLoginLevel,
-                    sPlayerbotAIConfig->randomBotMaxLoginLevel, effectiveMaxBots);
-
-            if (effectiveMaxBots >= sPlayerbotAIConfig->minRandomBots)
-            {
-                maxAllowedBotCount = urand(sPlayerbotAIConfig->minRandomBots, effectiveMaxBots);
-            }
-            else
-            {
-                maxAllowedBotCount = effectiveMaxBots;
-            }
-
-            SetEventValue(0, "bot_count", maxAllowedBotCount,
-                        urand(sPlayerbotAIConfig->randomBotCountChangeMinInterval,
-                                sPlayerbotAIConfig->randomBotCountChangeMaxInterval));
-
-            currentBots.clear();
-            levelFilterAdjusted = true;
-        }
-        else
-        {
-            LOG_ERROR("playerbots", "No eligible bots found with level filter {}-{}. Change the level range.",
-                    sPlayerbotAIConfig->randomBotMinLoginLevel, sPlayerbotAIConfig->randomBotMaxLoginLevel);
-            SetEventValue(0, "bot_count", 0, INT_MAX);
-            maxAllowedBotCount = 0;
-            currentBots.clear();
-            levelFilterAdjusted = true;
-        }
-    }
-    else if (!levelFilterAdjusted)
-    {
-        // Normal bot count logic (no level filtering)
-        if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig->minRandomBots ||
-                                    maxAllowedBotCount > sPlayerbotAIConfig->maxRandomBots))
-        {
-            maxAllowedBotCount = urand(sPlayerbotAIConfig->minRandomBots, sPlayerbotAIConfig->maxRandomBots);
-            SetEventValue(0, "bot_count", maxAllowedBotCount,
-                        urand(sPlayerbotAIConfig->randomBotCountChangeMinInterval,
-                                sPlayerbotAIConfig->randomBotCountChangeMaxInterval));
-        }
-        levelFilterAdjusted = true;
+        maxAllowedBotCount = urand(sPlayerbotAIConfig->minRandomBots, sPlayerbotAIConfig->maxRandomBots);
+        SetEventValue(0, "bot_count", maxAllowedBotCount,
+                      urand(sPlayerbotAIConfig->randomBotCountChangeMinInterval,
+                            sPlayerbotAIConfig->randomBotCountChangeMaxInterval));
     }
 
     GetBots();
@@ -836,41 +772,23 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
 
         for (uint32 accountId : accountsToUse)
         {
-            // Lambda to process results regardless of query type
-            auto processResults = [&](auto result)
-            {
-                if (!result)
-                    return;
+            CharacterDatabasePreparedStatement* stmt =
+                CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARS_BY_ACCOUNT_ID);
+            stmt->SetData(0, accountId);
+            PreparedQueryResult result = CharacterDatabase.Query(stmt);
+            if (!result)
+                continue;
 
-                do
-                {
-                    Field* fields = result->Fetch();
-                    CharacterInfo info;
-                    info.guid = fields[0].Get<uint32>();
-                    info.rClass = fields[1].Get<uint8>();
-                    info.rRace = fields[2].Get<uint8>();
-                    info.accountId = accountId;
-                    allCharacters.push_back(info);
-                } while (result->NextRow());
-            };
-
-            if (IsLevelFilterActive())
+            do
             {
-                // Custom query with level filtering
-                auto result = CharacterDatabase.Query(
-                    "SELECT guid, class, race FROM characters WHERE account = {} AND level >= {} AND level <= {}",
-                    accountId, sPlayerbotAIConfig->randomBotMinLoginLevel, sPlayerbotAIConfig->randomBotMaxLoginLevel
-                );
-                processResults(result);
-            }
-            else
-            {
-                CharacterDatabasePreparedStatement* stmt =
-                    CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARS_BY_ACCOUNT_ID);
-                stmt->SetData(0, accountId);
-                auto result = CharacterDatabase.Query(stmt);
-                processResults(result);
-            }
+                Field* fields = result->Fetch();
+                CharacterInfo info;
+                info.guid = fields[0].Get<uint32>();
+                info.rClass = fields[1].Get<uint8>();
+                info.rRace = fields[2].Get<uint8>();
+                info.accountId = accountId;
+                allCharacters.push_back(info);
+            } while (result->NextRow());
         }
 
         // Shuffle for class balance
@@ -2752,55 +2670,17 @@ void RandomPlayerbotMgr::GetBots()
     stmt->SetData(0, 0);
     stmt->SetData(1, "add");
     uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
-
     if (PreparedQueryResult result = PlayerbotsDatabase.Query(stmt))
     {
         do
         {
             Field* fields = result->Fetch();
             uint32 bot = fields[0].Get<uint32>();
-
             if (GetEventValue(bot, "add"))
-            {
-                // Single query to get both account and level
-                QueryResult charResult = CharacterDatabase.Query("SELECT account, level FROM characters WHERE guid = {}", bot);
-                if (!charResult)
-                    continue;
-
-                Field* charFields = charResult->Fetch();
-                uint32 botAccountId = charFields[0].Get<uint32>();
-                uint32 botLevel = charFields[1].Get<uint32>();
-
-                // Skip if not an RNDbot account
-                bool isRndBotAccount = false;
-                for (uint32 accountId : rndBotTypeAccounts)
-                {
-                    if (accountId == botAccountId)
-                    {
-                        isRndBotAccount = true;
-                        break;
-                    }
-                }
-
-                if (!isRndBotAccount)
-                    continue;
-
-                // If level filtering is active, check bot level
-                if (IsLevelFilterActive())
-                {
-                    // Skip bots outside the allowed level range
-                    if (botLevel < sPlayerbotAIConfig->randomBotMinLoginLevel ||
-                        botLevel > sPlayerbotAIConfig->randomBotMaxLoginLevel)
-                    {
-                        continue;
-                    }
-                }
-
                 currentBots.push_back(bot);
 
-                if (currentBots.size() >= maxAllowedBotCount)
-                    break;
-            }
+            if (currentBots.size() >= maxAllowedBotCount)
+                break;
         } while (result->NextRow());
     }
 }
@@ -2826,51 +2706,6 @@ std::vector<uint32> RandomPlayerbotMgr::GetBgBots(uint32 bracket)
     }
 
     return std::move(BgBots);
-}
-
-void RandomPlayerbotMgr::PopulateEligibleBots()
-{
-    if (!sPlayerbotAIConfig || !(sPlayerbotAIConfig->randomBotMinLoginLevel > 1 ||
-        sPlayerbotAIConfig->randomBotMaxLoginLevel < 80))
-        return;
-
-    LOG_INFO("playerbots", "Populating eligible bots for level filter ({}-{})...",
-             sPlayerbotAIConfig->randomBotMinLoginLevel, sPlayerbotAIConfig->randomBotMaxLoginLevel);
-
-    bool botsAdded = false;
-
-    // Use only RNDbot type accounts (type 1)
-    for (uint32 accountId : rndBotTypeAccounts)
-    {
-        QueryResult result = CharacterDatabase.Query(
-            "SELECT guid, level, online FROM characters WHERE account = {} AND level >= {} AND level <= {}",
-            accountId, sPlayerbotAIConfig->randomBotMinLoginLevel, sPlayerbotAIConfig->randomBotMaxLoginLevel
-        );
-
-        if (result)
-        {
-            do
-            {
-                Field* fields = result->Fetch();
-                uint32 botGuid = fields[0].Get<uint32>();
-                bool isOnline = fields[2].Get<bool>();
-
-                // Skip bots that are already online or already have "add" event
-                if (isOnline || GetEventValue(botGuid, "add"))
-                    continue;
-
-                uint32 add_time = urand(sPlayerbotAIConfig->minRandomBotInWorldTime,
-                                    sPlayerbotAIConfig->maxRandomBotInWorldTime);
-                SetEventValue(botGuid, "add", 1, add_time);
-                botsAdded = true;
-            } while (result->NextRow());
-        }
-    }
-
-    if (botsAdded)
-    {
-        currentBots.clear(); // Force reload
-    }
 }
 
 uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, std::string const event)
@@ -2900,13 +2735,23 @@ uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, std::string const event)
     }
 
     CachedEvent& e = eventCache[bot][event];
+    /*if (e.IsEmpty())
+    {
+        QueryResult results = PlayerbotsDatabase.Query("SELECT `value`, `time`, validIn, `data` FROM
+    playerbots_random_bots WHERE owner = 0 AND bot = {} AND event = {}", bot, event.c_str());
 
-    bool shouldExpire = (time(0) - e.lastChangeTime) >= e.validIn &&
-                       event != "specNo" &&
-                       event != "specLink" &&
-                       !(event == "bot_count" && IsLevelFilterActive());  // Don't expire bot_count when level filtering is active
+        if (results)
+        {
+            Field* fields = results->Fetch();
+            e.value = fields[0].Get<uint32>();
+            e.lastChangeTime = fields[1].Get<uint32>();
+            e.validIn = fields[2].Get<uint32>();
+            e.data = fields[3].Get<std::string>();
+        }
+    }
+    */
 
-    if (shouldExpire)
+    if ((time(0) - e.lastChangeTime) >= e.validIn && event != "specNo" && event != "specLink")
         e.value = 0;
 
     return e.value;

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -193,14 +193,6 @@ public:
     void AssignAccountTypes();
     bool IsAccountType(uint32 accountId, uint8 accountType);
 
-    // Allowed login range management
-    void ForceRecount() { SetEventValue(0, "bot_count", 0, 0); }
-    void MarkBotForLogout(uint32 bot)
-    {
-        SetEventValue(bot, "add", 0, 0);        // Clear the "add" event to trigger logout
-        SetEventValue(bot, "logout", 1, 1);     // Also set logout for clarity
-    }
-
 protected:
     void OnBotLoginInternal(Player* const bot) override;
 
@@ -244,16 +236,6 @@ private:
     // Account lists
     std::vector<uint32> rndBotTypeAccounts;             // Accounts marked as RNDbot (type 1)
     std::vector<uint32> addClassTypeAccounts;           // Accounts marked as AddClass (type 2)
-
-    // Login level filtering
-    bool levelFilterAdjusted = false;
-    void PopulateEligibleBots();
-    bool IsLevelFilterActive() const
-    {
-        return sPlayerbotAIConfig &&
-               (sPlayerbotAIConfig->randomBotMinLoginLevel > 1 ||
-                sPlayerbotAIConfig->randomBotMaxLoginLevel < 80);
-    }
 
     //void ScaleBotActivity();      // Deprecated function
 };


### PR DESCRIPTION
Reverts liyunfan1223/mod-playerbots#1499

We talked about this merge amongst the developers; this feature extension leans against piece of code which isnt considered fully stabile yet. 

These bot managers need some more analyzing and stabilization before adding more complexity. We understand for some this feature is wanted but we dont feel comfortable at this time for adding more complexity to that part of the code.  So we decided to revert the PR for now.

Apologies @NoxMax 