### PR TITLE
Bug: Fix bots leaving LFG groups before master

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -365,7 +365,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
     }
 
     // Update the bot's group status (moved to helper function)
-    UpdateAIGroupAndMaster();
+    UpdateAIGroupMaster();
 
     // Update internal AI
     UpdateAIInternal(elapsed, minimal);
@@ -373,7 +373,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 }
 
 // Helper function for UpdateAI to check group membership and handle removal if necessary
-void PlayerbotAI::UpdateAIGroupAndMaster()
+void PlayerbotAI::UpdateAIGroupMaster()
 {
     if (!bot)
         return;
@@ -431,8 +431,6 @@ void PlayerbotAI::UpdateAIGroupAndMaster()
                 botAI->ChangeStrategy("-follow", BOT_STATE_NON_COMBAT);
             }
         }
-        else if (!newMaster && !bot->InBattleground())
-            LeaveOrDisbandGroup();
     }
 }
 

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -612,7 +612,7 @@ private:
     static void _fillGearScoreData(Player* player, Item* item, std::vector<uint32>* gearScore, uint32& twoHandScore,
                                    bool mixed = false);
     bool IsTellAllowed(PlayerbotSecurityLevel securityLevel = PLAYERBOT_SECURITY_ALLOW_ALL);
-    void UpdateAIGroupAndMaster();
+    void UpdateAIGroupMaster();
     Item* FindItemInInventory(std::function<bool(ItemTemplate const*)> checkItem) const;
     void HandleCommands();
     void HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);

--- a/src/strategy/generic/GroupStrategy.cpp
+++ b/src/strategy/generic/GroupStrategy.cpp
@@ -11,7 +11,6 @@ void GroupStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("invite nearby", 4.0f), nullptr)));
     triggers.push_back(new TriggerNode("random", NextAction::array(0, new NextAction("invite guild", 4.0f), nullptr)));
-    triggers.push_back(new TriggerNode("often", NextAction::array(0, new NextAction("leave far away", 4.0f), nullptr)));
-    triggers.push_back(
-        new TriggerNode("seldom", NextAction::array(0, new NextAction("reset instances", 1.0f), nullptr)));
+    triggers.push_back(new TriggerNode("random", NextAction::array(0, new NextAction("leave far away", 4.0f), nullptr)));
+    triggers.push_back(new TriggerNode("seldom", NextAction::array(0, new NextAction("reset instances", 1.0f), nullptr)));
 }


### PR DESCRIPTION
I removed bots checking if they should leave group every tick, and will rely on the LeaveGroupFarAway action. I also increased the timer from 5 seconds to 20 seconds. No need to check this that often. 
