### PR TITLE
Fix PositionInfo constructors' members order

### DIFF
--- a/src/strategy/values/PositionValue.h
+++ b/src/strategy/values/PositionValue.h
@@ -15,13 +15,13 @@ class PlayerbotAI;
 class PositionInfo
 {
 public:
-    PositionInfo() : valueSet(false), x(0), y(0), z(0), mapId(0) {}
+    PositionInfo() : x(0), y(0), z(0), mapId(0), valueSet(false) {}
     PositionInfo(float x, float y, float z, uint32 mapId, bool valueSet = true)
-        : valueSet(valueSet), x(x), y(y), z(z), mapId(mapId)
+        : x(x), y(y), z(z), mapId(mapId), valueSet(valueSet)
     {
     }
     PositionInfo(PositionInfo const& other)
-        : valueSet(other.valueSet), x(other.x), y(other.y), z(other.z), mapId(other.mapId)
+        : x(other.x), y(other.y), z(other.z), mapId(other.mapId), valueSet(other.valueSet)
     {
     }
 
@@ -41,8 +41,8 @@ public:
     float x;
     float y;
     float z;
-    bool valueSet;
     uint32 mapId;
+    bool valueSet;
 };
 
 typedef std::map<std::string, PositionInfo> PositionMap;


### PR DESCRIPTION
Fix warnings: -Wreorder-ctor
```
#23 9.775 /azerothcore/modules/mod-playerbots/src/strategy/values/PositionValue.h:18:22: warning: field 'valueSet' will be initialized after field 'x' [-Wreorder-ctor]
#23 9.775     PositionInfo() : valueSet(false), x(0), y(0), z(0), mapId(0) {}
#23 9.775                      ^~~~~~~~~~~~~~~  ~~~~  ~~~~  ~~~~
#23 9.775                      x(0)             y(0)  z(0)  valueSet(false)
#23 9.775 /azerothcore/modules/mod-playerbots/src/strategy/values/PositionValue.h:20:11: warning: field 'valueSet' will be initialized after field 'x' [-Wreorder-ctor]
#23 9.775         : valueSet(valueSet), x(x), y(y), z(z), mapId(mapId)
#23 9.775           ^~~~~~~~~~~~~~~~~~  ~~~~  ~~~~  ~~~~
#23 9.775           x(x)                y(y)  z(z)  valueSet(valueSet)
#23 9.775 /azerothcore/modules/mod-playerbots/src/strategy/values/PositionValue.h:24:11: warning: field 'valueSet' will be initialized after field 'x' [-Wreorder-ctor]
#23 9.775         : valueSet(other.valueSet), x(other.x), y(other.y), z(other.z), mapId(other.mapId)
#23 9.775           ^~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~  ~~~~~~~~~~  ~~~~~~~~~~
#23 9.775           x(other.x)                y(other.y)  z(other.z)  valueSet(other.valueSet)
```