### PR TITLE
Fix Opcode dispatch, trusts every queued packet to have a handler

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -227,6 +227,12 @@ void PlayerbotHolder::HandleBotPackets(WorldSession* session)
     {
         OpcodeClient opcode = static_cast<OpcodeClient>(packet->GetOpcode());
         ClientOpcodeHandler const* opHandle = opcodeTable[opcode];
+        if (!opHandle)
+        {
+            LOG_ERROR("playerbots", "Unhandled opcode {} queued for bot session {}. Packet dropped.", static_cast<uint32>(opcode), session->GetAccountId());
+            delete packet;
+            continue;
+        }
         opHandle->Call(session, *packet);
         delete packet;
     }


### PR DESCRIPTION
Fix : Opcode dispatch trusts every queued packet to have a handler

`PlayerbotHolder::HandleBotPackets` pulls packets from the session queue and dereferences `opcodeTable[opcode]` without validating that the handler exists. When AzerothCore adds new opcodes (which happens frequently on master) the entry can be `nullptr`, so calling `opHandle->Call` raises a null-pointer crash. Guarding the lookup and optionally logging unknown opcodes avoids the failure. 