### PR TITLE
Fix: Allow bots to duel in PVP prohibited areas

### DIFF
--- a/src/strategy/actions/AttackAction.cpp
+++ b/src/strategy/actions/AttackAction.cpp
@@ -15,7 +15,7 @@
 #include "SharedDefines.h"
 #include "Unit.h"
 
-bool AttackAction::Execute(Event event)
+bool AttackAction::Execute(Event /*event*/)
 {
     Unit* target = GetTarget();
     if (!target)
@@ -27,7 +27,7 @@ bool AttackAction::Execute(Event event)
     return Attack(target);
 }
 
-bool AttackMyTargetAction::Execute(Event event)
+bool AttackMyTargetAction::Execute(Event /*event*/)
 {
     Player* master = GetMaster();
     if (!master)
@@ -50,7 +50,7 @@ bool AttackMyTargetAction::Execute(Event event)
     return result;
 }
 
-bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
+bool AttackAction::Attack(Unit* target, bool /*with_pet*/ /*true*/)
 {
     Unit* oldTarget = context->GetValue<Unit*>("current target")->Get();
     bool shouldMelee = bot->IsWithinMeleeRange(target) || botAI->IsMelee(bot);
@@ -160,9 +160,8 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
     }
 
     if (IsMovingAllowed() && !bot->HasInArc(CAST_ANGLE_IN_FRONT, target))
-    {
         sServerFacade->SetFacingTo(bot, target);
-    }
+
     botAI->ChangeEngine(BOT_STATE_COMBAT);
 
     bot->Attack(target, shouldMelee);
@@ -192,4 +191,4 @@ bool AttackAction::Attack(Unit* target, bool with_pet /*true*/)
 
 bool AttackDuelOpponentAction::isUseful() { return AI_VALUE(Unit*, "duel target"); }
 
-bool AttackDuelOpponentAction::Execute(Event event) { return Attack(AI_VALUE(Unit*, "duel target")); }
+bool AttackDuelOpponentAction::Execute(Event /*event*/) { return Attack(AI_VALUE(Unit*, "duel target")); }

--- a/src/strategy/actions/PetsAction.cpp
+++ b/src/strategy/actions/PetsAction.cpp
@@ -18,9 +18,7 @@ bool PetsAction::Execute(Event event)
     // Extract the command parameter from the event (e.g., "aggressive", "defensive", "attack", etc.)
     std::string param = event.getParam();
     if (param.empty() && !defaultCmd.empty())
-    {
         param = defaultCmd;
-    }
 
     if (param.empty())
     {
@@ -129,9 +127,7 @@ bool PetsAction::Execute(Event event)
         {
             ObjectGuid masterTargetGuid = master->GetTarget();
             if (!masterTargetGuid.IsEmpty())
-            {
                 targetUnit = botAI->GetUnit(masterTargetGuid);
-            }
         }
 
         // If no valid target is selected, show an error and return.
@@ -156,9 +152,9 @@ bool PetsAction::Execute(Event event)
             botAI->TellError(text);
             return false;
         }
-        if (sPlayerbotAIConfig->IsPvpProhibited(bot->GetZoneId(), bot->GetAreaId())
-            && (targetUnit->IsPlayer() || targetUnit->IsPet())
-            && (!bot->duel || bot->duel->Opponent != targetUnit))
+        if (sPlayerbotAIConfig->IsPvpProhibited(bot->GetZoneId(), bot->GetAreaId()) &&
+            (targetUnit->IsPlayer() || targetUnit->IsPet()) &&
+            (!bot->duel || bot->duel->Opponent != targetUnit))
         {
             std::string text = sPlayerbotTextMgr->GetBotTextOrDefault(
                 "pet_pvp_prohibited_error", "I cannot command my pet to attack players in PvP prohibited areas.", {});

--- a/src/strategy/values/AttackersValue.cpp
+++ b/src/strategy/values/AttackersValue.cpp
@@ -33,18 +33,14 @@ GuidVector AttackersValue::Calculate()
     {
         Unit* unit = botAI->GetUnit(target);
         if (unit && IsValidTarget(unit, bot))
-        {
             targets.insert(unit);
-        }
     }
     if (Group* group = bot->GetGroup())
     {
         ObjectGuid skullGuid = group->GetTargetIcon(7);
         Unit* skullTarget = botAI->GetUnit(skullGuid);
         if (skullTarget && IsValidTarget(skullTarget, bot))
-        {
             targets.insert(skullTarget);
-        }
     }
 
     for (Unit* unit : targets)
@@ -61,9 +57,7 @@ GuidVector AttackersValue::Calculate()
         {
             Unit* unit = botAI->GetUnit(guid);
             if (unit && unit->IsPlayer() && IsValidTarget(unit, bot))
-            {
                 result.push_back(unit->GetGUID());
-            }
         }
     }
 
@@ -110,9 +104,8 @@ void AttackersValue::AddAttackersOf(Player* player, std::unordered_set<Unit*>& t
 
         if (player->IsValidAttackTarget(attacker) &&
             player->GetDistance2d(attacker) < sPlayerbotAIConfig->sightDistance)
-        {
             targets.insert(attacker);
-        }
+
         ref = ref->next();
     }
 }


### PR DESCRIPTION
Noticed that if you ask a bot to duel in a PVP prohibited area, it will accept, and do nothing. I thought about making the bot reject the request, but if you (the real player) want to duel with it, the duel should happen. This is just a minor fix to allow bots to duel if you ask them to in such areas.

Tested with bots in party, random bots of the same faction, and random bots of the opposite faction. All behaved the same before and after fix. An example place to test is Zim'Torga in Zul'Drak which is by default is a PVP prohibited area.

- Before fix, you challenge a bot, they accept and turn red, then they either just stay where they are or wander off.

- After fix, bot attacks you within the PVP prohibited area when the duel starts.