### PR TITLE
Simplify IsBotMainTank logic

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -2219,58 +2219,7 @@ bool PlayerbotAI::IsMainTank(Player* player)
 
 bool PlayerbotAI::IsBotMainTank(Player* player)
 {
-    if (!player->GetSession()->IsBot() || !IsTank(player))
-    {
-        return false;
-    }
-
-    if (IsMainTank(player))
-    {
-        return true;
-    }
-
-    Group* group = player->GetGroup();
-    if (!group)
-    {
-        return true;  // If no group, consider the bot as main tank
-    }
-
-    uint32 botAssistTankIndex = GetAssistTankIndex(player);
-
-    if (botAssistTankIndex == -1)
-    {
-        return false;
-    }
-
-    for (GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
-    {
-        Player* member = gref->GetSource();
-        if (!member)
-        {
-            continue;
-        }
-
-        uint32 memberAssistTankIndex = GetAssistTankIndex(member);
-
-        if (memberAssistTankIndex == -1)
-        {
-            continue;
-        }
-
-        if (memberAssistTankIndex == botAssistTankIndex && player == member)
-        {
-            return true;
-        }
-
-        if (memberAssistTankIndex < botAssistTankIndex && member->GetSession()->IsBot())
-        {
-            return false;
-        }
-
-        return false;
-    }
-
-    return false;
+    return player->GetSession()->IsBot() && IsMainTank(player);
 }
 
 uint32 PlayerbotAI::GetGroupTankNum(Player* player)


### PR DESCRIPTION
IsBotMainTank() has an excess return false at the end that makes it not function properly. I was going to just delete that, but now I think the function as a whole is needlessly complex. It goes through a process of setting fallbacks based on assistant index if there is no main tank set; that is not something used for IsMainTank(), and I don't see the point in doing so as opposed to having the same general logic as just iterating through tanks generally if there is no main tank set.

Therefore, I'm proposing to greatly simplify IsBotMainTank() to just be IsMainTank(), with the additional requirement that the main tank be a bot, which is how I would expect IsBotMainTank() to work in practice.