### PR TITLE
Use actual item stats for scaling items

### DIFF
--- a/src/factory/StatsCollector.cpp
+++ b/src/factory/StatsCollector.cpp
@@ -43,19 +43,51 @@ void StatsCollector::CollectItemStats(ItemTemplate const* proto, uint8 playerLev
     ScalingStatValuesEntry const* ssv =
         proto->ScalingStatValue ? sScalingStatValuesStore.LookupEntry(ssdLevel) : nullptr;
 
-    if (proto->IsRangedWeapon())
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
     {
-        float val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
-        stats[STATS_TYPE_RANGED_DPS] += val;
+        float minDamage = proto->Damage[i].DamageMin;
+        float maxDamage = proto->Damage[i].DamageMax;
+
+        if (ssv && i == 0)
+        {
+            int extraDPS = ssv->getDPSMod(ScalingStatValue);
+            if (extraDPS)
+            {
+                float average = extraDPS * proto->Delay / 1000.0f;
+                float mod = ssv->IsTwoHand(proto->ScalingStatValue) ? 0.2 : 0.3f;
+
+                minDamage = (1.0 - mod) * average;
+                maxDamage = (1.0 + mod) * average;
+            }
+        }
+
+        if (proto->IsRangedWeapon())
+        {
+            float val = (minDamage + maxDamage) * 1000 / 2 / proto->Delay;
+            stats[STATS_TYPE_RANGED_DPS] += val;
+        }
+        else if (proto->IsWeapon())
+        {
+            float val = (minDamage + maxDamage) * 1000 / 2 / proto->Delay;
+            stats[STATS_TYPE_MELEE_DPS] += val;
+        }
     }
-    else if (proto->IsWeapon())
-    {
-        float val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
-        stats[STATS_TYPE_MELEE_DPS] += val;
-    }
-    stats[STATS_TYPE_ARMOR] += proto->Armor;
+
     stats[STATS_TYPE_BLOCK_VALUE] += proto->Block;
-    for (int i = 0; i < MAX_ITEM_PROTO_STATS; i++)
+
+    uint32 armor = proto->Armor;
+    if (ssv)
+    {
+        uint32 ssvarmor = ssv->getArmorMod(ScalingStatValue);
+        if (proto->ScalingStatValue > 0 || ssvarmor < proto->Armor)
+            armor = ssvarmor;
+    }
+    else if (armor && proto->ArmorDamageModifier)
+        armor -= uint32(proto->ArmorDamageModifier);
+
+    stats[STATS_TYPE_ARMOR] += armor;
+
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_STATS; i++)
     {
         const _ItemStat& stat = proto->ItemStat[i];
         uint32 statType = stat.ItemStatType;
@@ -69,9 +101,19 @@ void StatsCollector::CollectItemStats(ItemTemplate const* proto, uint8 playerLev
         }
         else if (i < proto->StatsCount)
             val = stat.ItemStatValue;
+        else
+            continue;
 
         CollectByItemStatType(statType, val);
     }
+
+    uint32 spellBonus = ssv ? ssv->getSpellBonus(ScalingStatValue) : 0;
+    if (ssv && spellBonus)
+    {
+        stats[STATS_TYPE_SPELL_POWER] += spellBonus;
+        stats[STATS_TYPE_HEAL_POWER] += spellBonus;
+    }
+
     for (uint8 j = 0; j < MAX_ITEM_PROTO_SPELLS; j++)
     {
         switch (proto->Spells[j].SpellTrigger)

--- a/src/factory/StatsCollector.cpp
+++ b/src/factory/StatsCollector.cpp
@@ -25,8 +25,24 @@ void StatsCollector::Reset()
     }
 }
 
-void StatsCollector::CollectItemStats(ItemTemplate const* proto)
+void StatsCollector::CollectItemStats(ItemTemplate const* proto, uint8 playerLevel)
 {
+    ScalingStatDistributionEntry const* ssd =
+        proto->ScalingStatDistribution ? sScalingStatDistributionStore.LookupEntry(proto->ScalingStatDistribution)
+                                       : nullptr;
+
+    uint32 ScalingStatValue = proto->ScalingStatValue > 0 ? proto->ScalingStatValue : 0;
+    uint32 ssdLevel = playerLevel;
+
+    if (ssd != nullptr)
+    {
+        if (ssdLevel > ssd->MaxLevel)
+            ssdLevel = ssd->MaxLevel;
+    }
+
+    ScalingStatValuesEntry const* ssv =
+        proto->ScalingStatValue ? sScalingStatValuesStore.LookupEntry(ssdLevel) : nullptr;
+
     if (proto->IsRangedWeapon())
     {
         float val = (proto->Damage[0].DamageMin + proto->Damage[0].DamageMax) * 1000 / 2 / proto->Delay;
@@ -39,11 +55,22 @@ void StatsCollector::CollectItemStats(ItemTemplate const* proto)
     }
     stats[STATS_TYPE_ARMOR] += proto->Armor;
     stats[STATS_TYPE_BLOCK_VALUE] += proto->Block;
-    for (int i = 0; i < proto->StatsCount; i++)
+    for (int i = 0; i < MAX_ITEM_PROTO_STATS; i++)
     {
         const _ItemStat& stat = proto->ItemStat[i];
-        const int32& val = stat.ItemStatValue;
-        CollectByItemStatType(stat.ItemStatType, val);
+        uint32 statType = stat.ItemStatType;
+        int32 val;
+
+        if (ssv && ssd && ssd->StatMod[i] >= 0)
+        {
+            statType = ssd->StatMod[i];
+            uint32 mul = ssv->getssdMultiplier(ScalingStatValue);
+            val = mul * ssd->Modifier[i] / 10000;
+        }
+        else if (i < proto->StatsCount)
+            val = stat.ItemStatValue;
+
+        CollectByItemStatType(statType, val);
     }
     for (uint8 j = 0; j < MAX_ITEM_PROTO_SPELLS; j++)
     {

--- a/src/factory/StatsCollector.h
+++ b/src/factory/StatsCollector.h
@@ -64,7 +64,7 @@ public:
     StatsCollector(CollectorType type, int32 cls = -1);
     StatsCollector(StatsCollector& stats) = default;
     void Reset();
-    void CollectItemStats(ItemTemplate const* proto);
+    void CollectItemStats(ItemTemplate const* proto, uint8 playerLevel);
     void CollectSpellStats(uint32 spellId, float multiplier = 1.0f, int32 spellCooldown = -1);
     void CollectEnchantStats(SpellItemEnchantmentEntry const* enchant, uint32 default_enchant_amount = 0);
     bool CanBeTriggeredByType(SpellInfo const* spellInfo, uint32 procFlags, bool strict = true);

--- a/src/factory/StatsWeightCalculator.cpp
+++ b/src/factory/StatsWeightCalculator.cpp
@@ -70,7 +70,7 @@ float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyId
 
     Reset();
 
-    collector_->CollectItemStats(proto);
+    collector_->CollectItemStats(proto, lvl);
 
     if (randomPropertyIds != 0)
         CalculateRandomProperty(randomPropertyIds, itemId);


### PR DESCRIPTION
# Issue

Currently, items with scaling stats (e.g. heirlooms) are evaluated at their minimum level, meaning they are often weighted much lower than even e.g. gray items. This leads to `autogear` replacing heirlooms with whatever equipment the bots can pick up.

# Changes

`StatsCollector::CollectItemStats` gets a second parameter for the player level and then attempts to evaluate the stats according to the passed level. This results in the item having the proper stats that the player/bot should actually have when wearing the item, rather than using some level 0/1 kind of value which is likely worse than most gray items.

The code for the scaling has more-or-less been lifted from Player.cpp, except for the scripting bits. In order to make it work, I had to rework the loop to always iterate over the all possible props, because for the heirlooms I've tested, `StatsCount` is 0.

# Open Questions

There's a few things that this PR does not address because it's a bit more than I currently know about playerbots, so I'd like to mention them. Any guidance is appreciated.

1. `StatsCollector::CollectItemStats` gets another parameter, which is technically an public interface change. Should a default parameter value (likely `0`) be specified, or an overload created so that the old method still exists (and just calls the method with the parameter and a default value)? What are the backwards compatibility concerns for e.g. third parties that may use this code?
2. The original code in `Player.cpp` also allowed scripts to change these values. I'm not doing that here because I don't have a reference to the player, and since the Player variant seems to be in a method that is called when the player stats are refreshed, I'm not sure if there might be side-effects if we call these scripts just for comparison's sake. So while this works for unscripted items, scripted items with scaling would still generate the wrong values.
3. ~~Values that aren't iterated upon in the stats list (e.g. attack damage) aren't scaled yet. I would need to dig deeper to figure out where those scales are set/applied.~~ - attack damage, spell power and armor should be done now, as should be scaled attributes in general.
4. ~~I'm not 100% certain on the way the item templates (`proto`) works, and as such, I'm not entirely sure if `proto->StatsMod[i]` and `proto->ItemStat[i]` are even related.~~ As far as I can tell from the few heirlooms I've tried, there's no strict relation - if an SSD/SSV exists, it will take precedence and the normal stat is completely ignored

# Testing

Limited testing has been done from my side, but usually something like this:

1. Create a bot character of a significantly high level (e.g. 20) and equip it with a heirloom
2. Give it a random gray item that matches its level
3. Run `autogear`
5. Prior to this patch, the bot replaces all heirlooms with gray-or-better items if available; after this patch, they seem to stick around.

I haven't really done any in-depth testing with broad ranges of equipment/player levels/similar because I lack the knowledge to do so, but I thought I would share what I have so far. :)