### PR TITLE
Added shaman default combat strategy names on top of custom

### DIFF
--- a/src/strategy/shaman/ShamanAiObjectContext.cpp
+++ b/src/strategy/shaman/ShamanAiObjectContext.cpp
@@ -41,6 +41,11 @@ class ShamanCombatStrategyFactoryInternal : public NamedObjectContext<Strategy>
 public:
     ShamanCombatStrategyFactoryInternal() : NamedObjectContext<Strategy>(false, true)
     {
+        creators["heal"] = &ShamanCombatStrategyFactoryInternal::resto;
+        creators["melee"] = &ShamanCombatStrategyFactoryInternal::enh;
+        creators["dps"] = &ShamanCombatStrategyFactoryInternal::enh;
+        creators["caster"] = &ShamanCombatStrategyFactoryInternal::ele;
+        //creators["offheal"] = &ShamanCombatStrategyFactoryInternal::offheal;
         creators["resto"] = &ShamanCombatStrategyFactoryInternal::resto;
         creators["enh"] = &ShamanCombatStrategyFactoryInternal::enh;
         creators["ele"] = &ShamanCombatStrategyFactoryInternal::ele;


### PR DESCRIPTION
We should stick with the default names or should be at least part of the list. These default names are there for a certain level of abstraction and unity between classes. Adding addtional specialization shouldn't be issue as long the default strategies name such as caster, dps, melee, healer, offhealer are supported out of the box.