### PR TITLE
feat. Enable bots to respond to GM messages.

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -2771,8 +2771,7 @@ bool PlayerbotAI::TellMaster(std::string const text, PlayerbotSecurityLevel secu
     if (!master)
     {
         if (sPlayerbotAIConfig->randomBotSayWithoutMaster)
-            TellMasterNoFacing(text, securityLevel);
-        return false;
+            return TellMasterNoFacing(text, securityLevel);
     }
     if (!TellMasterNoFacing(text, securityLevel))
         return false;


### PR DESCRIPTION
I found an existing config option that allows bots to speak without a master, and extended its use so that protected commands (nc, co) are taken from a bot by GM players. This is primarily a debugging tool and shouldnt be on generally. 

My testing of this is the following. 
With the option off, no error is seen, but no text output is shown. 

With the option on 
GM accounts (Whether GM is on or off) will respond to nc and co commands by just saying the output directly. Strategies can be changed by GMs for bots whom they are not masters for (Note, im pretty sure that a GM could change the strategies even before this change, you just couldnt see the output of that.)

For non GM characters you get "Invite me to your group first" with the option on/off. 