### PR TITLE
README.md edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
     <a href="https://github.com/mod-playerbots/mod-playerbots/blob/master/README.md">English</a>
     |
     <a href="https://github.com/mod-playerbots/mod-playerbots/blob/master/README_CN.md">中文</a>
+    |
+    <a href="https://github.com/mod-playerbots/mod-playerbots/blob/master/README_ES.md">Español</a>
 </p>
 
 
@@ -65,7 +67,7 @@ services:
       - ./modules:/azerothcore/modules:ro
 ```
 
-itionally, this override file can be used to set custom configuration settings for `ac-worldserver` and any modules you install as environment variables:
+Additionally, this override file can be used to set custom configuration settings for `ac-worldserver` and any modules you install as environment variables:
 
 ```yml
 services:


### PR DESCRIPTION
I've noticed some sprawl in the README.md. The following edits have been made around the goal of clarity, brevity, and emphases when needed:

- Removed dead link to the Spanish README.md at the top. The README_ES.md file itself is not removed from the repo, but is however out of date and does not seem useful at this time
- Removed the addons section. This seems to be covered by the Wiki in the Documentation section unless I'm mistaken? We can add these back if needed
- Reorganized installation instructions to emphasize the importance of using the Playerbots branch of AzerothCore for all installations
- Moved the platform support from the Frequently Asked Questions section to the installation instructions
- Modified punctuation of bulleted list. These can return if it irks someone, but it seems easier to read without them
- Added a encouragement to star the project for updates and gain more visibility
- Removed the Frequently Asked Questions section. I encourage this to be covered in a wiki page but it can return if deemed necessary. I think a lot of it can be moved to other sections if we really need them in there
- Added a "Contributing" section that replaces the Coding Standards section
- Coding Standards are included in the Contributing section
- Added a second link to the Discord server in the Contributing section
- Removed a link to the main Playerbots branch from the introduction section. This is covered and emphasized in the installation section instead
- Migrated the encouragements to make bug reports from the introduction, along with the message that this is still in active development, to the contributing section
- Reduced redundant language when not necessary (e.g. "As noted above,")
- Updated language around custom branch and require branch for uniformity. This will make it more clear to the users about the subject
- Removed "Classic" from the "Classic Installation" terminology for being inaccurate. The subject is now known simply as "Cloning the Repositories" while "Docker Installation" still remains distinct. This will make what was formerly known as "Classic Installation" as de facto default
- Appended the "Documentation" section with add-on information
- Unified all instances of AddOn to the Blizzard spelling without a hyphen following the WoW 3.3.5a client spelling
- Appended "AzerothCore" to instances of "branch" to ensure readers they are, in fact, installing AzerothCore here from our required branch