### PR TITLE
FIX: Battlegrounds - Unset bot's master when current master left BG

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -374,10 +374,12 @@ void PlayerbotAI::UpdateAIGroupAndMaster()
 
     Group* group = bot->GetGroup();
 
+    bool IsRandomBot = sRandomPlayerbotMgr->IsRandomBot(bot);
+
     // If bot is not in group verify that for is RandomBot before clearing  master and resetting.
     if (!group)
     {
-        if (master && sRandomPlayerbotMgr->IsRandomBot(bot))
+        if (master && IsRandomBot)
         {
             SetMaster(nullptr);
             Reset(true);
@@ -387,7 +389,8 @@ void PlayerbotAI::UpdateAIGroupAndMaster()
     }
 
     // Bot in BG, but master no longer part of a group: release master
-    if (bot->InBattleground() && master && !master->GetGroup())
+    // Exclude alt and addclass bots as they rely on current (real player) master, security-wise.
+    if (bot->InBattleground() && IsRandomBot && master && !master->GetGroup())
         SetMaster(nullptr);
 
     PlayerbotAI* masterBotAI = nullptr;


### PR DESCRIPTION
Adds a check for if current master left the BG and group,  if so release set master and carry on in BG.

This prevents multiple bots in (potentially multiple different) BG's to still consider you as their master when you yourself have left.

- Applies when you join BGs with a party of bots.