### PR TITLE
Add missing break in ApplyInstanceStrategies

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -1477,6 +1477,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 544:
             strategyName = "magtheridon";  // Magtheridon's Lair
+            break;
         case 565:
             strategyName = "gruulslair";  // Gruul's Lair
             break;


### PR DESCRIPTION
Well, I hope nobody has tried Magtheridon lately. It looks like this got inadvertently deleted during the merge.