### PR TITLE
FIX: Set an uninitialized variable in PvpValues.cpp

### DIFF
--- a/src/strategy/values/PvpValues.cpp
+++ b/src/strategy/values/PvpValues.cpp
@@ -102,7 +102,7 @@ std::vector<CreatureData const*> BgMastersValue::Calculate()
         }
     }
 
-    return std::move(bmGuids);
+    return bmGuids;
 }
 
 CreatureData const* BgMasterValue::Calculate()
@@ -120,7 +120,7 @@ CreatureData const* BgMasterValue::NearestBm(bool allowDead)
 
     std::vector<CreatureData const*> bmPairs = AI_VALUE2(std::vector<CreatureData const*>, "bg masters", qualifier);
 
-    float rDist;
+    float rDist = 0.0f;
     CreatureData const* rbmPair = nullptr;
 
     for (auto& bmPair : bmPairs)


### PR DESCRIPTION
Set uninitialized variable, Silence uninitialized before use error.
Remove std::move