### PR TITLE
Fixe Warning : Warning C4715 'StatsWeightCalculator::CalculateItem': not all control paths return a value wile compiling the server

### DIFF
--- a/src/factory/StatsWeightCalculator.cpp
+++ b/src/factory/StatsWeightCalculator.cpp
@@ -103,7 +103,8 @@ float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyId
 
         return weight_;
     }
-
+    // If quality/level blending is disabled, also return the calculated weight.
+    return weight_;
 }
 
 float StatsWeightCalculator::CalculateEnchant(uint32 enchantId)


### PR DESCRIPTION
Fixe Warning : Warning C4715 'StatsWeightCalculator::CalculateItem': not all control paths return a value wile compiling the server, this warning was introduced by PR : https://github.com/mod-playerbots/mod-playerbots/commit/553b8276eb8d0d9dfac9fd35e61ef6a47162b4da