### PR TITLE
Core - Fix freeze/crash when using "spells" command in MapUpdater worker thread

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -1477,6 +1477,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 544:
             strategyName = "magtheridon";  // Magtheridon's Lair
+            break;
         case 565:
             strategyName = "gruulslair";  // Gruul's Lair
             break;


### PR DESCRIPTION
This will fix Crash 3 Source in issue [#1840](https://github.com/mod-playerbots/mod-playerbots/issues/1840) found in logs posted by @Regrad

## Summary

Fix a freeze/crash caused by the `spells` command when executed in a `MapUpdater` worker thread. The old `CompareSpells` implementation was extremely expensive and could block `Map::Update` for more than 60 seconds, triggering the `FreezeDetector` and `Acore::Abort()`.

## What was wrong

Call path on crash:

- World::Update → MapMgr::Update → MapUpdater::wait()
- MapUpdater::WorkerThread → MapUpdateRequest::call → Map::Update → Player::Update
- ScriptMgr::OnPlayerAfterUpdate → PlayerbotsPlayerScript::OnPlayerAfterUpdate
- botAI->UpdateAI → PlayerbotAI::DoNextAction → Engine::DoNextAction
- Engine::ListenAndExecute → ListSpellsAction::Execute → GetSpellList / CompareSpells

`CompareSpells` rescanned the entire `sSkillLineAbilityStore` DBC table for every comparison inside `std::sort`, which becomes extremely slow on bots with many spells.

## What this PR does

- Replace the heavy `CompareSpells` with a **cheap comparator**:
  - Uses `SpellInfo` only (school + spell name) for sorting.
  - No more `sSkillLineAbilityStore` scan inside the comparator.
- Keep sending the **full spell list** to the master so existing addons that parse chat still work.
- Make filter parsing a bit safer:
  - No out-of-bounds on `spells first` vs `spells first aid`.
  - Support `spells +tailoring`, `spells tailoring+`, etc. for craftable-only filters.
  - Return `"No spells found."` when nothing matches.
  
### Testing

Tested locally on an AzerothCore WotLK 3.3.5a server with mod-playerbots:
**Functional:**
- spells
- spells first aid
- spells tailoring
- spells 20-40
- spells +tailoring
- spells head
- spells qsdqsdqsd (returns No spells found. as expected)

**Scenario with bots having:**
- multiple professions (Tailoring, Blacksmithing, First Aid, etc.),
- many known spells and recipes,
- various reagents in bags and vendor-only reagents.

**Verified that:**
- the full spell list is still sent to the master chat,
- client-side addons that parse chat to reconstruct the bot spellbook still see all spells, there is no noticeable stall or freeze on the world server when spamming spells on multiple bots simultaneously,
- no crashes or FreezeDetector aborts were observed during these tests.

### Need tests and feedback on a large server please.