### PR TITLE
fix: Made bots roll in a more reasonable time on group loots.

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -1384,8 +1384,6 @@ void PlayerbotAI::DoNextAction(bool min)
     else if (bot->isAFK())
         bot->ToggleAFK();
 
-    PlayerbotAI* masterBotAI = nullptr;
-
     if (master && master->IsInWorld())
     {
         float distance = sServerFacade->GetDistance2d(bot, master);

--- a/src/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -5,9 +5,6 @@
 
 #include "WorldPacketHandlerStrategy.h"
 
-#include "Playerbots.h"
-#include "Strategy.h"
-
 void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     PassTroughStrategy::InitTriggers(triggers);


### PR DESCRIPTION
# Description

This PR changes the way loot rolls are being evaluated.

It puts a maximum priority on the loot action so it does not hang for so long.
