### PR TITLE
Updated the spell id for Spirit of Redemption

### DIFF
--- a/src/strategy/values/StatsValues.cpp
+++ b/src/strategy/values/StatsValues.cpp
@@ -119,7 +119,7 @@ bool HasManaValue::Calculate()
     if (!target)
         return false;
 
-    constexpr uint32 PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID = 20711u;
+    constexpr uint32 PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID = 27827u;
     if (target->HasAura(PRIEST_SPIRIT_OF_REDEMPTION_SPELL_ID))
         return false;
 


### PR DESCRIPTION
Replaced the spell id for Spirit of Redemption to allow a Holy Priest to drink

It needs some testing to make sure it always returns false when Spirit of Redemption is active