### PR TITLE
feat(randombot): Added true persistence option and teleportation disabling.

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -630,7 +630,7 @@ AiPlayerbot.RandomBotHordeRatio = 50
 AiPlayerbot.DisableDeathKnightLogin = 0
 
 # Enable simulated expansion limitation for talents and glyphs
-# If enabled, limits talent trees to 5 rows plus the middle talent of the 6th row for bots until level 61 
+# If enabled, limits talent trees to 5 rows plus the middle talent of the 6th row for bots until level 61
 # and 7 rows plus the middle talent of the 8th row for bots from level 61 until level 71
 # Default: 0 (disabled)
 AiPlayerbot.LimitTalentsExpansion = 0
@@ -641,6 +641,17 @@ AiPlayerbot.EnableRandomBotTrading = 1
 
 # Configure message prefixes which will be excluded in analysis in trade action to open trade window
 AiPlayerbot.TradeActionExcludedPrefixes = "RPLL_H_,DBMv4,{звезда} Questie,{rt1} Questie"
+
+# This option will prevent ALL random bots from being randomized.
+# It does not prevent periodic teleport.
+# Without it, random bots will be periodically randomized unless they are in a guild
+# with at least one character who is not a random bot.
+AiPlayerbot.DisableRandomBotPeriodicRandomization = 1
+
+# This option will prevent ALL random bots from being periodically teleported.
+# THIS SHOULD NOT BE ENABLED AT ALL TIMES. It exists mostly for debugging purposes.
+# Disabling periodic teleport will make the bots almost unable to reach new areas.
+AiPlayerbot.DisableRandomBotPeriodicTeleportation = 0
 
 #
 #

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -647,6 +647,9 @@ bool PlayerbotAIConfig::Initialize()
 
     selfBotLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.SelfBotLevel", 1);
 
+    disableRandomBotPeriodicRandomization = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableRandomBotPeriodicRandomization", false);
+    disableRandomBotPeriodicTeleportation = sConfigMgr->GetOption<bool>("AiPlayerbot.DisableRandomBotPeriodicTeleportation", false);
+
     RandomPlayerbotFactory::CreateRandomBots();
     if (World::IsStopped())
     {

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -302,6 +302,9 @@ public:
     std::vector<std::string> botCheats;
     uint32 botCheatMask = 0;
 
+	bool disableRandomBotPeriodicRandomization;
+	bool disableRandomBotPeriodicTeleportation;
+
     struct worldBuff
     {
         uint32 spellId;

--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -5,18 +5,22 @@
 
 #include "PlayerbotMgr.h"
 
+#include <openssl/sha.h>
+
+#include <algorithm>  // Added for gender choice
 #include <cstdio>
 #include <cstring>
+#include <iomanip>
 #include <istream>
 #include <string>
-#include <openssl/sha.h>
 #include <unordered_set>
-#include <iomanip>
 
+#include "BroadcastHelper.h"
 #include "ChannelMgr.h"
 #include "CharacterCache.h"
 #include "CharacterPackets.h"
 #include "Common.h"
+#include "DatabaseEnv.h"  // Added for gender choice
 #include "Define.h"
 #include "Group.h"
 #include "GroupMgr.h"
@@ -32,12 +36,7 @@
 #include "RandomPlayerbotMgr.h"
 #include "SharedDefines.h"
 #include "WorldSession.h"
-#include "ChannelMgr.h"
-#include "BroadcastHelper.h"
-#include "PlayerbotDbStore.h"
 #include "WorldSessionMgr.h"
-#include "DatabaseEnv.h"        // Added for gender choice
-#include <algorithm>            // Added for gender choice
 
 class BotInitGuard
 {
@@ -73,6 +72,7 @@ class PlayerbotLoginQueryHolder : public LoginQueryHolder
 private:
     uint32 masterAccountId;
     PlayerbotHolder* playerbotHolder;
+
 public:
     PlayerbotLoginQueryHolder(PlayerbotHolder* playerbotHolder, uint32 masterAccount, uint32 accountId, ObjectGuid guid)
         : LoginQueryHolder(accountId, guid), masterAccountId(masterAccount), playerbotHolder(playerbotHolder)
@@ -109,20 +109,33 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
     bool linkedAccount = sPlayerbotAIConfig->allowTrustedAccountBots && IsAccountLinked(accountId, masterAccountId);
 
     bool allowed = true;
+
     std::ostringstream out;
     std::string botName;
     sCharacterCache->GetCharacterNameByGuid(playerGuid, botName);
+
     if (!isRndbot && !sameAccount && !sameGuild && !addClassBot && !linkedAccount)
     {
         allowed = false;
+    }
+
+    if (!allowed && masterPlayer && masterPlayer->IsGameMaster())
+    {
+        allowed = true;
+    }
+
+    if (!allowed)
+    {
         out << "Failure: You are not allowed to control bot " << botName.c_str();
     }
+
     if (masterAccountId && masterPlayer)
     {
         PlayerbotMgr* mgr = GET_PLAYERBOT_MGR(masterPlayer);
         if (!mgr)
         {
-            LOG_DEBUG("playerbots", "PlayerbotMgr not found for master player with GUID: {}", masterPlayer->GetGUID().GetRawValue());
+            LOG_DEBUG("playerbots", "PlayerbotMgr not found for master player with GUID: {}",
+                      masterPlayer->GetGUID().GetRawValue());
             return;
         }
         uint32 count = mgr->GetPlayerbotsCount() + botLoading.size();
@@ -153,13 +166,14 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
     // Always login in with world session to avoid race condition
     sWorld->AddQueryHolderCallback(CharacterDatabase.DelayQueryHolder(holder))
         .AfterComplete([this](SQLQueryHolderBase const& holder)
-                        { HandlePlayerBotLoginCallback(static_cast<PlayerbotLoginQueryHolder const&>(holder)); });
+                       { HandlePlayerBotLoginCallback(static_cast<PlayerbotLoginQueryHolder const&>(holder)); });
 }
 
 bool PlayerbotHolder::IsAccountLinked(uint32 accountId, uint32 linkedAccountId)
 {
     QueryResult result = PlayerbotsDatabase.Query(
-        "SELECT 1 FROM playerbots_account_links WHERE account_id = {} AND linked_account_id = {}", accountId, linkedAccountId);
+        "SELECT 1 FROM playerbots_account_links WHERE account_id = {} AND linked_account_id = {}", accountId,
+        linkedAccountId);
     return result != nullptr;
 }
 
@@ -168,8 +182,9 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
     uint32 botAccountId = holder.GetAccountId();
     // At login DBC locale should be what the server is set to use by default (as spells etc are hardcoded to ENUS this
     // allows channels to work as intended)
-    WorldSession* botSession = new WorldSession(botAccountId, "", 0x0, nullptr, SEC_PLAYER, EXPANSION_WRATH_OF_THE_LICH_KING,
-                                                time_t(0), sWorld->GetDefaultDbcLocale(), 0, false, false, 0, true);
+    WorldSession* botSession =
+        new WorldSession(botAccountId, "", 0x0, nullptr, SEC_PLAYER, EXPANSION_WRATH_OF_THE_LICH_KING, time_t(0),
+                         sWorld->GetDefaultDbcLocale(), 0, false, false, 0, true);
 
     botSession->HandlePlayerLoginFromDB(holder);  // will delete lqh
 
@@ -191,7 +206,8 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
     Player* masterPlayer = masterSession ? masterSession->GetPlayer() : nullptr;
     if (masterSession && !masterPlayer)
     {
-        LOG_DEBUG("mod-playerbots", "Master session found but no player is associated for master account ID: {}", masterAccount);
+        LOG_DEBUG("mod-playerbots", "Master session found but no player is associated for master account ID: {}",
+                  masterAccount);
     }
 
     sRandomPlayerbotMgr->OnPlayerLogin(bot);
@@ -229,7 +245,8 @@ void PlayerbotHolder::HandleBotPackets(WorldSession* session)
         ClientOpcodeHandler const* opHandle = opcodeTable[opcode];
         if (!opHandle)
         {
-            LOG_ERROR("playerbots", "Unhandled opcode {} queued for bot session {}. Packet dropped.", static_cast<uint32>(opcode), session->GetAccountId());
+            LOG_ERROR("playerbots", "Unhandled opcode {} queued for bot session {}. Packet dropped.",
+                      static_cast<uint32>(opcode), session->GetAccountId());
             delete packet;
             continue;
         }
@@ -388,8 +405,8 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
             }
             else
             {
-                RemoveFromPlayerbotsMap(guid);     // deletes bot player ptr inside this WorldSession PlayerBotMap
-                delete botWorldSessionPtr;  // finally delete the bot's WorldSession
+                RemoveFromPlayerbotsMap(guid);  // deletes bot player ptr inside this WorldSession PlayerBotMap
+                delete botWorldSessionPtr;      // finally delete the bot's WorldSession
                 if (target)
                     delete target;
             }
@@ -398,7 +415,7 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         else if (bot && (logout || !botWorldSessionPtr->isLogingOut()))
         {
             botAI->TellMaster("Goodbye!");
-            RemoveFromPlayerbotsMap(guid);                  // deletes bot player ptr inside this WorldSession PlayerBotMap
+            RemoveFromPlayerbotsMap(guid);           // deletes bot player ptr inside this WorldSession PlayerBotMap
             botWorldSessionPtr->LogoutPlayer(true);  // this will delete the bot Player object and PlayerbotAI object
             delete botWorldSessionPtr;               // finally delete the bot's WorldSession
         }
@@ -441,10 +458,7 @@ void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)
     }
 }
 
-void PlayerbotHolder::RemoveFromPlayerbotsMap(ObjectGuid guid)
-{
-    playerBots.erase(guid);
-}
+void PlayerbotHolder::RemoveFromPlayerbotsMap(ObjectGuid guid) { playerBots.erase(guid); }
 
 Player* PlayerbotHolder::GetPlayerBot(ObjectGuid playerGuid) const
 {
@@ -648,11 +662,13 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
                 case ChatChannelId::GUILD_RECRUITMENT:
                 {
                     char new_channel_name_buf[100];
-                    //3459 is ID for a zone named "City" (only exists for the sake of using its name)
-                    //Currently in magons TBC, if you switch zones, then you join "Trade - <zone>" and "GuildRecruitment - <zone>"
-                    //which is a core bug, should be "Trade - City" and "GuildRecruitment - City" in both 1.12 and TBC
-                    //but if you (actual player) logout in a city and log back in - you join "City" versions
-                    snprintf(new_channel_name_buf, 100, channel->pattern[locale], GET_PLAYERBOT_AI(bot)->GetLocalizedAreaName(GetAreaEntryByAreaID(3459)).c_str());
+                    // 3459 is ID for a zone named "City" (only exists for the sake of using its name)
+                    // Currently in magons TBC, if you switch zones, then you join "Trade - <zone>" and
+                    // "GuildRecruitment - <zone>" which is a core bug, should be "Trade - City" and "GuildRecruitment -
+                    // City" in both 1.12 and TBC but if you (actual player) logout in a city and log back in - you join
+                    // "City" versions
+                    snprintf(new_channel_name_buf, 100, channel->pattern[locale],
+                             GET_PLAYERBOT_AI(bot)->GetLocalizedAreaName(GetAreaEntryByAreaID(3459)).c_str());
                     new_channel = cMgr->GetJoinChannel(new_channel_name_buf, channel->ChannelID);
                     break;
                 }
@@ -679,9 +695,9 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
         return "bot system is disabled";
 
     uint32 botAccount = sCharacterCache->GetCharacterAccountIdByGuid(guid);
-    //bool isRandomBot = sRandomPlayerbotMgr->IsRandomBot(guid.GetCounter()); //not used, line marked for removal.
-    //bool isRandomAccount = sPlayerbotAIConfig->IsInRandomAccountList(botAccount); //not used, shadowed, line marked for removal.
-    //bool isMasterAccount = (masterAccountId == botAccount); //not used, line marked for removal.
+    // bool isRandomBot = sRandomPlayerbotMgr->IsRandomBot(guid.GetCounter()); //not used, line marked for removal.
+    // bool isRandomAccount = sPlayerbotAIConfig->IsInRandomAccountList(botAccount); //not used, shadowed, line marked
+    // for removal. bool isMasterAccount = (masterAccountId == botAccount); //not used, line marked for removal.
 
     if (cmd == "add" || cmd == "addaccount" || cmd == "login")
     {
@@ -695,11 +711,11 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
             if (!accountId)
                 return "character not found";
 
-                if (!sPlayerbotAIConfig->allowAccountBots && accountId != masterAccountId &&
-                    !(sPlayerbotAIConfig->allowTrustedAccountBots && IsAccountLinked(accountId, masterAccountId)))
-                {
-                    return "you can only add bots from your own account or linked accounts";
-                }
+            if (!sPlayerbotAIConfig->allowAccountBots && accountId != masterAccountId &&
+                !(sPlayerbotAIConfig->allowTrustedAccountBots && IsAccountLinked(accountId, masterAccountId)))
+            {
+                return "you can only add bots from your own account or linked accounts";
+            }
         }
 
         AddPlayerBot(guid, masterAccountId);
@@ -797,14 +813,18 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
                     mixedGearScore = 1;
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
                 factory.Randomize(false);
-                return "ok, gear score limit: " + std::to_string(mixedGearScore / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) +
+                return "ok, gear score limit: " +
+                       std::to_string(mixedGearScore /
+                                      PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) +
                        "(for epic)";
             }
             else if (cmd.starts_with("init=") && sscanf(cmd.c_str(), "init=%d", &gs) != -1)
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, gs);
                 factory.Randomize(false);
-                return "ok, gear score limit: " + std::to_string(gs / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) + "(for epic)";
+                return "ok, gear score limit: " +
+                       std::to_string(gs / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) +
+                       "(for epic)";
             }
         }
 
@@ -848,13 +868,12 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
 // Added for gender choice : Returns the gender of an offline character: 0 = male, 1 = female.
 static uint8 GetOfflinePlayerGender(ObjectGuid guid)
 {
-    QueryResult result = CharacterDatabase.Query(
-        "SELECT gender FROM characters WHERE guid = {}", guid.GetCounter());
+    QueryResult result = CharacterDatabase.Query("SELECT gender FROM characters WHERE guid = {}", guid.GetCounter());
 
     if (result)
-        return (*result)[0].Get<uint8>();       // 0 = male, 1 = female
+        return (*result)[0].Get<uint8>();  // 0 = male, 1 = female
 
-    return GENDER_MALE;                         // fallback value
+    return GENDER_MALE;  // fallback value
 }
 
 bool PlayerbotMgr::HandlePlayerbotMgrCommand(ChatHandler* handler, char const* args)
@@ -905,11 +924,12 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
 
     char* cmd = strtok((char*)args, " ");
     char* charname = strtok(nullptr, " ");
-    char* genderArg = strtok(nullptr, " ");    // Added for gender choice [male|female|0|1] optionnel
+    char* genderArg = strtok(nullptr, " ");  // Added for gender choice [male|female|0|1] optionnel
 
     if (!cmd)
     {
-        messages.push_back("usage: list/reload/tweak/self or add/init/remove PLAYERNAME or addclass CLASSNAME [male|female]");
+        messages.push_back(
+            "usage: list/reload/tweak/self or add/init/remove PLAYERNAME or addclass CLASSNAME [male|female]");
         return messages;
     }
 
@@ -1133,22 +1153,22 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             return messages;
         }
         //  Added for gender choice : Parsing gender
-        int8 gender = -1; // -1 = gender will be random
+        int8 gender = -1;  // -1 = gender will be random
         if (genderArg)
         {
             std::string g = genderArg;
             std::transform(g.begin(), g.end(), g.begin(), ::tolower);
 
             if (g == "male" || g == "0")
-                gender = GENDER_MALE; // 0
+                gender = GENDER_MALE;  // 0
             else if (g == "female" || g == "1")
-                gender = GENDER_FEMALE; // 1
+                gender = GENDER_FEMALE;  // 1
             else
             {
                 messages.push_back("Unknown gender : " + g + " (male/female/0/1)");
                 return messages;
             }
-        } //end
+        }  // end
 
         if (claz == 6 && master->GetLevel() < sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL))
         {
@@ -1156,8 +1176,9 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             return messages;
         }
         uint8 teamId = master->GetTeamId(true);
-        const std::unordered_set<ObjectGuid> &guidCache = sRandomPlayerbotMgr->addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(teamId == TEAM_ALLIANCE, claz)];
-        for (const ObjectGuid &guid: guidCache)
+        const std::unordered_set<ObjectGuid>& guidCache =
+            sRandomPlayerbotMgr->addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(teamId == TEAM_ALLIANCE, claz)];
+        for (const ObjectGuid& guid : guidCache)
         {
             // If the user requested a specific gender, skip any character that doesn't match.
             if (gender != -1 && GetOfflinePlayerGender(guid) != gender)
@@ -1780,9 +1801,8 @@ void PlayerbotMgr::HandleSetSecurityKeyCommand(Player* player, const std::string
         hashedKey << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
 
     // Store the hashed key in the database
-    PlayerbotsDatabase.Execute(
-        "REPLACE INTO playerbots_account_keys (account_id, security_key) VALUES ({}, '{}')",
-        accountId, hashedKey.str());
+    PlayerbotsDatabase.Execute("REPLACE INTO playerbots_account_keys (account_id, security_key) VALUES ({}, '{}')",
+                               accountId, hashedKey.str());
 
     ChatHandler(player->GetSession()).PSendSysMessage("Security key set successfully.");
 }
@@ -1799,7 +1819,8 @@ void PlayerbotMgr::HandleLinkAccountCommand(Player* player, const std::string& a
     Field* fields = result->Fetch();
     uint32 linkedAccountId = fields[0].Get<uint32>();
 
-    result = PlayerbotsDatabase.Query("SELECT security_key FROM playerbots_account_keys WHERE account_id = {}", linkedAccountId);
+    result = PlayerbotsDatabase.Query("SELECT security_key FROM playerbots_account_keys WHERE account_id = {}",
+                                      linkedAccountId);
     if (!result)
     {
         ChatHandler(player->GetSession()).PSendSysMessage("Invalid security key.");
@@ -1825,11 +1846,11 @@ void PlayerbotMgr::HandleLinkAccountCommand(Player* player, const std::string& a
 
     uint32 accountId = player->GetSession()->GetAccountId();
     PlayerbotsDatabase.Execute(
-        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})",
-        accountId, linkedAccountId);
+        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})", accountId,
+        linkedAccountId);
     PlayerbotsDatabase.Execute(
-        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})",
-        linkedAccountId, accountId);
+        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})", linkedAccountId,
+        accountId);
 
     ChatHandler(player->GetSession()).PSendSysMessage("Account linked successfully.");
 }
@@ -1837,7 +1858,8 @@ void PlayerbotMgr::HandleLinkAccountCommand(Player* player, const std::string& a
 void PlayerbotMgr::HandleViewLinkedAccountsCommand(Player* player)
 {
     uint32 accountId = player->GetSession()->GetAccountId();
-    QueryResult result = PlayerbotsDatabase.Query("SELECT linked_account_id FROM playerbots_account_links WHERE account_id = {}", accountId);
+    QueryResult result = PlayerbotsDatabase.Query(
+        "SELECT linked_account_id FROM playerbots_account_links WHERE account_id = {}", accountId);
 
     if (!result)
     {
@@ -1878,8 +1900,10 @@ void PlayerbotMgr::HandleUnlinkAccountCommand(Player* player, const std::string&
     uint32 linkedAccountId = fields[0].Get<uint32>();
     uint32 accountId = player->GetSession()->GetAccountId();
 
-    PlayerbotsDatabase.Execute("DELETE FROM playerbots_account_links WHERE (account_id = {} AND linked_account_id = {}) OR (account_id = {} AND linked_account_id = {})",
-                                accountId, linkedAccountId, linkedAccountId, accountId);
+    PlayerbotsDatabase.Execute(
+        "DELETE FROM playerbots_account_links WHERE (account_id = {} AND linked_account_id = {}) OR (account_id = {} "
+        "AND linked_account_id = {})",
+        accountId, linkedAccountId, linkedAccountId, accountId);
 
     ChatHandler(player->GetSession()).PSendSysMessage("Account unlinked successfully.");
 }

--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "Playerbots.h"
+#include <cstdint>
+#include <unordered_set>
 
 #include "Channel.h"
 #include "Config.h"
@@ -24,12 +26,18 @@
 #include "GuildTaskMgr.h"
 #include "Metric.h"
 #include "PlayerScript.h"
+#include "GuildScript.h"
 #include "PlayerbotAIConfig.h"
 #include "RandomPlayerbotMgr.h"
 #include "ScriptMgr.h"
 #include "cs_playerbots.h"
 #include "cmath"
 #include "BattleGroundTactics.h"
+#include "PlayerGuildRegistry.h"
+#include "Log.h"
+#include "registry/PlayerGuildRegistry.h"
+#include "repository/PlayerGuildRepository.h"
+#include "Guild.h"
 
 class PlayerbotsDatabaseScript : public DatabaseScript
 {
@@ -329,6 +337,12 @@ public:
 
         LOG_INFO("server.loading", ">> Loaded playerbots config in {} ms", GetMSTimeDiffToNow(oldMSTime));
         LOG_INFO("server.loading", " ");
+
+        uint32_t beforeGuildRegistryInit = getMSTime();
+
+		sPlayerGuildRegistry.Initialize();
+
+        LOG_INFO("server.loading", ">> Initialized PlayerGuildRegistry in {} ms", GetMSTimeDiffToNow(beforeGuildRegistryInit));
     }
 };
 
@@ -459,6 +473,82 @@ public:
     void OnBattlegroundEnd(Battleground* bg, TeamId /*winnerTeam*/) override { bgStrategies.erase(bg->GetInstanceID()); }
 };
 
+class PlayerbotsGuildScript : public GuildScript
+{
+	public:
+
+	PlayerbotsGuildScript() : GuildScript("PlayerbotsGuildScript") {}
+
+	void OnAddMember(Guild* guild, Player* player, [[maybe_unused]] uint8_t& plRank)
+	{
+		if (sRandomPlayerbotMgr->IsRandomBot(player))
+			return;
+
+		uint32_t guildId = guild->GetId();
+
+		if (sPlayerGuildRegistry.Contains(guildId))
+			return;
+
+		sPlayerGuildRegistry.Add(guildId);
+
+		LOG_DEBUG("playerbots", "Added guild with id {} to PlayerGuildRegistry because it now contains a non random bot.", guildId);
+	}
+
+	/**
+	 * @brief Handles the player guilds registry maintenance when a member is removed from a guild.
+	 *
+	 * This hook is executed BEFORE the member is removed within the core. This method handles this properly and already handles
+	 * the eventual change where the hook is being ran AFTER the removal making it future-proof.
+	 */
+	void OnGuildRemoveMember(Guild* guild, Player* player)
+	{
+		if (sRandomPlayerbotMgr->IsRandomBot(player))
+			return;
+
+		uint32_t guildId = guild->GetId();
+
+		if (!sPlayerGuildRegistry.Contains(guildId))
+			return;
+
+		// This does a non prepared database query. Since this event should be quite rare, it does not need to be overly optimised for now.
+		std::unordered_set<uint64_t> memberIds = sPlayerGuildRepository.GetGuildMembersIds(guildId);
+
+		uint64_t removedCharacterId = player->GetGUID().GetRawValue();
+
+		bool noNonRandomBotMember = memberIds.empty();
+		bool removedPlayerWasLastNonBotMember = memberIds.size() == 1 && memberIds.find(removedCharacterId) != memberIds.end();
+
+		if (noNonRandomBotMember || removedPlayerWasLastNonBotMember)
+		{
+			sPlayerGuildRegistry.Remove(guildId);
+		}
+	}
+
+	void OnGuildDisband(Guild* guild)
+	{
+		uint32_t guildId = guild->GetId();
+
+		if (!sPlayerGuildRegistry.Contains(guildId))
+			return;
+
+		sPlayerGuildRegistry.Remove(guildId);
+	}
+
+	void OnGuildCreate(Guild* guild, [[maybe_unused]] Player* leader, [[maybe_unused]] const std::string& name)
+	{
+		uint32_t guildId = guild->GetId();
+
+		std::unordered_set<uint64_t> memberIds = sPlayerGuildRepository.GetGuildMembersIds(guildId);
+
+		bool nonRandomBotMember = !memberIds.empty();
+
+		if (nonRandomBotMember)
+		{
+			sPlayerGuildRegistry.Add(guildId);
+		}
+	}
+};
+
 void AddPlayerbotsScripts()
 {
     new PlayerbotsDatabaseScript();
@@ -468,6 +558,7 @@ void AddPlayerbotsScripts()
     new PlayerbotsWorldScript();
     new PlayerbotsScript();
     new PlayerBotsBGScript();
+	new PlayerbotsGuildScript();
 
     AddSC_playerbots_commandscript();
 }

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -52,6 +52,7 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "World.h"
+#include "registry/PlayerGuildRegistry.h"
 
 struct GuidClassRaceInfo
 {
@@ -60,44 +61,61 @@ struct GuidClassRaceInfo
     uint32 rRace;
 };
 
-enum class CityId : uint8 {
-    STORMWIND, IRONFORGE, DARNASSUS, EXODAR,
-    ORGRIMMAR, UNDERCITY, THUNDER_BLUFF, SILVERMOON_CITY,
-    SHATTRATH_CITY, DALARAN
+enum class CityId : uint8
+{
+    STORMWIND,
+    IRONFORGE,
+    DARNASSUS,
+    EXODAR,
+    ORGRIMMAR,
+    UNDERCITY,
+    THUNDER_BLUFF,
+    SILVERMOON_CITY,
+    SHATTRATH_CITY,
+    DALARAN
 };
 
-enum class FactionId : uint8 { ALLIANCE, HORDE, NEUTRAL };
+enum class FactionId : uint8
+{
+    ALLIANCE,
+    HORDE,
+    NEUTRAL
+};
 
 // Map of banker entry → city + faction
 static const std::unordered_map<uint16, std::pair<CityId, FactionId>> bankerToCity = {
-    {2455,  {CityId::STORMWIND,       FactionId::ALLIANCE}}, {2456,  {CityId::STORMWIND,       FactionId::ALLIANCE}}, {2457,  {CityId::STORMWIND,       FactionId::ALLIANCE}},
-    {2460,  {CityId::IRONFORGE,       FactionId::ALLIANCE}}, {2461,  {CityId::IRONFORGE,       FactionId::ALLIANCE}}, {5099,  {CityId::IRONFORGE,       FactionId::ALLIANCE}},
-    {4155,  {CityId::DARNASSUS,       FactionId::ALLIANCE}}, {4208,  {CityId::DARNASSUS,       FactionId::ALLIANCE}}, {4209,  {CityId::DARNASSUS,       FactionId::ALLIANCE}},
-    {17773, {CityId::EXODAR,          FactionId::ALLIANCE}}, {18350, {CityId::EXODAR,          FactionId::ALLIANCE}}, {16710, {CityId::EXODAR,          FactionId::ALLIANCE}},
-    {3320,  {CityId::ORGRIMMAR,       FactionId::HORDE}},    {3309,  {CityId::ORGRIMMAR,       FactionId::HORDE}},    {3318,  {CityId::ORGRIMMAR,       FactionId::HORDE}},
-    {4549,  {CityId::UNDERCITY,       FactionId::HORDE}},    {2459,  {CityId::UNDERCITY,       FactionId::HORDE}},    {2458,  {CityId::UNDERCITY,       FactionId::HORDE}},    {4550, {CityId::UNDERCITY, FactionId::HORDE}},
-    {2996,  {CityId::THUNDER_BLUFF,   FactionId::HORDE}},    {8356,  {CityId::THUNDER_BLUFF,   FactionId::HORDE}},    {8357,  {CityId::THUNDER_BLUFF,   FactionId::HORDE}},
-    {17631, {CityId::SILVERMOON_CITY, FactionId::HORDE}},    {17632, {CityId::SILVERMOON_CITY, FactionId::HORDE}},    {17633, {CityId::SILVERMOON_CITY, FactionId::HORDE}},
-    {16615, {CityId::SILVERMOON_CITY, FactionId::HORDE}},    {16616, {CityId::SILVERMOON_CITY, FactionId::HORDE}},    {16617, {CityId::SILVERMOON_CITY, FactionId::HORDE}},
-    {19246, {CityId::SHATTRATH_CITY,  FactionId::NEUTRAL}},  {19338, {CityId::SHATTRATH_CITY,  FactionId::NEUTRAL}},
-    {19034, {CityId::SHATTRATH_CITY,  FactionId::NEUTRAL}},  {19318, {CityId::SHATTRATH_CITY,  FactionId::NEUTRAL}},
-    {30604, {CityId::DALARAN,         FactionId::NEUTRAL}},  {30605, {CityId::DALARAN,         FactionId::NEUTRAL}},  {30607, {CityId::DALARAN,         FactionId::NEUTRAL}},
-    {28675, {CityId::DALARAN,         FactionId::NEUTRAL}},  {28676, {CityId::DALARAN,         FactionId::NEUTRAL}},  {28677, {CityId::DALARAN,         FactionId::NEUTRAL}}
-};
+    {2455, {CityId::STORMWIND, FactionId::ALLIANCE}},      {2456, {CityId::STORMWIND, FactionId::ALLIANCE}},
+    {2457, {CityId::STORMWIND, FactionId::ALLIANCE}},      {2460, {CityId::IRONFORGE, FactionId::ALLIANCE}},
+    {2461, {CityId::IRONFORGE, FactionId::ALLIANCE}},      {5099, {CityId::IRONFORGE, FactionId::ALLIANCE}},
+    {4155, {CityId::DARNASSUS, FactionId::ALLIANCE}},      {4208, {CityId::DARNASSUS, FactionId::ALLIANCE}},
+    {4209, {CityId::DARNASSUS, FactionId::ALLIANCE}},      {17773, {CityId::EXODAR, FactionId::ALLIANCE}},
+    {18350, {CityId::EXODAR, FactionId::ALLIANCE}},        {16710, {CityId::EXODAR, FactionId::ALLIANCE}},
+    {3320, {CityId::ORGRIMMAR, FactionId::HORDE}},         {3309, {CityId::ORGRIMMAR, FactionId::HORDE}},
+    {3318, {CityId::ORGRIMMAR, FactionId::HORDE}},         {4549, {CityId::UNDERCITY, FactionId::HORDE}},
+    {2459, {CityId::UNDERCITY, FactionId::HORDE}},         {2458, {CityId::UNDERCITY, FactionId::HORDE}},
+    {4550, {CityId::UNDERCITY, FactionId::HORDE}},         {2996, {CityId::THUNDER_BLUFF, FactionId::HORDE}},
+    {8356, {CityId::THUNDER_BLUFF, FactionId::HORDE}},     {8357, {CityId::THUNDER_BLUFF, FactionId::HORDE}},
+    {17631, {CityId::SILVERMOON_CITY, FactionId::HORDE}},  {17632, {CityId::SILVERMOON_CITY, FactionId::HORDE}},
+    {17633, {CityId::SILVERMOON_CITY, FactionId::HORDE}},  {16615, {CityId::SILVERMOON_CITY, FactionId::HORDE}},
+    {16616, {CityId::SILVERMOON_CITY, FactionId::HORDE}},  {16617, {CityId::SILVERMOON_CITY, FactionId::HORDE}},
+    {19246, {CityId::SHATTRATH_CITY, FactionId::NEUTRAL}}, {19338, {CityId::SHATTRATH_CITY, FactionId::NEUTRAL}},
+    {19034, {CityId::SHATTRATH_CITY, FactionId::NEUTRAL}}, {19318, {CityId::SHATTRATH_CITY, FactionId::NEUTRAL}},
+    {30604, {CityId::DALARAN, FactionId::NEUTRAL}},        {30605, {CityId::DALARAN, FactionId::NEUTRAL}},
+    {30607, {CityId::DALARAN, FactionId::NEUTRAL}},        {28675, {CityId::DALARAN, FactionId::NEUTRAL}},
+    {28676, {CityId::DALARAN, FactionId::NEUTRAL}},        {28677, {CityId::DALARAN, FactionId::NEUTRAL}}};
 
 // Map of city → available banker entries
 static const std::unordered_map<CityId, std::vector<uint16>> cityToBankers = {
-    {CityId::STORMWIND,       {2455, 2456, 2457}},
-    {CityId::IRONFORGE,       {2460, 2461, 5099}},
-    {CityId::DARNASSUS,       {4155, 4208, 4209}},
-    {CityId::EXODAR,          {17773, 18350, 16710}},
-    {CityId::ORGRIMMAR,       {3320, 3309, 3318}},
-    {CityId::UNDERCITY,       {4549, 2459, 2458, 4550}},
-    {CityId::THUNDER_BLUFF,   {2996, 8356, 8357}},
+    {CityId::STORMWIND, {2455, 2456, 2457}},
+    {CityId::IRONFORGE, {2460, 2461, 5099}},
+    {CityId::DARNASSUS, {4155, 4208, 4209}},
+    {CityId::EXODAR, {17773, 18350, 16710}},
+    {CityId::ORGRIMMAR, {3320, 3309, 3318}},
+    {CityId::UNDERCITY, {4549, 2459, 2458, 4550}},
+    {CityId::THUNDER_BLUFF, {2996, 8356, 8357}},
     {CityId::SILVERMOON_CITY, {17631, 17632, 17633, 16615, 16616, 16617}},
-    {CityId::SHATTRATH_CITY,  {19246, 19338, 19034, 19318}},
-    {CityId::DALARAN,         {30604, 30605, 30607, 28675, 28676, 28677, 29530}}
-};
+    {CityId::SHATTRATH_CITY, {19246, 19338, 19034, 19318}},
+    {CityId::DALARAN, {30604, 30605, 30607, 28675, 28676, 28677, 29530}}};
 
 // Quick lookup map: banker entry → location
 static std::unordered_map<uint32, WorldLocation> bankerEntryToLocation;
@@ -571,9 +589,8 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
     // First, get ALL randombot accounts from the database
     std::vector<uint32> allRandomBotAccounts;
-    QueryResult allAccounts = LoginDatabase.Query(
-        "SELECT id FROM account WHERE username LIKE '{}%%' ORDER BY id",
-        sPlayerbotAIConfig->randomBotAccountPrefix.c_str());
+    QueryResult allAccounts = LoginDatabase.Query("SELECT id FROM account WHERE username LIKE '{}%%' ORDER BY id",
+                                                  sPlayerbotAIConfig->randomBotAccountPrefix.c_str());
 
     if (allAccounts)
     {
@@ -588,7 +605,8 @@ void RandomPlayerbotMgr::AssignAccountTypes()
     LOG_INFO("playerbots", "Found {} total randombot accounts in database", allRandomBotAccounts.size());
 
     // Check existing assignments
-    QueryResult existingAssignments = PlayerbotsDatabase.Query("SELECT account_id, account_type FROM playerbots_account_type");
+    QueryResult existingAssignments =
+        PlayerbotsDatabase.Query("SELECT account_id, account_type FROM playerbots_account_type");
     std::map<uint32, uint8> currentAssignments;
 
     if (existingAssignments)
@@ -607,7 +625,10 @@ void RandomPlayerbotMgr::AssignAccountTypes()
     {
         if (currentAssignments.find(accountId) == currentAssignments.end())
         {
-            PlayerbotsDatabase.Execute("INSERT INTO playerbots_account_type (account_id, account_type) VALUES ({}, 0) ON DUPLICATE KEY UPDATE account_type = account_type", accountId);
+            PlayerbotsDatabase.Execute(
+                "INSERT INTO playerbots_account_type (account_id, account_type) VALUES ({}, 0) ON DUPLICATE KEY UPDATE "
+                "account_type = account_type",
+                accountId);
             currentAssignments[accountId] = 0;
         }
     }
@@ -625,7 +646,8 @@ void RandomPlayerbotMgr::AssignAccountTypes()
             maxBots *= sPlayerbotAIConfig->periodicOnlineOfflineRatio;
         }
 
-        // Calculate base accounts needed for RNDbots, ensuring round up for maxBots not cleanly divisible by the divisor
+        // Calculate base accounts needed for RNDbots, ensuring round up for maxBots not cleanly divisible by the
+        // divisor
         neededRndBotAccounts = (maxBots + divisor - 1) / divisor;
     }
 
@@ -635,8 +657,10 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
     for (auto const& [accountId, accountType] : currentAssignments)
     {
-        if (accountType == 1) existingRndBotAccounts++;
-        else if (accountType == 2) existingAddClassAccounts++;
+        if (accountType == 1)
+            existingRndBotAccounts++;
+        else if (accountType == 2)
+            existingAddClassAccounts++;
     }
 
     // Assign RNDbot accounts from lowest position if needed
@@ -648,9 +672,12 @@ void RandomPlayerbotMgr::AssignAccountTypes()
         for (uint32 i = 0; i < allRandomBotAccounts.size() && assigned < toAssign; i++)
         {
             uint32 accountId = allRandomBotAccounts[i];
-            if (currentAssignments[accountId] == 0) // Unassigned
+            if (currentAssignments[accountId] == 0)  // Unassigned
             {
-                PlayerbotsDatabase.Execute("UPDATE playerbots_account_type SET account_type = 1, assignment_date = NOW() WHERE account_id = {}", accountId);
+                PlayerbotsDatabase.Execute(
+                    "UPDATE playerbots_account_type SET account_type = 1, assignment_date = NOW() WHERE account_id = "
+                    "{}",
+                    accountId);
                 currentAssignments[accountId] = 1;
                 assigned++;
             }
@@ -658,7 +685,9 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
         if (assigned < toAssign)
         {
-            LOG_ERROR("playerbots", "Not enough unassigned accounts to fulfill RNDbot requirements. Need {} more accounts.", toAssign - assigned);
+            LOG_ERROR("playerbots",
+                      "Not enough unassigned accounts to fulfill RNDbot requirements. Need {} more accounts.",
+                      toAssign - assigned);
         }
     }
 
@@ -673,9 +702,12 @@ void RandomPlayerbotMgr::AssignAccountTypes()
         for (int i = allRandomBotAccounts.size() - 1; i >= 0 && assigned < toAssign; i--)
         {
             uint32 accountId = allRandomBotAccounts[i];
-            if (currentAssignments[accountId] == 0) // Unassigned
+            if (currentAssignments[accountId] == 0)  // Unassigned
             {
-                PlayerbotsDatabase.Execute("UPDATE playerbots_account_type SET account_type = 2, assignment_date = NOW() WHERE account_id = {}", accountId);
+                PlayerbotsDatabase.Execute(
+                    "UPDATE playerbots_account_type SET account_type = 2, assignment_date = NOW() WHERE account_id = "
+                    "{}",
+                    accountId);
                 currentAssignments[accountId] = 2;
                 assigned++;
             }
@@ -683,15 +715,19 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
         if (assigned < toAssign)
         {
-            LOG_ERROR("playerbots", "Not enough unassigned accounts to fulfill AddClass requirements. Need {} more accounts.", toAssign - assigned);
+            LOG_ERROR("playerbots",
+                      "Not enough unassigned accounts to fulfill AddClass requirements. Need {} more accounts.",
+                      toAssign - assigned);
         }
     }
 
     // Populate filtered account lists with ALL accounts of each type
     for (auto const& [accountId, accountType] : currentAssignments)
     {
-        if (accountType == 1) rndBotTypeAccounts.push_back(accountId);
-        else if (accountType == 2) addClassTypeAccounts.push_back(accountId);
+        if (accountType == 1)
+            rndBotTypeAccounts.push_back(accountId);
+        else if (accountType == 2)
+            addClassTypeAccounts.push_back(accountId);
     }
 
     LOG_INFO("playerbots", "Account type assignment complete: {} RNDbot accounts, {} AddClass accounts, {} unassigned",
@@ -701,7 +737,8 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
 bool RandomPlayerbotMgr::IsAccountType(uint32 accountId, uint8 accountType)
 {
-    QueryResult result = PlayerbotsDatabase.Query("SELECT 1 FROM playerbots_account_type WHERE account_id = {} AND account_type = {}", accountId, accountType);
+    QueryResult result = PlayerbotsDatabase.Query(
+        "SELECT 1 FROM playerbots_account_type WHERE account_id = {} AND account_type = {}", accountId, accountType);
     return result != nullptr;
 }
 
@@ -740,11 +777,12 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
         std::vector<uint32> accountsToUse;
         if (sPlayerbotAIConfig->enablePeriodicOnlineOffline)
         {
-
             // Calculate how many accounts can be used
-            // With enablePeriodicOnlineOffline, don't use all of rndBotTypeAccounts right away. Fraction results are rounded up
-            uint32 accountsToUseCount = (rndBotTypeAccounts.size() + sPlayerbotAIConfig->periodicOnlineOfflineRatio - 1)
-                                        / sPlayerbotAIConfig->periodicOnlineOfflineRatio;
+            // With enablePeriodicOnlineOffline, don't use all of rndBotTypeAccounts right away. Fraction results are
+            // rounded up
+            uint32 accountsToUseCount =
+                (rndBotTypeAccounts.size() + sPlayerbotAIConfig->periodicOnlineOfflineRatio - 1) /
+                sPlayerbotAIConfig->periodicOnlineOfflineRatio;
 
             // Randomly select accounts
             std::vector<uint32> shuffledAccounts = rndBotTypeAccounts;
@@ -810,8 +848,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
         // Lambda to handle bot login logic
         auto tryLoginBot = [&](const CharacterInfo& charInfo) -> bool
         {
-            if (GetEventValue(charInfo.guid, "add") ||
-                GetEventValue(charInfo.guid, "logout") ||
+            if (GetEventValue(charInfo.guid, "add") || GetEventValue(charInfo.guid, "logout") ||
                 GetPlayerBot(charInfo.guid) ||
                 std::find(currentBots.begin(), currentBots.end(), charInfo.guid) != currentBots.end() ||
                 (sPlayerbotAIConfig->disableDeathKnightLogin && charInfo.rClass == CLASS_DEATH_KNIGHT))
@@ -819,10 +856,10 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
                 return false;
             }
 
-            uint32 add_time = sPlayerbotAIConfig->enablePeriodicOnlineOffline
-                                ? urand(sPlayerbotAIConfig->minRandomBotInWorldTime,
-                                        sPlayerbotAIConfig->maxRandomBotInWorldTime)
-                                : sPlayerbotAIConfig->permanantlyInWorldTime;
+            uint32 add_time =
+                sPlayerbotAIConfig->enablePeriodicOnlineOffline
+                    ? urand(sPlayerbotAIConfig->minRandomBotInWorldTime, sPlayerbotAIConfig->maxRandomBotInWorldTime)
+                    : sPlayerbotAIConfig->permanantlyInWorldTime;
 
             SetEventValue(charInfo.guid, "add", 1, add_time);
             SetEventValue(charInfo.guid, "logout", 0, 0);
@@ -874,20 +911,22 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
             {
                 int divisor = RandomPlayerbotFactory::CalculateAvailableCharsPerAccount();
                 uint32 moreAccountsNeeded = (maxAllowedBotCount + divisor - 1) / divisor;
-                LOG_ERROR("playerbots",
-                          "Can't log-in all the requested bots. Try increasing RandomBotAccountCount in your conf file.\n"
-                          "{} more accounts needed.", moreAccountsNeeded);
-                missingBotsTimer = 0;    // Reset timer so error is not spammed every tick
+                LOG_ERROR(
+                    "playerbots",
+                    "Can't log-in all the requested bots. Try increasing RandomBotAccountCount in your conf file.\n"
+                    "{} more accounts needed.",
+                    moreAccountsNeeded);
+                missingBotsTimer = 0;  // Reset timer so error is not spammed every tick
             }
         }
         else
         {
-            missingBotsTimer = 0;       // Reset timer if logins for this interval were successful
+            missingBotsTimer = 0;  // Reset timer if logins for this interval were successful
         }
     }
     else
     {
-        missingBotsTimer = 0;           // Reset timer if there's enough bots
+        missingBotsTimer = 0;  // Reset timer if there's enough bots
     }
 
     return currentBots.size();
@@ -1517,10 +1556,64 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
     return false;
 }
 
+bool RandomPlayerbotMgr::ProcessBotRandomization(Player* bot)
+{
+	if (sPlayerbotAIConfig->disableRandomBotPeriodicRandomization)
+		return false;
+
+	uint64_t botId = bot->GetGUID().GetRawValue();
+	uint32_t botGuildId = bot->GetGuildId();
+
+	if (sPlayerGuildRegistry.Contains(botGuildId))
+	{
+        LOG_DEBUG("playerbots", "Bot #{} {}:{} <{}>: Randomization skipped because it is part of a guild with at least one non random bot.", bot->GetGUID().GetRawValue(), IsAlliance(bot->getRace()) ? "A" : "H",
+                  bot->GetLevel(), bot->GetName().c_str());
+
+		return false;
+	}
+
+    uint32_t timeUntilRandomize = GetEventValue(botId, "randomize");
+
+    if (timeUntilRandomize > 0)
+        return false;
+
+    Randomize(bot);
+
+    uint32 time = urand(sPlayerbotAIConfig->minRandomBotRandomizeTime, sPlayerbotAIConfig->maxRandomBotRandomizeTime);
+
+    ScheduleRandomize(botId, time);
+
+    return true;
+}
+
+bool RandomPlayerbotMgr::ProcessBotTeleportation(Player* bot)
+{
+	if (sPlayerbotAIConfig->disableRandomBotPeriodicTeleportation)
+		return false;
+
+	uint64_t botId = bot->GetGUID().GetRawValue();
+	uint32_t timeUntilTeleport = GetEventValue(botId, "teleport");
+
+	if (timeUntilTeleport > 0)
+		return false;
+
+	LOG_DEBUG("playerbots", "Bot #{} <{}>: teleport for level and refresh", botId, bot->GetName());
+
+	Refresh(bot);
+	RandomTeleportForLevel(bot);
+
+	uint32_t time = urand(sPlayerbotAIConfig->minRandomBotTeleportInterval,
+						sPlayerbotAIConfig->maxRandomBotTeleportInterval);
+
+	ScheduleTeleport(botId, time);
+
+	return true;
+}
+
 bool RandomPlayerbotMgr::ProcessBot(Player* bot)
 {
-
     PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
     if (!botAI)
         return false;
 
@@ -1530,7 +1623,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* bot)
     if (bot->InBattlegroundQueue())
         return false;
 
-     uint32 botId = bot->GetGUID().GetCounter();
+    uint32 botId = bot->GetGUID().GetCounter();
 
     // if death revive
     if (bot->isDead())
@@ -1539,8 +1632,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* bot)
         {
             uint32 randomTime =
                 urand(sPlayerbotAIConfig->minRandomBotReviveTime, sPlayerbotAIConfig->maxRandomBotReviveTime);
-            LOG_DEBUG("playerbots", "Mark bot {} as dead, will be revived in {}s.", bot->GetName().c_str(),
-                      randomTime);
+            LOG_DEBUG("playerbots", "Mark bot {} as dead, will be revived in {}s.", bot->GetName().c_str(), randomTime);
             SetEventValue(botId, "dead", 1, sPlayerbotAIConfig->maxRandomBotInWorldTime);
             SetEventValue(botId, "revive", 1, randomTime);
             return false;
@@ -1557,6 +1649,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* bot)
 
     // leave group if leader is rndbot
     Group* group = bot->GetGroup();
+
     if (group && !group->isLFGGroup() && IsRandomBot(group->GetLeader()))
     {
         botAI->LeaveOrDisbandGroup();
@@ -1565,6 +1658,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* bot)
 
     // only randomize and teleport idle bots
     bool idleBot = false;
+
     if (TravelTarget* target = botAI->GetAiObjectContext()->GetValue<TravelTarget*>("travel target")->Get())
     {
         if (target->getTravelState() == TravelState::TRAVEL_STATE_IDLE)
@@ -1579,59 +1673,15 @@ bool RandomPlayerbotMgr::ProcessBot(Player* bot)
 
     if (idleBot)
     {
-        // randomize
-        uint32 randomize = GetEventValue(botId, "randomize");
-        if (!randomize)
-        {
-            // bool randomiser = true;
-            // if (player->GetGuildId())
-            // {
-            //     if (Guild* guild = sGuildMgr->GetGuildById(player->GetGuildId()))
-            //     {
-            //         if (guild->GetLeaderGUID() == player->GetGUID())
-            //         {
-            //             for (std::vector<Player*>::iterator i = players.begin(); i != players.end(); ++i)
-            //                 sGuildTaskMgr->Update(*i, player);
-            //         }
+        bool hasBeenRandomized = ProcessBotRandomization(bot);
 
-            //         uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(guild->GetLeaderGUID());
-            //         if (!sPlayerbotAIConfig->IsInRandomAccountList(accountId))
-            //         {
-            //             uint8 rank = player->GetRank();
-            //             randomiser = rank < 4 ? false : true;
-            //         }
-            //     }
-            // }
-            // if (randomiser)
-            // {
-            Randomize(bot);
-            LOG_DEBUG("playerbots", "Bot #{} {}:{} <{}>: randomized", botId,
-                      bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
-            uint32 randomTime =
-                urand(sPlayerbotAIConfig->minRandomBotRandomizeTime, sPlayerbotAIConfig->maxRandomBotRandomizeTime);
-            ScheduleRandomize(botId, randomTime);
-            return true;
-        }
+		if (hasBeenRandomized)
+			return true;
 
-        // uint32 changeStrategy = GetEventValue(bot, "change_strategy");
-        // if (!changeStrategy)
-        // {
-        //     LOG_INFO("playerbots", "Changing strategy for bot  #{} <{}>", bot, player->GetName().c_str());
-        //     ChangeStrategy(player);
-        //     return true;
-        // }
+		bool hasBeenTeleported = ProcessBotTeleportation(bot);
 
-        uint32 teleport = GetEventValue(botId, "teleport");
-        if (!teleport)
-        {
-            LOG_DEBUG("playerbots", "Bot #{} <{}>: teleport for level and refresh", botId, bot->GetName());
-            Refresh(bot);
-            RandomTeleportForLevel(bot);
-            uint32 time = urand(sPlayerbotAIConfig->minRandomBotTeleportInterval,
-                                sPlayerbotAIConfig->maxRandomBotTeleportInterval);
-            ScheduleTeleport(botId, time);
-            return true;
-        }
+		if (hasBeenTeleported)
+			return true;
     }
 
     return false;
@@ -1641,7 +1691,6 @@ void RandomPlayerbotMgr::Revive(Player* player)
 {
     uint32 bot = player->GetGUID().GetCounter();
 
-    // LOG_INFO("playerbots", "Bot {} revived", player->GetName().c_str());
     SetEventValue(bot, "dead", 0, 0);
     SetEventValue(bot, "revive", 0, 0);
 
@@ -2096,17 +2145,17 @@ void RandomPlayerbotMgr::PrepareTeleportCache()
             for (int32 l = 1; l <= maxLevel; l++)
             {
                 // Bots 1-60 go to base game bankers (all have minlevel 30 or 45)
-                if (l <=60 && level > 45)
+                if (l <= 60 && level > 45)
                 {
                     continue;
                 }
                 // Bots 61-70 go to Shattrath bankers (all have minlevel 60 or 70)
-                if ((l >=61 && l <=70) && (level < 60 || level > 70))
+                if ((l >= 61 && l <= 70) && (level < 60 || level > 70))
                 {
                     continue;
                 }
                 // Bots 71+ go to Dalaran bankers (all have minlevel 75)
-                if ((l >=71) && level != 75)
+                if ((l >= 71) && level != 75)
                 {
                     continue;
                 }
@@ -2150,7 +2199,8 @@ void RandomPlayerbotMgr::PrepareAddclassCache()
         }
     }
 
-    LOG_INFO("playerbots", ">> {} characters collected for addclass command from {} AddClass accounts.", collected, addClassTypeAccounts.size());
+    LOG_INFO("playerbots", ">> {} characters collected for addclass command from {} AddClass accounts.", collected,
+             addClassTypeAccounts.size());
 }
 
 void RandomPlayerbotMgr::Init()
@@ -2198,7 +2248,8 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
         for (auto& loc : bankerLocsPerLevelCache[level])
         {
             auto cityIt = bankerToCity.find(loc.entry);
-            if (cityIt == bankerToCity.end()) continue;
+            if (cityIt == bankerToCity.end())
+                continue;
 
             CityId cityId = cityIt->second.first;
             FactionId cityFactionId = cityIt->second.second;
@@ -2225,19 +2276,42 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
             int weight = 0;
             switch (city)
             {
-                case CityId::STORMWIND:       weight = sPlayerbotAIConfig->weightTeleToStormwind; break;
-                case CityId::IRONFORGE:       weight = sPlayerbotAIConfig->weightTeleToIronforge; break;
-                case CityId::DARNASSUS:       weight = sPlayerbotAIConfig->weightTeleToDarnassus; break;
-                case CityId::EXODAR:          weight = sPlayerbotAIConfig->weightTeleToExodar; break;
-                case CityId::ORGRIMMAR:       weight = sPlayerbotAIConfig->weightTeleToOrgrimmar; break;
-                case CityId::UNDERCITY:       weight = sPlayerbotAIConfig->weightTeleToUndercity; break;
-                case CityId::THUNDER_BLUFF:   weight = sPlayerbotAIConfig->weightTeleToThunderBluff; break;
-                case CityId::SILVERMOON_CITY: weight = sPlayerbotAIConfig->weightTeleToSilvermoonCity; break;
-                case CityId::SHATTRATH_CITY:  weight = sPlayerbotAIConfig->weightTeleToShattrathCity; break;
-                case CityId::DALARAN:         weight = sPlayerbotAIConfig->weightTeleToDalaran; break;
-                default:              weight = 0; break;
+                case CityId::STORMWIND:
+                    weight = sPlayerbotAIConfig->weightTeleToStormwind;
+                    break;
+                case CityId::IRONFORGE:
+                    weight = sPlayerbotAIConfig->weightTeleToIronforge;
+                    break;
+                case CityId::DARNASSUS:
+                    weight = sPlayerbotAIConfig->weightTeleToDarnassus;
+                    break;
+                case CityId::EXODAR:
+                    weight = sPlayerbotAIConfig->weightTeleToExodar;
+                    break;
+                case CityId::ORGRIMMAR:
+                    weight = sPlayerbotAIConfig->weightTeleToOrgrimmar;
+                    break;
+                case CityId::UNDERCITY:
+                    weight = sPlayerbotAIConfig->weightTeleToUndercity;
+                    break;
+                case CityId::THUNDER_BLUFF:
+                    weight = sPlayerbotAIConfig->weightTeleToThunderBluff;
+                    break;
+                case CityId::SILVERMOON_CITY:
+                    weight = sPlayerbotAIConfig->weightTeleToSilvermoonCity;
+                    break;
+                case CityId::SHATTRATH_CITY:
+                    weight = sPlayerbotAIConfig->weightTeleToShattrathCity;
+                    break;
+                case CityId::DALARAN:
+                    weight = sPlayerbotAIConfig->weightTeleToDalaran;
+                    break;
+                default:
+                    weight = 0;
+                    break;
             }
-            if (weight <= 0) continue;
+            if (weight <= 0)
+                continue;
 
             for (int i = 0; i < weight; ++i)
             {
@@ -2260,7 +2334,7 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
         auto locIt = bankerEntryToLocation.find(selectedBankerEntry);
         if (locIt != bankerEntryToLocation.end())
         {
-            std::vector<WorldLocation> teleportTarget = { locIt->second };
+            std::vector<WorldLocation> teleportTarget = {locIt->second};
             RandomTeleport(bot, teleportTarget, true);
             return;
         }
@@ -2333,24 +2407,28 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot)
 
 void RandomPlayerbotMgr::Randomize(Player* bot)
 {
+    uint8 level = bot->GetLevel();
+
     if (bot->InBattleground())
         return;
 
     if (bot->GetLevel() < 3 || (bot->GetLevel() < 56 && bot->getClass() == CLASS_DEATH_KNIGHT))
     {
         RandomizeFirst(bot);
+
+        return;
     }
-    else if (bot->GetLevel() < sPlayerbotAIConfig->randomBotMaxLevel || !sPlayerbotAIConfig->downgradeMaxLevelBot)
+
+    if (bot->GetLevel() < sPlayerbotAIConfig->randomBotMaxLevel || !sPlayerbotAIConfig->downgradeMaxLevelBot)
     {
-        uint8 level = bot->GetLevel();
         PlayerbotFactory factory(bot, level);
+
         factory.Randomize(true);
-        // IncreaseLevel(bot);
+
+        return;
     }
-    else
-    {
-        RandomizeFirst(bot);
-    }
+
+    RandomizeFirst(bot);
 }
 
 void RandomPlayerbotMgr::IncreaseLevel(Player* bot)
@@ -2656,7 +2734,7 @@ bool RandomPlayerbotMgr::IsAddclassBot(ObjectGuid::LowType bot)
 
     // If not in cache, check the account type
     uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(guid);
-    if (accountId && IsAccountType(accountId, 2)) // Type 2 = AddClass
+    if (accountId && IsAccountType(accountId, 2))  // Type 2 = AddClass
     {
         return true;
     }
@@ -2739,21 +2817,6 @@ uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, std::string const event)
     }
 
     CachedEvent& e = eventCache[bot][event];
-    /*if (e.IsEmpty())
-    {
-        QueryResult results = PlayerbotsDatabase.Query("SELECT `value`, `time`, validIn, `data` FROM
-    playerbots_random_bots WHERE owner = 0 AND bot = {} AND event = {}", bot, event.c_str());
-
-        if (results)
-        {
-            Field* fields = results->Fetch();
-            e.value = fields[0].Get<uint32>();
-            e.lastChangeTime = fields[1].Get<uint32>();
-            e.validIn = fields[2].Get<uint32>();
-            e.data = fields[3].Get<std::string>();
-        }
-    }
-    */
 
     if ((time(0) - e.lastChangeTime) >= e.validIn && event != "specNo" && event != "specLink")
         e.value = 0;

--- a/src/RandomPlayerbotMgr.h
+++ b/src/RandomPlayerbotMgr.h
@@ -177,13 +177,15 @@ public:
     std::map<uint8, std::vector<WorldLocation>> hordeStarterPerLevelCache;
     std::vector<uint32> allianceFlightMasterCache;
     std::vector<uint32> hordeFlightMasterCache;
-    struct LevelBracket {
+    struct LevelBracket
+    {
         uint32 low;
         uint32 high;
         bool InsideBracket(uint32 val) { return val >= low && val <= high; }
     };
     std::map<uint32, LevelBracket> zone2LevelBracket;
-    struct BankerLocation {
+    struct BankerLocation
+    {
         WorldLocation loc;
         uint32 entry;
     };
@@ -217,6 +219,8 @@ private:
     time_t printStatsTimer;
     uint32 AddRandomBots();
     bool ProcessBot(uint32 bot);
+	bool ProcessBotRandomization(Player* bot);
+	bool ProcessBotTeleportation(Player* bot);
     void ScheduleRandomize(uint32 bot, uint32 time);
     void RandomTeleport(Player* bot);
     void RandomTeleport(Player* bot, std::vector<WorldLocation>& locs, bool hearth = false);
@@ -234,10 +238,8 @@ private:
     uint32 playersLevel;
 
     // Account lists
-    std::vector<uint32> rndBotTypeAccounts;             // Accounts marked as RNDbot (type 1)
-    std::vector<uint32> addClassTypeAccounts;           // Accounts marked as AddClass (type 2)
-
-    //void ScaleBotActivity();      // Deprecated function
+    std::vector<uint32> rndBotTypeAccounts;    // Accounts marked as RNDbot (type 1)
+    std::vector<uint32> addClassTypeAccounts;  // Accounts marked as AddClass (type 2)
 };
 
 #define sRandomPlayerbotMgr RandomPlayerbotMgr::instance()

--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -10,6 +10,7 @@
 
 #include "AccountMgr.h"
 #include "AiFactory.h"
+#include "AiObjectContext.h"
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "DBCStores.h"
@@ -17,6 +18,7 @@
 #include "GuildMgr.h"
 #include "InventoryAction.h"
 #include "Item.h"
+#include "ItemPackets.h"
 #include "ItemTemplate.h"
 #include "ItemVisitors.h"
 #include "Log.h"
@@ -39,16 +41,16 @@
 #include "SpellAuraDefines.h"
 #include "StatsWeightCalculator.h"
 #include "World.h"
-#include "AiObjectContext.h"
-#include "ItemPackets.h"
 
 const uint64 diveMask = (1LL << 7) | (1LL << 44) | (1LL << 37) | (1LL << 38) | (1LL << 26) | (1LL << 30) | (1LL << 27) |
                         (1LL << 33) | (1LL << 24) | (1LL << 34);
 
-static std::vector<uint32> initSlotsOrder = {EQUIPMENT_SLOT_TRINKET1, EQUIPMENT_SLOT_TRINKET2, EQUIPMENT_SLOT_MAINHAND,
-    EQUIPMENT_SLOT_OFFHAND, EQUIPMENT_SLOT_RANGED, EQUIPMENT_SLOT_HEAD, EQUIPMENT_SLOT_SHOULDERS, EQUIPMENT_SLOT_CHEST,
-    EQUIPMENT_SLOT_LEGS, EQUIPMENT_SLOT_HANDS, EQUIPMENT_SLOT_NECK, EQUIPMENT_SLOT_BODY, EQUIPMENT_SLOT_WAIST,
-    EQUIPMENT_SLOT_FEET, EQUIPMENT_SLOT_WRISTS, EQUIPMENT_SLOT_FINGER1, EQUIPMENT_SLOT_FINGER2, EQUIPMENT_SLOT_BACK};
+static std::vector<uint32> initSlotsOrder = {EQUIPMENT_SLOT_TRINKET1,  EQUIPMENT_SLOT_TRINKET2, EQUIPMENT_SLOT_MAINHAND,
+                                             EQUIPMENT_SLOT_OFFHAND,   EQUIPMENT_SLOT_RANGED,   EQUIPMENT_SLOT_HEAD,
+                                             EQUIPMENT_SLOT_SHOULDERS, EQUIPMENT_SLOT_CHEST,    EQUIPMENT_SLOT_LEGS,
+                                             EQUIPMENT_SLOT_HANDS,     EQUIPMENT_SLOT_NECK,     EQUIPMENT_SLOT_BODY,
+                                             EQUIPMENT_SLOT_WAIST,     EQUIPMENT_SLOT_FEET,     EQUIPMENT_SLOT_WRISTS,
+                                             EQUIPMENT_SLOT_FINGER1,   EQUIPMENT_SLOT_FINGER2,  EQUIPMENT_SLOT_BACK};
 
 uint32 PlayerbotFactory::tradeSkills[] = {SKILL_ALCHEMY,        SKILL_ENCHANTING,  SKILL_SKINNING,  SKILL_TAILORING,
                                           SKILL_LEATHERWORKING, SKILL_ENGINEERING, SKILL_HERBALISM, SKILL_MINING,
@@ -124,17 +126,17 @@ void PlayerbotFactory::Init()
         if (id == 47181 || id == 50358 || id == 47242 || id == 52639 || id == 47147 || id == 7218)  // Test Enchant
             continue;
 
-        if (id == 15463 || id == 15490) // Legendary Arcane Amalgamation
+        if (id == 15463 || id == 15490)  // Legendary Arcane Amalgamation
             continue;
 
-        if (id == 29467 || id == 29475 || id == 29480 || id == 29483) // Naxx40 Sapphiron Shoulder Enchants
+        if (id == 29467 || id == 29475 || id == 29480 || id == 29483)  // Naxx40 Sapphiron Shoulder Enchants
             continue;
 
         SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(id);
         if (!spellInfo)
             continue;
 
-        //uint32 requiredLevel = spellInfo->BaseLevel; //not used, line marked for removal.
+        // uint32 requiredLevel = spellInfo->BaseLevel; //not used, line marked for removal.
 
         for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
         {
@@ -187,7 +189,7 @@ void PlayerbotFactory::Init()
 
         if (sRandomItemMgr->IsTestItem(gemId))
         {
-           continue;
+            continue;
         }
 
         if (!sGemPropertiesStore.LookupEntry(proto->GemProperties))
@@ -231,7 +233,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     //     return;
     // }
     LOG_DEBUG("playerbots", "{} randomizing {} (level {} class = {})...", (incremental ? "Incremental" : "Full"),
-             bot->GetName().c_str(), level, bot->getClass());
+              bot->GetName().c_str(), level, bot->getClass());
     // LOG_DEBUG("playerbots", "Preparing to {} randomize...", (incremental ? "incremental" : "full"));
     Prepare();
     LOG_DEBUG("playerbots", "Resetting player...");
@@ -481,6 +483,9 @@ void PlayerbotFactory::Randomize(bool incremental)
     bot->SetPower(POWER_MANA, bot->GetMaxPower(POWER_MANA));
     bot->SaveToDB(false, false);
     LOG_DEBUG("playerbots", "Initialization Done.");
+
+    LOG_DEBUG("playerbots", "Bot #{} {}:{} <{}>: randomized", bot->GetGUID().GetRawValue(),
+              bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
     if (pmo)
         pmo->finish();
 }
@@ -537,7 +542,8 @@ void PlayerbotFactory::InitConsumables()
             // Discipline or Holy: Mana Oil
             if (specTab == 0 || specTab == 1)
             {
-                std::vector<uint32> mana_oils = {BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL, MINOR_MANA_OIL};
+                std::vector<uint32> mana_oils = {BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL,
+                                                 MINOR_MANA_OIL};
                 for (uint32 itemId : mana_oils)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -550,7 +556,8 @@ void PlayerbotFactory::InitConsumables()
             // Shadow: Wizard Oil
             if (specTab == 2)
             {
-                std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL, LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
+                std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL,
+                                                   LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
                 for (uint32 itemId : wizard_oils)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -565,7 +572,8 @@ void PlayerbotFactory::InitConsumables()
         case CLASS_MAGE:
         {
             // Always Wizard Oil
-            std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL, LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
+            std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL, LESSER_WIZARD_OIL,
+                                               MINOR_WIZARD_OIL};
             for (uint32 itemId : wizard_oils)
             {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -581,7 +589,8 @@ void PlayerbotFactory::InitConsumables()
             // Balance: Wizard Oil
             if (specTab == 0)
             {
-                std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL, LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
+                std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL,
+                                                   LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
                 for (uint32 itemId : wizard_oils)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -594,8 +603,13 @@ void PlayerbotFactory::InitConsumables()
             // Feral: Sharpening Stones & Weightstones
             else if (specTab == 1)
             {
-                std::vector<uint32> sharpening_stones = {ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE, DENSE_SHARPENING_STONE, SOLID_SHARPENING_STONE, HEAVY_SHARPENING_STONE, COARSE_SHARPENING_STONE, ROUGH_SHARPENING_STONE};
-                std::vector<uint32> weightstones = {ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE, DENSE_WEIGHTSTONE, SOLID_WEIGHTSTONE, HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE, ROUGH_WEIGHTSTONE};
+                std::vector<uint32> sharpening_stones = {ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE,
+                                                         DENSE_SHARPENING_STONE,      SOLID_SHARPENING_STONE,
+                                                         HEAVY_SHARPENING_STONE,      COARSE_SHARPENING_STONE,
+                                                         ROUGH_SHARPENING_STONE};
+                std::vector<uint32> weightstones = {ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE,   DENSE_WEIGHTSTONE,
+                                                    SOLID_WEIGHTSTONE,      HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE,
+                                                    ROUGH_WEIGHTSTONE};
                 for (uint32 itemId : sharpening_stones)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -616,7 +630,8 @@ void PlayerbotFactory::InitConsumables()
             // Restoration: Mana Oil
             else if (specTab == 2)
             {
-                std::vector<uint32> mana_oils = {BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL, MINOR_MANA_OIL};
+                std::vector<uint32> mana_oils = {BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL,
+                                                 MINOR_MANA_OIL};
                 for (uint32 itemId : mana_oils)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -633,7 +648,8 @@ void PlayerbotFactory::InitConsumables()
             // Holy: Mana Oil
             if (specTab == 0)
             {
-                std::vector<uint32> mana_oils = {BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL, MINOR_MANA_OIL};
+                std::vector<uint32> mana_oils = {BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL,
+                                                 MINOR_MANA_OIL};
                 for (uint32 itemId : mana_oils)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -646,7 +662,8 @@ void PlayerbotFactory::InitConsumables()
             // Protection: Wizard Oil (Protection prioritizes Superior over Brilliant)
             else if (specTab == 1)
             {
-                std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL, LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
+                std::vector<uint32> wizard_oils = {BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL,
+                                                   LESSER_WIZARD_OIL, MINOR_WIZARD_OIL};
                 for (uint32 itemId : wizard_oils)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -659,8 +676,13 @@ void PlayerbotFactory::InitConsumables()
             // Retribution: Sharpening Stones & Weightstones
             else if (specTab == 2)
             {
-                std::vector<uint32> sharpening_stones = {ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE, DENSE_SHARPENING_STONE, SOLID_SHARPENING_STONE, HEAVY_SHARPENING_STONE, COARSE_SHARPENING_STONE, ROUGH_SHARPENING_STONE};
-                std::vector<uint32> weightstones = {ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE, DENSE_WEIGHTSTONE, SOLID_WEIGHTSTONE, HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE, ROUGH_WEIGHTSTONE};
+                std::vector<uint32> sharpening_stones = {ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE,
+                                                         DENSE_SHARPENING_STONE,      SOLID_SHARPENING_STONE,
+                                                         HEAVY_SHARPENING_STONE,      COARSE_SHARPENING_STONE,
+                                                         ROUGH_SHARPENING_STONE};
+                std::vector<uint32> weightstones = {ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE,   DENSE_WEIGHTSTONE,
+                                                    SOLID_WEIGHTSTONE,      HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE,
+                                                    ROUGH_WEIGHTSTONE};
                 for (uint32 itemId : sharpening_stones)
                 {
                     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -684,8 +706,12 @@ void PlayerbotFactory::InitConsumables()
         case CLASS_HUNTER:
         {
             // Sharpening Stones & Weightstones
-            std::vector<uint32> sharpening_stones = {ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE, DENSE_SHARPENING_STONE, SOLID_SHARPENING_STONE, HEAVY_SHARPENING_STONE, COARSE_SHARPENING_STONE, ROUGH_SHARPENING_STONE};
-            std::vector<uint32> weightstones = {ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE, DENSE_WEIGHTSTONE, SOLID_WEIGHTSTONE, HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE, ROUGH_WEIGHTSTONE};
+            std::vector<uint32> sharpening_stones = {
+                ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE,    DENSE_SHARPENING_STONE, SOLID_SHARPENING_STONE,
+                HEAVY_SHARPENING_STONE,      COARSE_SHARPENING_STONE, ROUGH_SHARPENING_STONE};
+            std::vector<uint32> weightstones = {ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE,   DENSE_WEIGHTSTONE,
+                                                SOLID_WEIGHTSTONE,      HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE,
+                                                ROUGH_WEIGHTSTONE};
             for (uint32 itemId : sharpening_stones)
             {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -707,8 +733,12 @@ void PlayerbotFactory::InitConsumables()
         case CLASS_ROGUE:
         {
             // Poisons
-            std::vector<uint32> instant_poisons = {INSTANT_POISON_IX, INSTANT_POISON_VIII, INSTANT_POISON_VII, INSTANT_POISON_VI, INSTANT_POISON_V, INSTANT_POISON_IV, INSTANT_POISON_III, INSTANT_POISON_II, INSTANT_POISON};
-            std::vector<uint32> deadly_poisons = {DEADLY_POISON_IX, DEADLY_POISON_VIII, DEADLY_POISON_VII, DEADLY_POISON_VI, DEADLY_POISON_V, DEADLY_POISON_IV, DEADLY_POISON_III, DEADLY_POISON_II, DEADLY_POISON};
+            std::vector<uint32> instant_poisons = {INSTANT_POISON_IX,  INSTANT_POISON_VIII, INSTANT_POISON_VII,
+                                                   INSTANT_POISON_VI,  INSTANT_POISON_V,    INSTANT_POISON_IV,
+                                                   INSTANT_POISON_III, INSTANT_POISON_II,   INSTANT_POISON};
+            std::vector<uint32> deadly_poisons = {DEADLY_POISON_IX,  DEADLY_POISON_VIII, DEADLY_POISON_VII,
+                                                  DEADLY_POISON_VI,  DEADLY_POISON_V,    DEADLY_POISON_IV,
+                                                  DEADLY_POISON_III, DEADLY_POISON_II,   DEADLY_POISON};
             for (uint32 itemId : deadly_poisons)
             {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -953,7 +983,7 @@ void PlayerbotFactory::InitPet()
             uint32 pet_number = sObjectMgr->GeneratePetNumber();
             if (bot->GetPetStable() && bot->GetPetStable()->CurrentPet)
             {
-                auto petGuid = bot->GetPetStable()->CurrentPet.value(); // To correct the build warnin in VS
+                auto petGuid = bot->GetPetStable()->CurrentPet.value();  // To correct the build warnin in VS
                 // bot->GetPetStable()->CurrentPet.value();
                 // bot->GetPetStable()->CurrentPet.reset();
                 bot->RemovePet(nullptr, PET_SAVE_AS_CURRENT);
@@ -1066,7 +1096,7 @@ void PlayerbotFactory::ClearSpells()
     for (PlayerSpellMap::iterator itr = bot->GetSpellMap().begin(); itr != bot->GetSpellMap().end(); ++itr)
     {
         uint32 spellId = itr->first;
-        //const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spellId); //not used, line marked for removal.
+        // const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spellId); //not used, line marked for removal.
         if (itr->second->State == PLAYERSPELL_REMOVED)
         {
             continue;
@@ -1098,7 +1128,6 @@ void PlayerbotFactory::ResetQuests()
 
         bot->RemoveRewardedQuest(entry);
         bot->RemoveActiveQuest(entry, false);
-
     }
 }
 
@@ -1709,7 +1738,8 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
     if (level < 5)
     {
         // original items
-        if (CharStartOutfitEntry const* oEntry = GetCharStartOutfitEntry(bot->getRace(), bot->getClass(), bot->getGender()))
+        if (CharStartOutfitEntry const* oEntry =
+                GetCharStartOutfitEntry(bot->getRace(), bot->getClass(), bot->getGender()))
         {
             for (int j = 0; j < MAX_OUTFIT_ITEMS; ++j)
             {
@@ -2352,7 +2382,7 @@ void PlayerbotFactory::UpdateTradeSkills()
 
 void PlayerbotFactory::InitSkills()
 {
-    //uint32 maxValue = level * 5; //not used, line marked for removal.
+    // uint32 maxValue = level * 5; //not used, line marked for removal.
     bot->UpdateSkillsForLevel();
 
     bot->SetSkill(SKILL_RIDING, 0, 0, 0);
@@ -2509,7 +2539,7 @@ void PlayerbotFactory::SetRandomSkill(uint16 id)
 
     // uint32 value = urand(maxValue - level, maxValue);
     uint32 value = maxValue;
-    //uint32 curValue = bot->GetSkillValue(id); //not used, line marked for removal.
+    // uint32 curValue = bot->GetSkillValue(id); //not used, line marked for removal.
 
     uint16 step = bot->GetSkillValue(id) ? bot->GetSkillStep(id) : 1;
 
@@ -2812,10 +2842,12 @@ void PlayerbotFactory::InitTalentsByTemplate(uint32 specTab)
         for (std::vector<uint32>& p : sPlayerbotAIConfig->parsedSpecLinkOrder[cls][specIndex][level])
         {
             uint32 tab = p[0], row = p[1], col = p[2], lvl = p[3];
-            if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 60 && (row > 6 || (row == 6 && col != 1)))
+            if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 60 &&
+                (row > 6 || (row == 6 && col != 1)))
                 continue;
 
-            if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 70 && (row > 8 || (row == 8 && col != 1)))
+            if (sPlayerbotAIConfig->limitTalentsExpansion && bot->GetLevel() <= 70 &&
+                (row > 8 || (row == 8 && col != 1)))
                 continue;
 
             uint32 talentID = 0;
@@ -3323,45 +3355,45 @@ void PlayerbotFactory::InitReagents()
     switch (bot->getClass())
     {
         case CLASS_DEATH_KNIGHT:
-        if (level >= 56)
-                items.push_back({37201, 40});   // Corpse Dust
+            if (level >= 56)
+                items.push_back({37201, 40});  // Corpse Dust
             break;
         case CLASS_DRUID:
             if (level >= 20 && level < 30)
-                items.push_back({17034, 20});   // Maple Seed
+                items.push_back({17034, 20});  // Maple Seed
             else if (level >= 30 && level < 40)
-                items.push_back({17035, 20});   // Stranglethorn Seed
+                items.push_back({17035, 20});  // Stranglethorn Seed
             else if (level >= 40 && level < 50)
-                items.push_back({17036, 20});   // Ashwood Seed
+                items.push_back({17036, 20});  // Ashwood Seed
             else if (level >= 50 && level < 60)
             {
-                items.push_back({17037, 20});   // Hornbeam Seed
-                items.push_back({17021, 20});   // Wild Berries
+                items.push_back({17037, 20});  // Hornbeam Seed
+                items.push_back({17021, 20});  // Wild Berries
             }
             else if (level >= 60 && level < 69)
             {
-                items.push_back({17038, 20});   // Ironwood Seed
-                items.push_back({17026, 20});   // Wild Thornroot
+                items.push_back({17038, 20});  // Ironwood Seed
+                items.push_back({17026, 20});  // Wild Thornroot
             }
             else if (level == 69)
             {
-                items.push_back({22147, 20});   // Flintweed Seed
-                items.push_back({17026, 20});   // Wild Thornroot
+                items.push_back({22147, 20});  // Flintweed Seed
+                items.push_back({17026, 20});  // Wild Thornroot
             }
             else if (level >= 70 && level < 79)
             {
-                items.push_back({22147, 20});   // Flintweed Seed
-                items.push_back({22148, 20});   // Wild Quillvine
+                items.push_back({22147, 20});  // Flintweed Seed
+                items.push_back({22148, 20});  // Wild Quillvine
             }
             else if (level == 79)
             {
-                items.push_back({44614, 20});   // Starleaf Seed
-                items.push_back({22148, 20});   // Wild Quillvine
+                items.push_back({44614, 20});  // Starleaf Seed
+                items.push_back({22148, 20});  // Wild Quillvine
             }
             else if (level >= 80)
             {
-                items.push_back({44614, 20});   // Starleaf Seed
-                items.push_back({44605, 20});   // Wild Spineleaf
+                items.push_back({44614, 20});  // Starleaf Seed
+                items.push_back({44605, 20});  // Wild Spineleaf
             }
             break;
         case CLASS_MAGE:
@@ -3374,7 +3406,7 @@ void PlayerbotFactory::InitReagents()
             break;
         case CLASS_PALADIN:
             if (level >= 52)
-                items.push_back({21177, 80});   // Symbol of Kings
+                items.push_back({21177, 80});  // Symbol of Kings
             break;
         case CLASS_PRIEST:
             if (level >= 48 && level < 56)
@@ -3403,7 +3435,7 @@ void PlayerbotFactory::InitReagents()
                 items.push_back({5177, 1});  // Water Totem
             if (level >= 30)
             {
-                items.push_back({5178, 1});  // Air Totem
+                items.push_back({5178, 1});    // Air Totem
                 items.push_back({17030, 20});  // Ankh
             }
             break;
@@ -3421,7 +3453,7 @@ void PlayerbotFactory::InitReagents()
     }
 }
 
-void PlayerbotFactory::CleanupConsumables() // remove old consumables as part of randombot level-up maintenance
+void PlayerbotFactory::CleanupConsumables()  // remove old consumables as part of randombot level-up maintenance
 {
     std::vector<Item*> itemsToDelete;
 
@@ -3439,7 +3471,8 @@ void PlayerbotFactory::CleanupConsumables() // remove old consumables as part of
     for (Item* item : items)
     {
         ItemTemplate const* proto = item->GetTemplate();
-        if (!proto) continue;
+        if (!proto)
+            continue;
 
         // Remove ammo
         if (proto->Class == ITEM_CLASS_PROJECTILE)
@@ -3454,27 +3487,58 @@ void PlayerbotFactory::CleanupConsumables() // remove old consumables as part of
             itemsToDelete.push_back(item);
 
         // Remove reagents
-        if (proto->Class == ITEM_CLASS_REAGENT || (proto->Class == ITEM_CLASS_MISC && proto->SubClass == ITEM_SUBCLASS_REAGENT))
+        if (proto->Class == ITEM_CLASS_REAGENT ||
+            (proto->Class == ITEM_CLASS_MISC && proto->SubClass == ITEM_SUBCLASS_REAGENT))
             itemsToDelete.push_back(item);
     }
 
-    std::set<uint32> idsToDelete = {
-        BRILLIANT_MANA_OIL, SUPERIOR_MANA_OIL, LESSER_MANA_OIL, MINOR_MANA_OIL,
-        BRILLIANT_WIZARD_OIL, SUPERIOR_WIZARD_OIL, WIZARD_OIL, LESSER_WIZARD_OIL, MINOR_WIZARD_OIL,
-        ADAMANTITE_SHARPENING_STONE, FEL_SHARPENING_STONE, DENSE_SHARPENING_STONE, SOLID_SHARPENING_STONE,
-        HEAVY_SHARPENING_STONE, COARSE_SHARPENING_STONE, ROUGH_SHARPENING_STONE,
-        ADAMANTITE_WEIGHTSTONE, FEL_WEIGHTSTONE, DENSE_WEIGHTSTONE, SOLID_WEIGHTSTONE,
-        HEAVY_WEIGHTSTONE, COARSE_WEIGHTSTONE, ROUGH_WEIGHTSTONE,
-        INSTANT_POISON_IX, INSTANT_POISON_VIII, INSTANT_POISON_VII, INSTANT_POISON_VI, INSTANT_POISON_V,
-        INSTANT_POISON_IV, INSTANT_POISON_III, INSTANT_POISON_II, INSTANT_POISON,
-        DEADLY_POISON_IX, DEADLY_POISON_VIII, DEADLY_POISON_VII, DEADLY_POISON_VI, DEADLY_POISON_V,
-        DEADLY_POISON_IV, DEADLY_POISON_III, DEADLY_POISON_II, DEADLY_POISON
-    };
+    std::set<uint32> idsToDelete = {BRILLIANT_MANA_OIL,
+                                    SUPERIOR_MANA_OIL,
+                                    LESSER_MANA_OIL,
+                                    MINOR_MANA_OIL,
+                                    BRILLIANT_WIZARD_OIL,
+                                    SUPERIOR_WIZARD_OIL,
+                                    WIZARD_OIL,
+                                    LESSER_WIZARD_OIL,
+                                    MINOR_WIZARD_OIL,
+                                    ADAMANTITE_SHARPENING_STONE,
+                                    FEL_SHARPENING_STONE,
+                                    DENSE_SHARPENING_STONE,
+                                    SOLID_SHARPENING_STONE,
+                                    HEAVY_SHARPENING_STONE,
+                                    COARSE_SHARPENING_STONE,
+                                    ROUGH_SHARPENING_STONE,
+                                    ADAMANTITE_WEIGHTSTONE,
+                                    FEL_WEIGHTSTONE,
+                                    DENSE_WEIGHTSTONE,
+                                    SOLID_WEIGHTSTONE,
+                                    HEAVY_WEIGHTSTONE,
+                                    COARSE_WEIGHTSTONE,
+                                    ROUGH_WEIGHTSTONE,
+                                    INSTANT_POISON_IX,
+                                    INSTANT_POISON_VIII,
+                                    INSTANT_POISON_VII,
+                                    INSTANT_POISON_VI,
+                                    INSTANT_POISON_V,
+                                    INSTANT_POISON_IV,
+                                    INSTANT_POISON_III,
+                                    INSTANT_POISON_II,
+                                    INSTANT_POISON,
+                                    DEADLY_POISON_IX,
+                                    DEADLY_POISON_VIII,
+                                    DEADLY_POISON_VII,
+                                    DEADLY_POISON_VI,
+                                    DEADLY_POISON_V,
+                                    DEADLY_POISON_IV,
+                                    DEADLY_POISON_III,
+                                    DEADLY_POISON_II,
+                                    DEADLY_POISON};
 
     for (Item* item : items)
     {
         ItemTemplate const* proto = item->GetTemplate();
-        if (!proto) continue;
+        if (!proto)
+            continue;
 
         if (idsToDelete.find(proto->ItemId) != idsToDelete.end())
             itemsToDelete.push_back(item);
@@ -3487,9 +3551,8 @@ void PlayerbotFactory::CleanupConsumables() // remove old consumables as part of
 void PlayerbotFactory::InitGlyphs(bool increment)
 {
     bot->InitGlyphsForLevel();
-    if (!increment && botAI &&
-        botAI->GetAiObjectContext()->GetValue<bool>("custom_glyphs")->Get())
-        return;   // // Added for custom Glyphs - custom glyphs flag test
+    if (!increment && botAI && botAI->GetAiObjectContext()->GetValue<bool>("custom_glyphs")->Get())
+        return;  // // Added for custom Glyphs - custom glyphs flag test
 
     if (!increment)
     {
@@ -3586,7 +3649,8 @@ void PlayerbotFactory::InitGlyphs(bool increment)
         // Marksmanship PvP (spec index 4): If the bot has the Concussive Barrage talent
         else if (bot->HasAura(35102))
             tab = 4;
-        // Survival PvP (spec index 5): If the bot has the Entrapment talent and does NOT have the Concussive Barrage talent
+        // Survival PvP (spec index 5): If the bot has the Entrapment talent and does NOT have the Concussive Barrage
+        // talent
         else if (bot->HasAura(19388) && !bot->HasAura(35102))
             tab = 5;
     }
@@ -3703,7 +3767,7 @@ void PlayerbotFactory::InitGlyphs(bool increment)
     ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
     for (ItemTemplateContainer::const_iterator i = itemTemplates->begin(); i != itemTemplates->end(); ++i)
     {
-        //uint32 itemId = i->first; //not used, line marked for removal.
+        // uint32 itemId = i->first; //not used, line marked for removal.
         ItemTemplate const* proto = &i->second;
         if (!proto)
             continue;
@@ -3803,9 +3867,9 @@ void PlayerbotFactory::InitGlyphs(bool increment)
                 ids.push_back(id);
             }
 
-            //int maxCount = urand(0, 3); //not used, line marked for removal.
-            //int count = 0; //not used, line marked for removal.
-            //bool found = false; //not used, line marked for removal.
+            // int maxCount = urand(0, 3); //not used, line marked for removal.
+            // int count = 0; //not used, line marked for removal.
+            // bool found = false; //not used, line marked for removal.
             for (int attempts = 0; attempts < 15; ++attempts)
             {
                 uint32 index = urand(0, ids.size() - 1);
@@ -3823,7 +3887,7 @@ void PlayerbotFactory::InitGlyphs(bool increment)
                                                 ~(TRIGGERED_IGNORE_SHAPESHIFT | TRIGGERED_IGNORE_CASTER_AURASTATE)));
 
                 bot->SetGlyph(realSlot, id, true);
-                //found = true; //not used, line marked for removal.
+                // found = true; //not used, line marked for removal.
                 break;
             }
         }
@@ -3870,7 +3934,7 @@ void PlayerbotFactory::InitInventorySkill()
 
 Item* PlayerbotFactory::StoreItem(uint32 itemId, uint32 count)
 {
-    //ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId); //not used, line marked for removal.
+    // ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId); //not used, line marked for removal.
     ItemPosCountVec sDest;
     InventoryResult msg = bot->CanStoreNewItem(INVENTORY_SLOT_BAG_0, NULL_SLOT, sDest, itemId, count);
     if (msg != EQUIP_ERR_OK)
@@ -4293,8 +4357,8 @@ void PlayerbotFactory::ApplyEnchantTemplate(uint8 spec)
 
 void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destroyOld)
 {
-    //int32 bestGemEnchantId[4] = {-1, -1, -1, -1};  // 1, 2, 4, 8 color //not used, line marked for removal.
-    //float bestGemScore[4] = {0, 0, 0, 0}; //not used, line marked for removal.
+    // int32 bestGemEnchantId[4] = {-1, -1, -1, -1};  // 1, 2, 4, 8 color //not used, line marked for removal.
+    // float bestGemScore[4] = {0, 0, 0, 0}; //not used, line marked for removal.
     std::vector<uint32> curCount = GetCurrentGemsCount();
     uint8 jewelersCount = 0;
     int requiredActive = 2;
@@ -4453,7 +4517,8 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destroyOld)
                 if (!enchant_id)
                     continue;
 
-                //SpellItemEnchantmentEntry const* enchant = sSpellItemEnchantmentStore.LookupEntry(enchant_id); //not used, line marked for removal.
+                // SpellItemEnchantmentEntry const* enchant = sSpellItemEnchantmentStore.LookupEntry(enchant_id); //not
+                // used, line marked for removal.
                 StatsWeightCalculator calculator(bot);
                 float score = calculator.CalculateEnchant(enchant_id);
                 if (curCount[0] != 0)
@@ -4669,25 +4734,27 @@ void PlayerbotFactory::InitKeyring()
     if (bot->GetLevel() < 70)
         return;
 
-    ReputationMgr& repMgr = bot->GetReputationMgr(); // Reference, use . instead of ->
+    ReputationMgr& repMgr = bot->GetReputationMgr();  // Reference, use . instead of ->
 
     std::vector<std::pair<uint32, uint32>> keysToCheck;
 
     // Reputation-based Keys (Honored requirement)
     if (repMgr.GetRank(sFactionStore.LookupEntry(1011)) >= REP_HONORED && !bot->HasItemCount(30633, 1))
-        keysToCheck.emplace_back(1011, 30633); // Lower City - Auchenai Key
+        keysToCheck.emplace_back(1011, 30633);  // Lower City - Auchenai Key
     if (repMgr.GetRank(sFactionStore.LookupEntry(942)) >= REP_HONORED && !bot->HasItemCount(30623, 1))
-        keysToCheck.emplace_back(942, 30623); // Cenarion Expedition - Reservoir Key
+        keysToCheck.emplace_back(942, 30623);  // Cenarion Expedition - Reservoir Key
     if (repMgr.GetRank(sFactionStore.LookupEntry(989)) >= REP_HONORED && !bot->HasItemCount(30635, 1))
-        keysToCheck.emplace_back(989, 30635); // Keepers of Time - Key of Time
+        keysToCheck.emplace_back(989, 30635);  // Keepers of Time - Key of Time
     if (repMgr.GetRank(sFactionStore.LookupEntry(935)) >= REP_HONORED && !bot->HasItemCount(30634, 1))
-        keysToCheck.emplace_back(935, 30634); // The Sha'tar - Warpforged Key
+        keysToCheck.emplace_back(935, 30634);  // The Sha'tar - Warpforged Key
 
     // Faction-specific Keys (Honored requirement)
-    if (bot->GetTeamId() == TEAM_ALLIANCE && repMgr.GetRank(sFactionStore.LookupEntry(946)) >= REP_HONORED && !bot->HasItemCount(30622, 1))
-        keysToCheck.emplace_back(946, 30622); // Honor Hold - Flamewrought Key (Alliance)
-    if (bot->GetTeamId() == TEAM_HORDE && repMgr.GetRank(sFactionStore.LookupEntry(947)) >= REP_HONORED && !bot->HasItemCount(30637, 1))
-        keysToCheck.emplace_back(947, 30637); // Thrallmar - Flamewrought Key (Horde)
+    if (bot->GetTeamId() == TEAM_ALLIANCE && repMgr.GetRank(sFactionStore.LookupEntry(946)) >= REP_HONORED &&
+        !bot->HasItemCount(30622, 1))
+        keysToCheck.emplace_back(946, 30622);  // Honor Hold - Flamewrought Key (Alliance)
+    if (bot->GetTeamId() == TEAM_HORDE && repMgr.GetRank(sFactionStore.LookupEntry(947)) >= REP_HONORED &&
+        !bot->HasItemCount(30637, 1))
+        keysToCheck.emplace_back(947, 30637);  // Thrallmar - Flamewrought Key (Horde)
 
     // Keys that do not require Rep or Faction
     // Shattered Halls Key, Shadow Labyrinth Key, Key to the Arcatraz, Master's Key
@@ -4704,7 +4771,7 @@ void PlayerbotFactory::InitKeyring()
         uint32 keyId = keyPair.second;
         if (keyId > 0)
         {
-            if (Item* newItem = StoreNewItemInInventorySlot(bot,keyId, 1))
+            if (Item* newItem = StoreNewItemInInventorySlot(bot, keyId, 1))
             {
                 newItem->AddToUpdateQueueOf(bot);
             }
@@ -4717,23 +4784,23 @@ void PlayerbotFactory::InitReputation()
         return;
 
     if (bot->GetLevel() < 70)
-        return; // Only apply for level 70+ bots
+        return;  // Only apply for level 70+ bots
 
     ReputationMgr& repMgr = bot->GetReputationMgr();
 
     // List of factions that require Honored reputation for heroic keys
     std::vector<uint32> factions = {
-        1011, // Lower City
-        942,  // Cenarion Expedition
-        989,  // Keepers of Time
-        935   // The Sha'tar
+        1011,  // Lower City
+        942,   // Cenarion Expedition
+        989,   // Keepers of Time
+        935    // The Sha'tar
     };
 
     // Add faction-specific reputation
     if (bot->GetTeamId() == TEAM_ALLIANCE)
-        factions.push_back(946); // Honor Hold (Alliance)
+        factions.push_back(946);  // Honor Hold (Alliance)
     else if (bot->GetTeamId() == TEAM_HORDE)
-        factions.push_back(947); // Thrallmar (Horde)
+        factions.push_back(947);  // Thrallmar (Horde)
 
     // Set reputation to Honored for each required faction
     for (uint32 factionId : factions)
@@ -4760,33 +4827,33 @@ void PlayerbotFactory::InitAttunementQuests()
 {
     uint32 level = bot->GetLevel();
     if (level < 55)
-        return; // Only apply for level 55+ bots
+        return;  // Only apply for level 55+ bots
 
     uint32 currentXP = bot->GetUInt32Value(PLAYER_XP);
 
     // List of attunement quest IDs
     std::list<uint32> attunementQuestsTBC = {
         // Caverns of Time - Part 1
-        10279, // To The Master's Lair
-        10277, // The Caverns of Time
+        10279,  // To The Master's Lair
+        10277,  // The Caverns of Time
 
         // Caverns of Time - Part 2 (Escape from Durnholde Keep)
-        10282, // Old Hillsbrad
-        10283, // Taretha's Diversion
-        10284, // Escape from Durnholde
-        10285, // Return to Andormu
+        10282,  // Old Hillsbrad
+        10283,  // Taretha's Diversion
+        10284,  // Escape from Durnholde
+        10285,  // Return to Andormu
 
         // Caverns of Time - Part 2 (The Black Morass)
-        10296, // The Black Morass
-        10297, // The Opening of the Dark Portal
-        10298, // Hero of the Brood
+        10296,  // The Black Morass
+        10297,  // The Opening of the Dark Portal
+        10298,  // Hero of the Brood
 
         // Magister's Terrace Attunement
-        11481, // Crisis at the Sunwell
-        11482, // Duty Calls
-        11488, // Magisters' Terrace
-        11490, // The Scryer's Scryer
-        11492  // Hard to Kill
+        11481,  // Crisis at the Sunwell
+        11482,  // Duty Calls
+        11488,  // Magisters' Terrace
+        11490,  // The Scryer's Scryer
+        11492   // Hard to Kill
     };
 
     // Complete all level-appropriate attunement quests for the bot
@@ -4799,7 +4866,7 @@ void PlayerbotFactory::InitAttunementQuests()
         {
             QuestStatus questStatus = bot->GetQuestStatus(questId);
 
-            if (questStatus == QUEST_STATUS_NONE) // Quest not yet taken/completed
+            if (questStatus == QUEST_STATUS_NONE)  // Quest not yet taken/completed
             {
                 questsToComplete.push_back(questId);
             }

--- a/src/registry/PlayerGuildRegistry.cpp
+++ b/src/registry/PlayerGuildRegistry.cpp
@@ -1,0 +1,67 @@
+#include <unordered_set>
+#include <vector>
+#include <cstdint>
+#include <mutex>
+#include "PlayerGuildRegistry.h"
+#include "PlayerGuildRepository.h"
+#include "PlayerbotAIConfig.h"
+#include "UInt32VectorToString.h"
+#include "DatabaseEnv.h"
+#include "QueryResult.h"
+#include "Log.h"
+
+void PlayerGuildRegistry::Initialize()
+{
+	std::unordered_set<uint32_t> playerGuildsIds = sPlayerGuildRepository.GetPlayerGuildsIds();
+
+	ids_.clear();
+	ids_.merge(playerGuildsIds);
+
+	LOG_INFO("server.loading", "[PlayerGuildRegistry] Initialized PlayerGuildRegistry with {} guilds containing non random bot account characters.", Size());
+}
+
+// Add an ID if not already present
+void PlayerGuildRegistry::Add(uint32_t id)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	ids_.insert(id);
+}
+
+// Remove an ID if present
+void PlayerGuildRegistry::Remove(uint32_t id)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	ids_.erase(id);
+}
+
+// Check if ID is present
+bool PlayerGuildRegistry::Contains(uint32_t id) const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	return ids_.find(id) != ids_.end();
+}
+
+// Retrieve a copy (thread safe)
+std::vector<uint32_t> PlayerGuildRegistry::Snapshot() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	return std::vector<uint32_t>(ids_.begin(), ids_.end());
+}
+
+std::size_t PlayerGuildRegistry::Size() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	return ids_.size();
+}
+
+bool PlayerGuildRegistry::Empty() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	return ids_.empty();
+}

--- a/src/registry/PlayerGuildRegistry.h
+++ b/src/registry/PlayerGuildRegistry.h
@@ -1,0 +1,51 @@
+#ifndef PLAYER_GUILD_REGISTRY_H
+#define PLAYER_GUILD_REGISTRY_H
+
+#include <unordered_set>
+#include <vector>
+#include <cstdint>
+#include <mutex>
+
+class PlayerGuildRegistry {
+public:
+    static PlayerGuildRegistry& GetInstance()
+    {
+        static PlayerGuildRegistry instance;
+        return instance;
+    }
+
+    // Delete copy constructor and assignment operator to enforce singleton pattern
+    PlayerGuildRegistry(const PlayerGuildRegistry&) = delete;
+    PlayerGuildRegistry& operator=(const PlayerGuildRegistry&) = delete;
+
+    void Initialize();
+
+    // Add an ID if not already present
+    void Add(uint32_t id);
+
+    // Remove an ID if present
+    void Remove(uint32_t id);
+
+    // Check if ID is present
+    bool Contains(uint32_t id) const;
+
+    // Retrieve a copy (thread safe)
+    std::vector<uint32_t> Snapshot() const;
+
+    // Get the number of registered guilds
+    std::size_t Size() const;
+
+    // Check if registry is empty
+    bool Empty() const;
+
+private:
+    PlayerGuildRegistry() = default;
+    ~PlayerGuildRegistry() = default;
+
+    mutable std::mutex mutex_;
+    std::unordered_set<uint32_t> ids_;
+};
+
+#define sPlayerGuildRegistry PlayerGuildRegistry::GetInstance()
+
+#endif

--- a/src/repository/PlayerGuildRepository.cpp
+++ b/src/repository/PlayerGuildRepository.cpp
@@ -1,0 +1,76 @@
+#include <unordered_set>
+#include <cstdint>
+#include "PlayerGuildRepository.h"
+#include "PlayerbotAIConfig.h"
+#include "UInt32VectorToString.h"
+#include "DatabaseEnv.h"
+#include "QueryResult.h"
+#include "Log.h"
+
+std::unordered_set<uint32_t> PlayerGuildRepository::GetPlayerGuildsIds()
+{
+	std::string randomBotsAccountsIdsString = UInt32VectorToString(sPlayerbotAIConfig->randomBotAccounts);
+
+	std::unordered_set<uint32_t> guildIds;
+
+	QueryResult result = CharacterDatabase.Query(
+		"SELECT DISTINCT(guild.guildid) "
+		"FROM guild "
+		"INNER JOIN guild_member ON guild_member.guildid = guild.guildid "
+		"INNER JOIN characters ON guild_member.guid = characters.guid "
+		"WHERE characters.account NOT IN ({})",
+		randomBotsAccountsIdsString
+	);
+
+	if (!result)
+	{
+		LOG_INFO("playerbots", "[PlayerGuildRepository] No guild found containing real players. PlayerGuildRepository is empty.");
+
+		return guildIds;
+	}
+
+	do
+	{
+		Field* fields = result->Fetch();
+		uint32_t id = fields[0].Get<uint32_t>();
+
+		LOG_INFO("playerbots", "[PlayerGuildRepository] Adding guild with id '{}' to registry because it contains at least one non random bot account character.", id);
+
+		guildIds.insert(id);
+	} while (result->NextRow());
+
+	return guildIds;
+}
+
+std::unordered_set<uint64_t> PlayerGuildRepository::GetGuildMembersIds(uint32_t guildId)
+{
+	std::string randomBotsAccountsIdsString = UInt32VectorToString(sPlayerbotAIConfig->randomBotAccounts);
+
+	std::unordered_set<uint64_t> membersIds;
+
+	QueryResult result = CharacterDatabase.Query(
+		"SELECT characters.guid "
+		"INNER JOIN guild_member ON guild_member.guid = characters.guid "
+		"WHERE guild_member.guildid = {} "
+		"AND characters.account NOT IN ({})",
+		guildId,
+		randomBotsAccountsIdsString
+	);
+
+	if (!result)
+	{
+		LOG_DEBUG("playerbots", "[PlayerGuildRepository] No non random bot member for guild with id {}", guildId);
+
+		return membersIds;
+	}
+
+	do
+	{
+		Field* fields = result->Fetch();
+		uint64_t id = fields[0].Get<uint64_t>();
+
+		membersIds.insert(id);
+	} while (result->NextRow());
+
+	return membersIds;
+}

--- a/src/repository/PlayerGuildRepository.h
+++ b/src/repository/PlayerGuildRepository.h
@@ -1,0 +1,32 @@
+#ifndef PLAYER_GUILD_REPOSITORY_H
+#define PLAYER_GUILD_REPOSITORY_H
+
+#include <unordered_set>
+#include <vector>
+#include <cstdint>
+#include <mutex>
+
+class PlayerGuildRepository {
+public:
+    static PlayerGuildRepository& GetInstance()
+    {
+        static PlayerGuildRepository instance;
+        return instance;
+    }
+
+    // Delete copy constructor and assignment operator to enforce singleton pattern
+    PlayerGuildRepository(const PlayerGuildRepository&) = delete;
+    PlayerGuildRepository& operator=(const PlayerGuildRepository&) = delete;
+
+    std::unordered_set<uint32_t> GetPlayerGuildsIds();
+
+	std::unordered_set<uint64_t> GetGuildMembersIds(uint32_t guildId);
+
+private:
+    PlayerGuildRepository() = default;
+    ~PlayerGuildRepository() = default;
+};
+
+#define sPlayerGuildRepository PlayerGuildRepository::GetInstance()
+
+#endif

--- a/src/utility/UInt32VectorToString.h
+++ b/src/utility/UInt32VectorToString.h
@@ -1,0 +1,23 @@
+#ifndef UINT32_VECTOR_TO_STRING_H
+#define UINT32_VECTOR_TO_STRING_H
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <cstdint>
+
+inline std::string UInt32VectorToString(const std::vector<uint32_t>& vec)
+{
+    std::ostringstream oss;
+
+    for (size_t i = 0; i < vec.size(); ++i)
+    {
+        if (i > 0)
+            oss << ',';
+        oss << vec[i];
+    }
+
+    return oss.str();
+}
+
+#endif


### PR DESCRIPTION
#  Description

This PR adds two new configuration options:

```
# This option will prevent ALL random bots from being randomized.
# It does not prevent periodic teleport.
# Without it, random bots will be periodically randomized unless they are in a guild
# with at least one character who is not a random bot.
AiPlayerbot.DisableRandomBotPeriodicRandomization = 1

# This option will prevent ALL random bots from being periodically teleported.
# THIS SHOULD NOT BE ENABLED AT ALL TIMES. It exists mostly for debugging purposes.
# Disabling periodic teleport will make the bots almost unable to reach new areas.
AiPlayerbot.DisableRandomBotPeriodicTeleportation = 0
```

**It also makes it so all random bots currently within a guild with at least one member who is not a random bot (so not a randombot account) will not be randomized.**

It uses a Meyer's singleton as a registry for in-memory cache.
It does not require any database change.
It uses SOLID principles and DDD patterns (repository, registry, etc.).