### PR TITLE
playerbots: fix init talents stuck in 2nd spec

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -5,14 +5,16 @@
 
 #include "PlayerbotMgr.h"
 
+#include <openssl/sha.h>
+
 #include <cstdio>
 #include <cstring>
+#include <iomanip>
 #include <istream>
 #include <string>
-#include <openssl/sha.h>
 #include <unordered_set>
-#include <iomanip>
 
+#include "BroadcastHelper.h"
 #include "ChannelMgr.h"
 #include "CharacterCache.h"
 #include "CharacterPackets.h"
@@ -38,6 +40,55 @@
 #include "BroadcastHelper.h"
 #include "PlayerbotDbStore.h"
 #include "WorldSessionMgr.h"
+
+namespace
+{
+    // Fix talent state after init/randomize commands.
+    // Some bots can end up with talents effectively applied to a non-active spec (e.g. specMask=2 only).
+    // This forces primary spec and re-applies talents with reset=true (same idea as "talents autopick").
+    void FixTalentsAfterInit(Player* bot)
+    {
+        if (!bot || bot->GetLevel() < 10)
+            return;
+
+        auto CountTalents = [](Player* p, uint32 mask) -> uint32
+        {
+            uint32 c = 0;
+            auto const& tm = p->GetTalentMap();
+            for (auto const& kv : tm)
+                if (kv.second && (kv.second->specMask & mask))
+                    ++c;
+            return c;
+        };
+
+        // After setlevel/level tweaks the talent point state can get out of sync.
+        bot->InitTalentForLevel();
+
+        uint32 c1 = CountTalents(bot, 1);
+        uint32 c2 = CountTalents(bot, 2);
+
+        // Typical breakage: talents exist only for 2nd spec (specMask=2), while primary (specMask=1) is empty.
+        // In this case .reset talents / init may affect only the primary spec and never clear the 2nd one.
+        if (bot->GetSpecsCount() >= 2 && c1 == 0 && c2 > 0)
+        {
+            bot->ActivateSpec(1);
+            bot->resetTalents(true); // clear 2nd spec
+            bot->ActivateSpec(0);
+        }
+
+        // Always apply to primary spec.
+        if (bot->GetActiveSpec() != 0)
+            bot->ActivateSpec(0);
+
+        PlayerbotFactory factory(bot, bot->GetLevel());
+        factory.InitTalentsTree(false, true, true); // increment=false, use_template=true, reset=true
+        factory.InitPetTalents();
+
+        // Persist so the fix survives relog and does not stay in specMask=2 only.
+        bot->SaveToDB(false, false);
+    }
+
+}
 #include "DatabaseEnv.h"        // Added for gender choice
 #include <algorithm>            // Added for gender choice
 
@@ -68,6 +119,7 @@ private:
 };
 
 std::unordered_set<ObjectGuid> BotInitGuard::botsBeingInitialized;
+std::unordered_set<ObjectGuid> PlayerbotHolder::botLoading;
 
 PlayerbotHolder::PlayerbotHolder() : PlayerbotAIBase(false) {}
 class PlayerbotLoginQueryHolder : public LoginQueryHolder
@@ -75,6 +127,7 @@ class PlayerbotLoginQueryHolder : public LoginQueryHolder
 private:
     uint32 masterAccountId;
     PlayerbotHolder* playerbotHolder;
+
 public:
     PlayerbotLoginQueryHolder(PlayerbotHolder* playerbotHolder, uint32 masterAccount, uint32 accountId, ObjectGuid guid)
         : LoginQueryHolder(accountId, guid), masterAccountId(masterAccount), playerbotHolder(playerbotHolder)
@@ -123,7 +176,8 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
         PlayerbotMgr* mgr = GET_PLAYERBOT_MGR(masterPlayer);
         if (!mgr)
         {
-            LOG_DEBUG("playerbots", "PlayerbotMgr not found for master player with GUID: {}", masterPlayer->GetGUID().GetRawValue());
+            LOG_DEBUG("playerbots", "PlayerbotMgr not found for master player with GUID: {}",
+                      masterPlayer->GetGUID().GetRawValue());
             return;
         }
         uint32 count = mgr->GetPlayerbotsCount() + botLoading.size();
@@ -143,7 +197,7 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
         return;
     }
     std::shared_ptr<PlayerbotLoginQueryHolder> holder =
-        std::make_shared<PlayerbotLoginQueryHolder>(this, masterAccountId, accountId, playerGuid);
+        std::make_shared<PlayerbotLoginQueryHolder>(nullptr, masterAccountId, accountId, playerGuid);
     if (!holder->Initialize())
     {
         return;
@@ -153,14 +207,42 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
 
     // Always login in with world session to avoid race condition
     sWorld->AddQueryHolderCallback(CharacterDatabase.DelayQueryHolder(holder))
-        .AfterComplete([this](SQLQueryHolderBase const& holder)
-                        { HandlePlayerBotLoginCallback(static_cast<PlayerbotLoginQueryHolder const&>(holder)); });
+        .AfterComplete(
+            [](SQLQueryHolderBase const& queryHolder)
+            {
+                PlayerbotLoginQueryHolder const& holder = static_cast<PlayerbotLoginQueryHolder const&>(queryHolder);
+
+                PlayerbotHolder* mgr = nullptr;
+                uint32 masterAccount = holder.GetMasterAccountId();
+
+                if (masterAccount)
+                {
+                    WorldSession* masterSession = sWorldSessionMgr->FindSession(masterAccount);
+                    Player* masterPlayer = masterSession ? masterSession->GetPlayer() : nullptr;
+                    if (masterPlayer)
+                        mgr = GET_PLAYERBOT_MGR(masterPlayer);
+                }
+                else
+                {
+                    mgr = sRandomPlayerbotMgr;
+                }
+
+                if (mgr)
+                    mgr->HandlePlayerBotLoginCallback(holder);
+                else
+                {
+                    auto it2 = PlayerbotHolder::botLoading.find(holder.GetGuid());
+                    if (it2 != PlayerbotHolder::botLoading.end())
+                        PlayerbotHolder::botLoading.erase(it2);
+                }
+            });
 }
 
 bool PlayerbotHolder::IsAccountLinked(uint32 accountId, uint32 linkedAccountId)
 {
     QueryResult result = PlayerbotsDatabase.Query(
-        "SELECT 1 FROM playerbots_account_links WHERE account_id = {} AND linked_account_id = {}", accountId, linkedAccountId);
+        "SELECT 1 FROM playerbots_account_links WHERE account_id = {} AND linked_account_id = {}", accountId,
+        linkedAccountId);
     return result != nullptr;
 }
 
@@ -169,8 +251,9 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
     uint32 botAccountId = holder.GetAccountId();
     // At login DBC locale should be what the server is set to use by default (as spells etc are hardcoded to ENUS this
     // allows channels to work as intended)
-    WorldSession* botSession = new WorldSession(botAccountId, "", 0x0, nullptr, SEC_PLAYER, EXPANSION_WRATH_OF_THE_LICH_KING,
-                                                time_t(0), sWorld->GetDefaultDbcLocale(), 0, false, false, 0, true);
+    WorldSession* botSession =
+        new WorldSession(botAccountId, "", 0x0, nullptr, SEC_PLAYER, EXPANSION_WRATH_OF_THE_LICH_KING, time_t(0),
+                         sWorld->GetDefaultDbcLocale(), 0, false, false, 0, true);
 
     botSession->HandlePlayerLoginFromDB(holder);  // will delete lqh
 
@@ -181,7 +264,11 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
         LOG_DEBUG("mod-playerbots", "Bot player could not be loaded for account ID: {}", botAccountId);
         botSession->LogoutPlayer(true);
         delete botSession;
-        botLoading.erase(holder.GetGuid());
+
+        auto it = PlayerbotHolder::botLoading.find(holder.GetGuid());
+        if (it != PlayerbotHolder::botLoading.end())
+            PlayerbotHolder::botLoading.erase(it);
+
         return;
     }
 
@@ -192,15 +279,18 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(PlayerbotLoginQueryHolder con
     Player* masterPlayer = masterSession ? masterSession->GetPlayer() : nullptr;
     if (masterSession && !masterPlayer)
     {
-        LOG_DEBUG("mod-playerbots", "Master session found but no player is associated for master account ID: {}", masterAccount);
+        LOG_DEBUG("mod-playerbots", "Master session found but no player is associated for master account ID: {}",
+                  masterAccount);
     }
 
     sRandomPlayerbotMgr->OnPlayerLogin(bot);
 
-    auto op = std::make_unique<OnBotLoginOperation>(bot->GetGUID(), this);
+    auto op = std::make_unique<OnBotLoginOperation>(bot->GetGUID(), masterAccount);
     sPlayerbotWorldProcessor->QueueOperation(std::move(op));
 
-    botLoading.erase(holder.GetGuid());
+    auto it2 = PlayerbotHolder::botLoading.find(holder.GetGuid());
+    if (it2 != PlayerbotHolder::botLoading.end())
+        PlayerbotHolder::botLoading.erase(it2);
 }
 
 void PlayerbotHolder::UpdateSessions()
@@ -232,7 +322,8 @@ void PlayerbotHolder::HandleBotPackets(WorldSession* session)
         ClientOpcodeHandler const* opHandle = opcodeTable[opcode];
         if (!opHandle)
         {
-            LOG_ERROR("playerbots", "Unhandled opcode {} queued for bot session {}. Packet dropped.", static_cast<uint32>(opcode), session->GetAccountId());
+            LOG_ERROR("playerbots", "Unhandled opcode {} queued for bot session {}. Packet dropped.",
+                      static_cast<uint32>(opcode), session->GetAccountId());
             delete packet;
             continue;
         }
@@ -389,8 +480,8 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
             }
             else
             {
-                RemoveFromPlayerbotsMap(guid);     // deletes bot player ptr inside this WorldSession PlayerBotMap
-                delete botWorldSessionPtr;  // finally delete the bot's WorldSession
+                RemoveFromPlayerbotsMap(guid);  // deletes bot player ptr inside this WorldSession PlayerBotMap
+                delete botWorldSessionPtr;      // finally delete the bot's WorldSession
                 if (target)
                     delete target;
             }
@@ -399,7 +490,7 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         else if (bot && (logout || !botWorldSessionPtr->isLogingOut()))
         {
             botAI->TellMaster("Goodbye!");
-            RemoveFromPlayerbotsMap(guid);                  // deletes bot player ptr inside this WorldSession PlayerBotMap
+            RemoveFromPlayerbotsMap(guid);           // deletes bot player ptr inside this WorldSession PlayerBotMap
             botWorldSessionPtr->LogoutPlayer(true);  // this will delete the bot Player object and PlayerbotAI object
             delete botWorldSessionPtr;               // finally delete the bot's WorldSession
         }
@@ -442,10 +533,7 @@ void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)
     }
 }
 
-void PlayerbotHolder::RemoveFromPlayerbotsMap(ObjectGuid guid)
-{
-    playerBots.erase(guid);
-}
+void PlayerbotHolder::RemoveFromPlayerbotsMap(ObjectGuid guid) { playerBots.erase(guid); }
 
 Player* PlayerbotHolder::GetPlayerBot(ObjectGuid playerGuid) const
 {
@@ -655,11 +743,13 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
                 case ChatChannelId::GUILD_RECRUITMENT:
                 {
                     char new_channel_name_buf[100];
-                    //3459 is ID for a zone named "City" (only exists for the sake of using its name)
-                    //Currently in magons TBC, if you switch zones, then you join "Trade - <zone>" and "GuildRecruitment - <zone>"
-                    //which is a core bug, should be "Trade - City" and "GuildRecruitment - City" in both 1.12 and TBC
-                    //but if you (actual player) logout in a city and log back in - you join "City" versions
-                    snprintf(new_channel_name_buf, 100, channel->pattern[locale], GET_PLAYERBOT_AI(bot)->GetLocalizedAreaName(GetAreaEntryByAreaID(3459)).c_str());
+                    // 3459 is ID for a zone named "City" (only exists for the sake of using its name)
+                    // Currently in magons TBC, if you switch zones, then you join "Trade - <zone>" and
+                    // "GuildRecruitment - <zone>" which is a core bug, should be "Trade - City" and "GuildRecruitment -
+                    // City" in both 1.12 and TBC but if you (actual player) logout in a city and log back in - you join
+                    // "City" versions
+                    snprintf(new_channel_name_buf, 100, channel->pattern[locale],
+                             GET_PLAYERBOT_AI(bot)->GetLocalizedAreaName(GetAreaEntryByAreaID(3459)).c_str());
                     new_channel = cMgr->GetJoinChannel(new_channel_name_buf, channel->ChannelID);
                     break;
                 }
@@ -686,9 +776,9 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
         return "bot system is disabled";
 
     uint32 botAccount = sCharacterCache->GetCharacterAccountIdByGuid(guid);
-    //bool isRandomBot = sRandomPlayerbotMgr->IsRandomBot(guid.GetCounter()); //not used, line marked for removal.
-    //bool isRandomAccount = sPlayerbotAIConfig->IsInRandomAccountList(botAccount); //not used, shadowed, line marked for removal.
-    //bool isMasterAccount = (masterAccountId == botAccount); //not used, line marked for removal.
+    // bool isRandomBot = sRandomPlayerbotMgr->IsRandomBot(guid.GetCounter()); //not used, line marked for removal.
+    // bool isRandomAccount = sPlayerbotAIConfig->IsInRandomAccountList(botAccount); //not used, shadowed, line marked
+    // for removal. bool isMasterAccount = (masterAccountId == botAccount); //not used, line marked for removal.
 
     if (cmd == "add" || cmd == "addaccount" || cmd == "login")
     {
@@ -702,11 +792,11 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
             if (!accountId)
                 return "character not found";
 
-                if (!sPlayerbotAIConfig->allowAccountBots && accountId != masterAccountId &&
-                    !(sPlayerbotAIConfig->allowTrustedAccountBots && IsAccountLinked(accountId, masterAccountId)))
-                {
-                    return "you can only add bots from your own account or linked accounts";
-                }
+            if (!sPlayerbotAIConfig->allowAccountBots && accountId != masterAccountId &&
+                !(sPlayerbotAIConfig->allowTrustedAccountBots && IsAccountLinked(accountId, masterAccountId)))
+            {
+                return "you can only add bots from your own account or linked accounts";
+            }
         }
 
         AddPlayerBot(guid, masterAccountId);
@@ -769,30 +859,35 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_NORMAL);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok";
             }
             else if (cmd == "init=green" || cmd == "init=uncommon")
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_UNCOMMON);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok";
             }
             else if (cmd == "init=blue" || cmd == "init=rare")
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_RARE);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok";
             }
             else if (cmd == "init=epic" || cmd == "init=purple")
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_EPIC);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok";
             }
             else if (cmd == "init=legendary" || cmd == "init=yellow")
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok";
             }
             else if (cmd == "init=auto")
@@ -804,6 +899,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
                     mixedGearScore = 1;
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok, gear score limit: " + std::to_string(mixedGearScore / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) +
                        "(for epic)";
             }
@@ -811,6 +907,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
             {
                 PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, gs);
                 factory.Randomize(false);
+                FixTalentsAfterInit(bot);
                 return "ok, gear score limit: " + std::to_string(gs / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) + "(for epic)";
             }
         }
@@ -855,13 +952,12 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
 // Added for gender choice : Returns the gender of an offline character: 0 = male, 1 = female.
 static uint8 GetOfflinePlayerGender(ObjectGuid guid)
 {
-    QueryResult result = CharacterDatabase.Query(
-        "SELECT gender FROM characters WHERE guid = {}", guid.GetCounter());
+    QueryResult result = CharacterDatabase.Query("SELECT gender FROM characters WHERE guid = {}", guid.GetCounter());
 
     if (result)
-        return (*result)[0].Get<uint8>();       // 0 = male, 1 = female
+        return (*result)[0].Get<uint8>();  // 0 = male, 1 = female
 
-    return GENDER_MALE;                         // fallback value
+    return GENDER_MALE;  // fallback value
 }
 
 bool PlayerbotMgr::HandlePlayerbotMgrCommand(ChatHandler* handler, char const* args)
@@ -912,11 +1008,12 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
 
     char* cmd = strtok((char*)args, " ");
     char* charname = strtok(nullptr, " ");
-    char* genderArg = strtok(nullptr, " ");    // Added for gender choice [male|female|0|1] optionnel
+    char* genderArg = strtok(nullptr, " ");  // Added for gender choice [male|female|0|1] optionnel
 
     if (!cmd)
     {
-        messages.push_back("usage: list/reload/tweak/self or add/init/remove PLAYERNAME or addclass CLASSNAME [male|female]");
+        messages.push_back(
+            "usage: list/reload/tweak/self or add/init/remove PLAYERNAME or addclass CLASSNAME [male|female]");
         return messages;
     }
 
@@ -1140,22 +1237,22 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             return messages;
         }
         //  Added for gender choice : Parsing gender
-        int8 gender = -1; // -1 = gender will be random
+        int8 gender = -1;  // -1 = gender will be random
         if (genderArg)
         {
             std::string g = genderArg;
             std::transform(g.begin(), g.end(), g.begin(), ::tolower);
 
             if (g == "male" || g == "0")
-                gender = GENDER_MALE; // 0
+                gender = GENDER_MALE;  // 0
             else if (g == "female" || g == "1")
-                gender = GENDER_FEMALE; // 1
+                gender = GENDER_FEMALE;  // 1
             else
             {
                 messages.push_back("Unknown gender : " + g + " (male/female/0/1)");
                 return messages;
             }
-        } //end
+        }  // end
 
         if (claz == 6 && master->GetLevel() < sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL))
         {
@@ -1163,8 +1260,9 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             return messages;
         }
         uint8 teamId = master->GetTeamId(true);
-        const std::unordered_set<ObjectGuid> &guidCache = sRandomPlayerbotMgr->addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(teamId == TEAM_ALLIANCE, claz)];
-        for (const ObjectGuid &guid: guidCache)
+        const std::unordered_set<ObjectGuid>& guidCache =
+            sRandomPlayerbotMgr->addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(teamId == TEAM_ALLIANCE, claz)];
+        for (const ObjectGuid& guid : guidCache)
         {
             // If the user requested a specific gender, skip any character that doesn't match.
             if (gender != -1 && GetOfflinePlayerGender(guid) != gender)
@@ -1615,7 +1713,8 @@ void PlayerbotMgr::OnPlayerLogin(Player* player)
     WorldSession* session = player->GetSession();
     if (!session)
     {
-        LOG_WARN("playerbots", "Unable to register locale priority for player {} because the session is missing", player->GetName());
+        LOG_WARN("playerbots", "Unable to register locale priority for player {} because the session is missing",
+                 player->GetName());
         return;
     }
 
@@ -1625,7 +1724,7 @@ void PlayerbotMgr::OnPlayerLogin(Player* player)
     // For bot texts (DB-driven), prefer the database locale with a safe fallback.
     LocaleConstant usedLocale = databaseLocale;
     if (usedLocale >= MAX_LOCALES)
-        usedLocale = LOCALE_enUS; // fallback
+        usedLocale = LOCALE_enUS;  // fallback
 
     // set locale priority for bot texts
     sPlayerbotTextMgr->AddLocalePriority(usedLocale);
@@ -1722,6 +1821,10 @@ void PlayerbotsMgr::AddPlayerbotData(Player* player, bool isBotAI)
         ASSERT(_playerbotsMgrMap.emplace(player->GetGUID(), playerbotMgr).second);
 
         playerbotMgr->OnPlayerLogin(player);
+#ifdef MOD_PLAYERBOTS
+        if (WorldSession* sess = player->GetSession())
+            sess->SetHasPlayerbotMgr(true);
+#endif
     }
     else
     {
@@ -1751,6 +1854,11 @@ void PlayerbotsMgr::RemovePlayerBotData(ObjectGuid const& guid, bool is_AI)
         if (itr != _playerbotsMgrMap.end())
         {
             _playerbotsMgrMap.erase(itr);
+#ifdef MOD_PLAYERBOTS
+            if (Player* p = ObjectAccessor::FindConnectedPlayer(guid))
+                if (WorldSession* sess = p->GetSession())
+                    sess->SetHasPlayerbotMgr(false);
+#endif
         }
     }
 }
@@ -1805,9 +1913,8 @@ void PlayerbotMgr::HandleSetSecurityKeyCommand(Player* player, const std::string
         hashedKey << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
 
     // Store the hashed key in the database
-    PlayerbotsDatabase.Execute(
-        "REPLACE INTO playerbots_account_keys (account_id, security_key) VALUES ({}, '{}')",
-        accountId, hashedKey.str());
+    PlayerbotsDatabase.Execute("REPLACE INTO playerbots_account_keys (account_id, security_key) VALUES ({}, '{}')",
+                               accountId, hashedKey.str());
 
     ChatHandler(player->GetSession()).PSendSysMessage("Security key set successfully.");
 }
@@ -1824,7 +1931,8 @@ void PlayerbotMgr::HandleLinkAccountCommand(Player* player, const std::string& a
     Field* fields = result->Fetch();
     uint32 linkedAccountId = fields[0].Get<uint32>();
 
-    result = PlayerbotsDatabase.Query("SELECT security_key FROM playerbots_account_keys WHERE account_id = {}", linkedAccountId);
+    result = PlayerbotsDatabase.Query("SELECT security_key FROM playerbots_account_keys WHERE account_id = {}",
+                                      linkedAccountId);
     if (!result)
     {
         ChatHandler(player->GetSession()).PSendSysMessage("Invalid security key.");
@@ -1850,11 +1958,11 @@ void PlayerbotMgr::HandleLinkAccountCommand(Player* player, const std::string& a
 
     uint32 accountId = player->GetSession()->GetAccountId();
     PlayerbotsDatabase.Execute(
-        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})",
-        accountId, linkedAccountId);
+        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})", accountId,
+        linkedAccountId);
     PlayerbotsDatabase.Execute(
-        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})",
-        linkedAccountId, accountId);
+        "INSERT IGNORE INTO playerbots_account_links (account_id, linked_account_id) VALUES ({}, {})", linkedAccountId,
+        accountId);
 
     ChatHandler(player->GetSession()).PSendSysMessage("Account linked successfully.");
 }
@@ -1862,7 +1970,8 @@ void PlayerbotMgr::HandleLinkAccountCommand(Player* player, const std::string& a
 void PlayerbotMgr::HandleViewLinkedAccountsCommand(Player* player)
 {
     uint32 accountId = player->GetSession()->GetAccountId();
-    QueryResult result = PlayerbotsDatabase.Query("SELECT linked_account_id FROM playerbots_account_links WHERE account_id = {}", accountId);
+    QueryResult result = PlayerbotsDatabase.Query(
+        "SELECT linked_account_id FROM playerbots_account_links WHERE account_id = {}", accountId);
 
     if (!result)
     {
@@ -1903,8 +2012,10 @@ void PlayerbotMgr::HandleUnlinkAccountCommand(Player* player, const std::string&
     uint32 linkedAccountId = fields[0].Get<uint32>();
     uint32 accountId = player->GetSession()->GetAccountId();
 
-    PlayerbotsDatabase.Execute("DELETE FROM playerbots_account_links WHERE (account_id = {} AND linked_account_id = {}) OR (account_id = {} AND linked_account_id = {})",
-                                accountId, linkedAccountId, linkedAccountId, accountId);
+    PlayerbotsDatabase.Execute(
+        "DELETE FROM playerbots_account_links WHERE (account_id = {} AND linked_account_id = {}) OR (account_id = {} "
+        "AND linked_account_id = {})",
+        accountId, linkedAccountId, linkedAccountId, accountId);
 
     ChatHandler(player->GetSession()).PSendSysMessage("Account unlinked successfully.");
 }

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -2442,6 +2442,41 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
     PlayerbotFactory factory(bot, level);
     factory.Randomize(false);
 
+    // ---- Talent spec auto-fix (same idea as talents autopick) ----
+    if (bot->GetLevel() >= 10)
+    {
+        auto CountTalents = [](Player* p, uint32 mask) -> uint32
+        {
+            uint32 c = 0;
+            const PlayerTalentMap& tm = p->GetTalentMap();
+            for (auto const& it : tm)
+                if (it.second && (it.second->specMask & mask))
+                    ++c;
+            return c;
+        };
+
+        uint32 c1 = CountTalents(bot, 1);
+        uint32 c2 = CountTalents(bot, 2);
+
+        // Типичный слом: первый спек пустой, а таланты записаны во второй (specMask=2)
+        if (c1 == 0 && c2 > 0 && bot->GetSpecsCount() >= 2)
+        {
+            bot->ActivateSpec(1);
+            bot->resetTalents(true);  // чистим второй спек, чтобы больше не "залипало" туда
+            bot->ActivateSpec(0);
+        }
+
+        // Гарантируем, что таланты кладём в первый спек
+        if (bot->GetActiveSpec() != 0)
+            bot->ActivateSpec(0);
+
+        PlayerbotFactory fixFactory(bot, bot->GetLevel());
+        fixFactory.InitTalentsTree(false, true, true);  // reset=true
+        fixFactory.InitPetTalents();
+
+        bot->SaveToDB(false, false);  // важно: чтобы в БД стало specMask=1, а не "исправилось до релога"
+    }
+
     uint32 randomTime =
         urand(sPlayerbotAIConfig->minRandomBotRandomizeTime, sPlayerbotAIConfig->maxRandomBotRandomizeTime);
     uint32 inworldTime =
@@ -2482,6 +2517,41 @@ void RandomPlayerbotMgr::RandomizeMin(Player* bot)
     SetValue(bot, "level", level);
     PlayerbotFactory factory(bot, level);
     factory.Randomize(false);
+
+    // ---- Talent spec auto-fix (same idea as talents autopick) ----
+    if (bot->GetLevel() >= 10)
+    {
+        auto CountTalents = [](Player* p, uint32 mask) -> uint32
+        {
+            uint32 c = 0;
+            const PlayerTalentMap& tm = p->GetTalentMap();
+            for (auto const& it : tm)
+                if (it.second && (it.second->specMask & mask))
+                    ++c;
+            return c;
+        };
+
+        uint32 c1 = CountTalents(bot, 1);
+        uint32 c2 = CountTalents(bot, 2);
+
+        // Типичный слом: первый спек пустой, а таланты записаны во второй (specMask=2)
+        if (c1 == 0 && c2 > 0 && bot->GetSpecsCount() >= 2)
+        {
+            bot->ActivateSpec(1);
+            bot->resetTalents(true);  // чистим второй спек, чтобы больше не "залипало" туда
+            bot->ActivateSpec(0);
+        }
+
+        // Гарантируем, что таланты кладём в первый спек
+        if (bot->GetActiveSpec() != 0)
+            bot->ActivateSpec(0);
+
+        PlayerbotFactory fixFactory(bot, bot->GetLevel());
+        fixFactory.InitTalentsTree(false, true, true);  // reset=true
+        fixFactory.InitPetTalents();
+
+        bot->SaveToDB(false, false);  // важно: чтобы в БД стало specMask=1, а не "исправилось до релога"
+    }
 
     uint32 randomTime =
         urand(sPlayerbotAIConfig->minRandomBotRandomizeTime, sPlayerbotAIConfig->maxRandomBotRandomizeTime);
@@ -3018,6 +3088,70 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
     else
     {
         bot->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
+    }
+    if (bot->GetLevel() >= 10)
+    {
+        bot->InitTalentForLevel();
+
+        // Посчитаем, есть ли таланты в активном спеке
+        auto CountTalentsForMask = [&](uint32 mask) -> uint32
+        {
+            uint32 c = 0;
+            const PlayerTalentMap& tm = bot->GetTalentMap();
+            for (auto const& it : tm)
+            {
+                if (it.second && (it.second->specMask & mask))
+                    ++c;
+            }
+            return c;
+        };
+
+        uint32 activeMask = bot->GetActiveSpecMask();  // 1 или 2
+        uint32 activeCnt = CountTalentsForMask(activeMask);
+
+        // Если активный спек пустой — лечим (это и есть твой случай)
+        if (activeCnt == 0 && bot->GetFreeTalentPoints() > 0)
+        {
+            // принудительно используем 1-й спек, чтобы таланты писались в specMask=1
+            if (bot->GetActiveSpec() != 0)
+                bot->ActivateSpec(0);
+
+            PlayerbotFactory factory(bot, bot->GetLevel());
+            factory.InitTalentsTree(false, true, true);
+            factory.InitPetTalents();
+        }
+    }
+    if (bot->GetLevel() >= 10)
+    {
+        bot->InitTalentForLevel();
+
+        // Посчитаем, есть ли таланты в активном спеке
+        auto CountTalentsForMask = [&](uint32 mask) -> uint32
+        {
+            uint32 c = 0;
+            const PlayerTalentMap& tm = bot->GetTalentMap();
+            for (auto const& it : tm)
+            {
+                if (it.second && (it.second->specMask & mask))
+                    ++c;
+            }
+            return c;
+        };
+
+        uint32 activeMask = bot->GetActiveSpecMask();  // 1 или 2
+        uint32 activeCnt = CountTalentsForMask(activeMask);
+
+        // Если активный спек пустой — лечим (это и есть твой случай)
+        if (activeCnt == 0 && bot->GetFreeTalentPoints() > 0)
+        {
+            // принудительно используем 1-й спек, чтобы таланты писались в specMask=1
+            if (bot->GetActiveSpec() != 0)
+                bot->ActivateSpec(0);
+
+            PlayerbotFactory factory(bot, bot->GetLevel());
+            factory.InitTalentsTree(false, true, true);
+            factory.InitPetTalents();
+        }
     }
 }
 

--- a/src/strategy/actions/ChangeTalentsAction.cpp
+++ b/src/strategy/actions/ChangeTalentsAction.cpp
@@ -55,8 +55,39 @@ bool ChangeTalentsAction::Execute(Event event)
         }
         else if (param.find("autopick") != std::string::npos)
         {
+            auto CountTalents = [](Player* p, uint32 mask) -> uint32
+            {
+                uint32 c = 0;
+                auto const& tm = p->GetTalentMap();
+                for (auto const& kv : tm)
+                    if (kv.second && (kv.second->specMask & mask))
+                        ++c;
+                return c;
+            };
+
+            // После setlevel/понижения/повышения у некоторых персонажей очки талантов/спек могут быть несогласованы
+            bot->InitTalentForLevel();
+
+            uint32 c1 = CountTalents(bot, 1);
+            uint32 c2 = CountTalents(bot, 2);
+
+            // Типичный слом: таланты лежат во 2-м спеке (specMask=2), а 1-й пустой.
+            // Чистим 2-й спек, чтобы сброс/инициализация снова работали корректно.
+            if (bot->GetSpecsCount() >= 2 && c1 == 0 && c2 > 0)
+            {
+                bot->ActivateSpec(1);
+                bot->resetTalents(true);
+                bot->ActivateSpec(0);
+            }
+
+            // Гарантируем раскладку в первый спек
+            if (bot->GetActiveSpec() != 0)
+                bot->ActivateSpec(0);
+
             PlayerbotFactory factory(bot, bot->GetLevel());
-            factory.InitTalentsTree(true);
+            factory.InitTalentsTree(false, true, true);  // increment=false, use_template=true, reset=true
+            factory.InitPetTalents();
+
             out << "Auto pick talents";
             botAI->ResetStrategies();
         }


### PR DESCRIPTION
Fixing a bug where bots can't expose their talents due to the second spec.