### PR TITLE
Revert "feat: Improve bot mount behavior to faster close distance between bot and master"

### DIFF
--- a/src/strategy/actions/CheckMountStateAction.cpp
+++ b/src/strategy/actions/CheckMountStateAction.cpp
@@ -122,21 +122,18 @@ bool CheckMountStateAction::Execute(Event /*event*/)
     bool shouldMount = false;
 
     Unit* currentTarget = AI_VALUE(Unit*, "current target");
-    bool masterInCombat = master && master->IsInCombat();
-
-    if (currentTarget && (bot->IsInCombat() || masterInCombat))
+    if (currentTarget)
     {
-        // Use target-based logic if bot is in combat OR master is in combat and needs assistance
         float dismountDistance = CalculateDismountDistance();
         float mountDistance = CalculateMountDistance();
+        float combatReach = bot->GetCombatReach() + currentTarget->GetCombatReach();
         float distanceToTarget = bot->GetExactDist(currentTarget);
 
-        shouldDismount = (distanceToTarget <= dismountDistance);
-        shouldMount = (distanceToTarget > mountDistance);
+        shouldDismount = (distanceToTarget <= dismountDistance + combatReach);
+        shouldMount = (distanceToTarget > mountDistance + combatReach);
     }
     else
     {
-        // If neither bot nor master is in combat, prioritize master-following
         shouldMount = true;
     }
 
@@ -163,18 +160,9 @@ bool CheckMountStateAction::Execute(Event /*event*/)
 
         else if (ShouldDismountForMaster(master) && bot->IsMounted())
         {
-            // If master dismounted, stay mounted until close enough to assist
-            if (StayMountedToCloseDistance())
-                return false;
-
             Dismount();
             return true;
         }
-
-        // Mount up to close distance to master if beneficial - allow mounting even if master is in combat
-        // as long as the bot itself is not in combat and has no attackers
-        else if (!bot->IsMounted() && noAttackers && !bot->IsInCombat() && ShouldMountToCloseDistance())
-            return Mount();
 
         return false;
     }
@@ -407,50 +395,6 @@ bool CheckMountStateAction::TryRandomMountFiltered(const std::map<int32, std::ve
         }
     }
     return false;
-}
-
-bool CheckMountStateAction::StayMountedToCloseDistance() const
-{
-    // Keep the bot mounted while closing distance to a recently dismounted master.
-    // Rationale: if the master dismounts far away, immediately dismounting slows the bot down
-    // and delays assistance. Instead, remain mounted until within reasonable proximity
-    // of the master, then dismount to help.
-
-    if (!master)
-        return false;
-
-    float distToMaster = sServerFacade->GetDistance2d(bot, master);
-
-    // If master is in combat, dismount at combat assist range to help immediately
-    if (master->IsInCombat())
-    {
-        float assistRange = CalculateDismountDistance();
-        return distToMaster > assistRange;
-    }
-
-    // If master is not in combat, use smaller proximity range for general following
-    float masterProximityRange = 10.0f; // Close enough to be near master but not attack range
-    return distToMaster > masterProximityRange;
-}
-
-bool CheckMountStateAction::ShouldMountToCloseDistance() const
-{
-    // Mount up to close distance to master if beneficial
-    // Uses the same logic as CalculateMountDistance() which already considers the 2-second mount cast time
-    // This handles cases where master is in combat but bot isn't, and bot needs to mount to reach master
-
-    if (!master)
-        return false;
-
-    // Only mount to close distance when actively following
-    if (!botAI->HasStrategy("follow", BOT_STATE_NON_COMBAT))
-        return false;
-
-    float distToMaster = sServerFacade->GetDistance2d(bot, master);
-    float mountDistance = CalculateMountDistance();
-
-    // Mount if distance is greater than the calculated mount distance threshold
-    return distToMaster > mountDistance;
 }
 
 float CheckMountStateAction::CalculateDismountDistance() const

--- a/src/strategy/actions/CheckMountStateAction.h
+++ b/src/strategy/actions/CheckMountStateAction.h
@@ -60,8 +60,6 @@ private:
     bool TryPreferredMount(Player* master) const;
     uint32 GetMountType(Player* master) const;
     bool TryRandomMountFiltered(const std::map<int32, std::vector<uint32>>& spells, int32 masterSpeed) const;
-    bool StayMountedToCloseDistance() const;
-    bool ShouldMountToCloseDistance() const;
 };
 
 #endif


### PR DESCRIPTION
Reverts mod-playerbots/mod-playerbots#1760

This, as it is causing issues in BG, where bots just don't dismount and just stand there instead.

<img width="2336" height="1374" alt="image" src="https://github.com/user-attachments/assets/b61d7a77-1561-4f05-a438-edbb9321e113" />
