### PR TITLE
FIX: part of logic in picking quest reward

### DIFF
--- a/src/strategy/actions/TalkToQuestGiverAction.cpp
+++ b/src/strategy/actions/TalkToQuestGiverAction.cpp
@@ -211,7 +211,7 @@ void TalkToQuestGiverAction::RewardMultipleItem(Quest const* quest, Object* ques
         if (bestIds.size() > 1)
             AskToSelectReward(quest, out, true);
 
-        else
+        else if (!bestIds.empty())
         {
             // Pick the first item
             uint32 firstId = *bestIds.begin();


### PR DESCRIPTION
Avoids dereferencing begin() after confirming the set is empty.