### PR TITLE
Prevent Crash if sTaxiPathStore.LookupEntry return nullptr

### DIFF
--- a/src/TravelNode.cpp
+++ b/src/TravelNode.cpp
@@ -178,6 +178,9 @@ uint32 TravelNodePath::getPrice()
 
     TaxiPathEntry const* taxiPath = sTaxiPathStore.LookupEntry(pathObject);
 
+    if (!taxiPath)
+        return 0;
+	
     return taxiPath->price;
 }
 


### PR DESCRIPTION
When the taxi path lookup fails. In the playerbots module a path object can exist without a corresponding taxi path database entry, typically when content is missing from the DBC or has been removed, so `sTaxiPathStore.LookupEntry` may return `nullptr`. In that case we must avoid dereferencing the pointer and return a safe default of `0` to keep the bot AI running.
 
The pre-existing guards only handle other scenarios:
 
- `getPathType() != TravelNodePathType::flightPath` ensures ground or water
paths skip pricing entirely.
- `!pathObject` catches paths that never received a taxi identifier.
 
Neither condition covers the situation where the identifier is present but the
looked-up entry is absent, which is why the additional null check is required.
