### PR TITLE
Disable bot XP gain when master has XP turned off

### DIFF
--- a/src/Playerbots.cpp
+++ b/src/Playerbots.cpp
@@ -238,12 +238,22 @@ public:
 
     void OnPlayerGiveXP(Player* player, uint32& amount, Unit* /*victim*/, uint8 /*xpSource*/) override
     {
-        // early return
-        if (sPlayerbotAIConfig->randomBotXPRate == 1.0 || !player)
+        // no XP multiplier, when player is no bot.
+        if (!player || !player->GetSession()->IsBot())
             return;
 
-        // no XP multiplier, when player is no bot.
-        if (!player->GetSession()->IsBot() || !sRandomPlayerbotMgr->IsRandomBot(player))
+        // no XP gain, if master is not a bot and has xp gain disabled.
+        if (const Player* master = GET_PLAYERBOT_AI(player)->GetMaster())
+        {
+            if (!master->GetSession()->IsBot() && master->HasPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN))
+            {
+                amount = 0;
+                return;
+            }
+        }
+
+        // early return
+        if (sPlayerbotAIConfig->randomBotXPRate == 1.0 || !sRandomPlayerbotMgr->IsRandomBot(player))
             return;
 
         // no XP multiplier, when bot is in a group with a real player.


### PR DESCRIPTION
Addresses #1846

This PR disables XP gain for bots whose non-bot master has disabled XP gain via an "Experience Eliminator" NPC.

If the current master has disabled XP gain, randombots in the group and addclass-bots belonging to the player won't gain XP.
Randombots not grouped with a player will continue to gain XP as normal.

Discussed points:
- `Should this feature only be enabled via a new configuration value?`: Comments currently tend towards no config value.

Open points:
- Should bots be allowed to gain XP until they reach the player's level, even if the player has disabled XP gain?