### PR TITLE
fix: warning updating movement flags while rooted

### DIFF
--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -1048,7 +1048,6 @@ void MovementAction::UpdateMovementState()
 
         if (movementFlagsUpdated)
             bot->SendMovementFlagUpdate();
-
     }
 
      // Save current state for the next check


### PR DESCRIPTION
fixes https://github.com/mod-playerbots/mod-playerbots/issues/1854
-----
Also includes fixes for:
-----
* Bots swimming with waterWalk kept switching between swimming and walking, as result jittering effect swimming under water when water walking active
* Bots flying close above water they would land on water and start walking, now they stay flying unless on solid ground they will land and start walking by design

-----
Moved all flag setting to updateMovementState:
   * So all movement flag are handled in updateMovementState which also contains the restricted movement logic.
   * Handle restricted movement logic and preventing SendMovementFlagUpdate while being restricted.


-----
Known issue when flying the following bots feel a bit jittering, wont touch for now at least till core movement changes quirks has been dealt with.

The current code is the extended version of what is originally was before core merge with refactored movements. Once the core movement refactors are settled a bit more i would like to revisit this code; as i would expect more imperative code and less manual flag setting e.g. bot->SetWaterWalking, SetGravitiy..SetCanFly etc.