### PR TITLE
[fix crash] check bot / target world-state before cast

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3498,22 +3498,22 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
 
 
     // check if the actual target is valid, spell system uses targets.GetUnitTarget(), GetItemTarget(), GetGOTarget() internally.
-    Unit* unitTarget = targets.GetUnitTarget();
-    if (unitTarget && (!unitTarget->IsInWorld() || unitTarget->IsDuringRemoveFromWorld()))
+    Unit* uTarget = targets.GetUnitTarget();
+    if (uTarget && (!uTarget->IsInWorld() || uTarget->IsDuringRemoveFromWorld()))
     {
         // fail if the spell has a unit target that is invalid or being removed from the world
         delete spell;
         return false;
     }
-    Item* itemTarget = targets.GetItemTarget();
-    if (!itemTarget && (spellInfo->Targets & (TARGET_FLAG_ITEM | TARGET_FLAG_GAMEOBJECT_ITEM)))
+    Item* iTarget = targets.GetItemTarget();
+    if (!iTarget && (spellInfo->Targets & (TARGET_FLAG_ITEM | TARGET_FLAG_GAMEOBJECT_ITEM)))
     {
         // fail only if the spell requires a specific item or GO item to cast but the bot does not have one
         delete spell;
         return false;
     }
-    GameObject* goTarget = targets.GetGOTarget();
-    if (goTarget && !goTarget->isSpawned())
+    GameObject* gTarget = targets.GetGOTarget();
+    if (gTarget && !gTarget->isSpawned())
     {
         // fail if the spell has a GO target that is not spawned or does not exist
         delete spell;

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3402,7 +3402,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         return false;
     }
 
-    // early bot/target world-state check before spell creationg a spell, after pet
+    // early return; bot/target world-state check
     if (!bot->IsInWorld() || bot->IsDuringRemoveFromWorld() ||
         (target && (!target->IsInWorld() || target->IsDuringRemoveFromWorld())))
     {

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3498,7 +3498,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
     //     return false;
 
 
-    // check bot/target world-state just before preparing the actual spel
+    // check bot/target world-state just before preparing the actual spell
     Unit* unitTarget = targets.GetUnitTarget();
     if (!bot->IsInWorld() || bot->IsDuringRemoveFromWorld() ||
         (unitTarget && (!unitTarget->IsInWorld() || unitTarget->IsDuringRemoveFromWorld())))

--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -3402,8 +3402,14 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         return false;
     }
 
-    Spell* spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
+    // early bot/target world-state check before spell creationg a spell, after pet
+    if (!bot->IsInWorld() || bot->IsDuringRemoveFromWorld() ||
+        (target && (!target->IsInWorld() || target->IsDuringRemoveFromWorld())))
+    {
+        return false;
+    }
 
+    Spell* spell = new Spell(bot, spellInfo, TRIGGERED_NONE);
     SpellCastTargets targets;
     if (spellInfo->Effects[0].Effect != SPELL_EFFECT_OPEN_LOCK &&
         (spellInfo->Targets & TARGET_FLAG_ITEM || spellInfo->Targets & TARGET_FLAG_GAMEOBJECT_ITEM))
@@ -3491,6 +3497,15 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
     // if (spellSuccess != SPELL_CAST_OK)
     //     return false;
 
+
+    // check bot/target world-state just before preparing the actual spel
+    Unit* unitTarget = targets.GetUnitTarget();
+    if (!bot->IsInWorld() || bot->IsDuringRemoveFromWorld() ||
+        (unitTarget && (!unitTarget->IsInWorld() || unitTarget->IsDuringRemoveFromWorld())))
+    {
+        delete spell;
+        return false;
+    }
     SpellCastResult result = spell->prepare(&targets);
 
     if (result != SPELL_CAST_OK)


### PR DESCRIPTION
https://github.com/liyunfan1223/mod-playerbots/issues/1718

Lowers the scope of the target/bot is in an invalid (world-)state  just before casting or receiving.

Kinda forced the error myself by cheating to debug the exact code path, but eitherway it seems the crash comes from the usage of invalid target when casted to be exact a target interally translates into UnitTarget, ItemTarget or GoTarget those targets are not checked before handing it over to the core, which can result into invalidObject at the time we call the prepare cast.

And added some additional checks when entering the method, for valid target en bot to begin with.