### PR TITLE
Fix Wrong Misdirection Spell ID for Gruul's Lair and Magtheridon Strategies

### DIFF
--- a/src/strategy/raids/gruulslair/RaidGruulsLairHelpers.h
+++ b/src/strategy/raids/gruulslair/RaidGruulsLairHelpers.h
@@ -15,7 +15,7 @@ namespace GruulsLairHelpers
         SPELL_SPELL_SHIELD = 33054,
 
         // Hunter
-        SPELL_MISDIRECTION = 34477,
+        SPELL_MISDIRECTION = 35079,
 
         // Warlock
         SPELL_BANISH = 18647, // Rank 2

--- a/src/strategy/raids/magtheridon/RaidMagtheridonHelpers.h
+++ b/src/strategy/raids/magtheridon/RaidMagtheridonHelpers.h
@@ -24,7 +24,7 @@ namespace MagtheridonHelpers
         SPELL_FEAR          =  6215,
 
         // Hunter
-        SPELL_MISDIRECTION  = 34477,
+        SPELL_MISDIRECTION  = 35079,
     };
 
     enum MagtheridonNPCs


### PR DESCRIPTION
Lol oops.

Confirmed with logs/in-game that the prior one was wrong (and thus always returning false) and current one is correct.