### PR TITLE
Fix - Druid Remove Tree of Life Form when out of combat

### DIFF
--- a/src/strategy/druid/GenericDruidNonCombatStrategy.cpp
+++ b/src/strategy/druid/GenericDruidNonCombatStrategy.cpp
@@ -126,7 +126,7 @@ void GenericDruidNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& trig
     triggers.push_back(
         new TriggerNode("no more attackers",
                         NextAction::array(0, new NextAction("cancel tree form", ACTION_HIGH + 8), nullptr)));
-						
+
     triggers.push_back(
         new TriggerNode("party member critical health",
                         NextAction::array(0,


### PR DESCRIPTION
This will remove Tree of Life form to druid where he's out of combat.