### PR TITLE
fix: Resolved an issue where the open spell was being cast by bots on despawned game objects.

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -14,6 +14,7 @@
 #include "BudgetValues.h"
 #include "ChannelMgr.h"
 #include "CharacterPackets.h"
+#include "ChatHelper.h"
 #include "Common.h"
 #include "CreatureAIImpl.h"
 #include "CreatureData.h"
@@ -277,6 +278,15 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
             Unit* spellTarget = currentSpell->m_targets.GetUnitTarget();
             // Interrupt if target is dead or spell can't target dead units
             if (spellTarget && !spellTarget->IsAlive() && !spellInfo->IsAllowingDeadTarget())
+            {
+                InterruptSpell();
+                YieldThread(GetReactDelay());
+                return;
+            }
+
+            GameObject* goSpellTarget = currentSpell->m_targets.GetGOTarget();
+
+            if (goSpellTarget && !goSpellTarget->isSpawned())
             {
                 InterruptSpell();
                 YieldThread(GetReactDelay());


### PR DESCRIPTION
# Description

This addresses the infamous "Possible hacking attempt" error when bots were furiously trying to interact with despawned game objects.
The problem was that the game objects were not being as spawned when evaluating what the bot should do. It was only done when spells were being cast on entities.