### PR TITLE
Fix: Prevent addClass bots from getting realm firsts

### DIFF
--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -220,7 +220,8 @@ public:
 
     bool OnPlayerBeforeAchievementComplete(Player* player, AchievementEntry const* achievement) override
     {
-        if ((sRandomPlayerbotMgr->IsRandomBot(player) || sRandomPlayerbotMgr->IsAddclassBot(player)) && (achievement->flags == 256 || achievement->flags == 768))
+        if ((sRandomPlayerbotMgr->IsRandomBot(player) || sRandomPlayerbotMgr->IsAddclassBot(player)) &&
+            (achievement->flags & (ACHIEVEMENT_FLAG_REALM_FIRST_REACH | ACHIEVEMENT_FLAG_REALM_FIRST_KILL)))
         {
             return false;
         }


### PR DESCRIPTION
Follow up to #1487, which targeted randombots only and addClass were still able to get realm firsts. This fix targets ~~anything that's not a real player~~ both.