### PR TITLE
Heirloom quality auto-equip calculation implemented

### DIFF
--- a/src/factory/StatsWeightCalculator.cpp
+++ b/src/factory/StatsWeightCalculator.cpp
@@ -94,16 +94,14 @@ float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyId
     if (enable_quality_blend_)
     {
         // Heirloom items scale with player level
+        // Use player level as effective item level for heirlooms - Quality EPIC
+        // Else - Blend with item quality and level for normal items
         if (proto->Quality == ITEM_QUALITY_HEIRLOOM)
-        {
-            // Use player level as effective item level for heirlooms - Quality EPIC
             weight_ *= PlayerbotFactory::CalcMixedGearScore(lvl, ITEM_QUALITY_EPIC);
-        }
+        
         else
-        {
-            // Blend with item quality and level for normal items
             weight_ *= PlayerbotFactory::CalcMixedGearScore(proto->ItemLevel, proto->Quality);
-        }
+
         return weight_;
     }
 


### PR DESCRIPTION
Edited quality_blend code to include a special case for heirloom items

This change sets the heirloom item to the player level, and assigns it an arbitrary quality of EPIC for purposes of calculation.
If the item is not an heirloom, the default calculation is run which assigns proto->ItemLevel and proto->Quality instead, using the default calculation values.

This may need tweaked slightly based on heirloom item scaling, but **should** prevent bots from equipping a green item over an heirloom item. 
