### PR TITLE
Fix Karazhan timers

### DIFF
--- a/src/strategy/raids/karazhan/RaidKarazhanHelpers.cpp
+++ b/src/strategy/raids/karazhan/RaidKarazhanHelpers.cpp
@@ -105,8 +105,8 @@ namespace KarazhanHelpers
         }
     }
 
-    // Only one bot is needed to set/reset mapwide timers
-    bool IsMapIDTimerManager(PlayerbotAI* botAI, Player* bot)
+    // Only one bot is needed to set/reset instance-wide timers
+    bool IsInstanceTimerManager(PlayerbotAI* botAI, Player* bot)
     {
         if (Group* group = bot->GetGroup())
         {

--- a/src/strategy/raids/karazhan/RaidKarazhanHelpers.h
+++ b/src/strategy/raids/karazhan/RaidKarazhanHelpers.h
@@ -112,7 +112,7 @@ namespace KarazhanHelpers
     void MarkTargetWithCircle(Player* bot, Unit* target);
     void MarkTargetWithMoon(Player* bot, Unit* target);
     void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target);
-    bool IsMapIDTimerManager(PlayerbotAI* botAI, Player* bot);
+    bool IsInstanceTimerManager(PlayerbotAI* botAI, Player* bot);
     Unit* GetFirstAliveUnit(const std::vector<Unit*>& units);
     Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
     Unit* GetNearestPlayerInRadius(Player* bot, float radius);

--- a/src/strategy/raids/karazhan/RaidKarazhanMultipliers.cpp
+++ b/src/strategy/raids/karazhan/RaidKarazhanMultipliers.cpp
@@ -61,10 +61,11 @@ float AttumenTheHuntsmanWaitForDpsMultiplier::GetValue(Action* action)
     if (!attumenMounted)
         return 1.0f;
 
+    const uint32 instanceId = attumenMounted->GetMap()->GetInstanceId();
     const time_t now = std::time(nullptr);
     const uint8 dpsWaitSeconds = 8;
 
-    auto it = attumenDpsWaitTimer.find(KARAZHAN_MAP_ID);
+    auto it = attumenDpsWaitTimer.find(instanceId);
     if (it == attumenDpsWaitTimer.end() || (now - it->second) < dpsWaitSeconds)
     {
         if (!botAI->IsMainTank(bot))
@@ -201,10 +202,11 @@ float NetherspiteWaitForDpsMultiplier::GetValue(Action* action)
     if (!netherspite || netherspite->HasAura(SPELL_NETHERSPITE_BANISHED))
         return 1.0f;
 
+    const uint32 instanceId = netherspite->GetMap()->GetInstanceId();
     const time_t now = std::time(nullptr);
     const uint8 dpsWaitSeconds = 5;
 
-    auto it = netherspiteDpsWaitTimer.find(KARAZHAN_MAP_ID);
+    auto it = netherspiteDpsWaitTimer.find(instanceId);
     if (it == netherspiteDpsWaitTimer.end() || (now - it->second) < dpsWaitSeconds)
     {
         if (!botAI->IsTank(bot))
@@ -299,10 +301,11 @@ float NightbaneWaitForDpsMultiplier::GetValue(Action* action)
     if (!nightbane || nightbane->GetPositionZ() > NIGHTBANE_FLIGHT_Z)
         return 1.0f;
 
+    const uint32 instanceId = nightbane->GetMap()->GetInstanceId();
     const time_t now = std::time(nullptr);
     const uint8 dpsWaitSeconds = 8;
 
-    auto it = nightbaneDpsWaitTimer.find(KARAZHAN_MAP_ID);
+    auto it = nightbaneDpsWaitTimer.find(instanceId);
     if (it == nightbaneDpsWaitTimer.end() || (now - it->second) < dpsWaitSeconds)
     {
         if (!botAI->IsMainTank(bot))

--- a/src/strategy/raids/karazhan/RaidKarazhanTriggers.cpp
+++ b/src/strategy/raids/karazhan/RaidKarazhanTriggers.cpp
@@ -40,7 +40,7 @@ bool AttumenTheHuntsmanAttumenIsMountedTrigger::IsActive()
 
 bool AttumenTheHuntsmanBossWipesAggroWhenMountingTrigger::IsActive()
 {
-    if (!IsMapIDTimerManager(botAI, bot))
+    if (!IsInstanceTimerManager(botAI, bot))
         return false;
 
     Unit* midnight = AI_VALUE2(Unit*, "find target", "midnight");
@@ -110,7 +110,7 @@ bool BigBadWolfBossIsChasingLittleRedRidingHoodTrigger::IsActive()
 
 bool RomuloAndJulianneBothBossesRevivedTrigger::IsActive()
 {
-    if (!IsMapIDTimerManager(botAI, bot))
+    if (!IsInstanceTimerManager(botAI, bot))
         return false;
 
     Unit* romulo = AI_VALUE2(Unit*, "find target", "romulo");
@@ -126,7 +126,7 @@ bool RomuloAndJulianneBothBossesRevivedTrigger::IsActive()
 
 bool WizardOfOzNeedTargetPriorityTrigger::IsActive()
 {
-    if (!IsMapIDTimerManager(botAI, bot))
+    if (!IsInstanceTimerManager(botAI, bot))
         return false;
 
     Unit* dorothee = AI_VALUE2(Unit*, "find target", "dorothee");
@@ -178,7 +178,7 @@ bool TheCuratorBossAstralFlaresCastArcingSearTrigger::IsActive()
 
 bool TerestianIllhoofNeedTargetPriorityTrigger::IsActive()
 {
-    if (!IsMapIDTimerManager(botAI, bot))
+    if (!IsInstanceTimerManager(botAI, bot))
         return false;
 
     Unit* illhoof = AI_VALUE2(Unit*, "find target", "terestian illhoof");
@@ -202,7 +202,7 @@ bool ShadeOfAranFlameWreathIsActiveTrigger::IsActive()
 // Exclusion of Banish is so the player may Banish elementals if they wish
 bool ShadeOfAranConjuredElementalsSummonedTrigger::IsActive()
 {
-    if (!IsMapIDTimerManager(botAI, bot))
+    if (!IsInstanceTimerManager(botAI, bot))
         return false;
 
     Unit* elemental = AI_VALUE2(Unit*, "find target", "conjured elemental");
@@ -279,7 +279,7 @@ bool NetherspiteBossIsBanishedTrigger::IsActive()
 
 bool NetherspiteNeedToManageTimersAndTrackersTrigger::IsActive()
 {
-    if (!botAI->IsTank(bot) && !IsMapIDTimerManager(botAI, bot))
+    if (!botAI->IsTank(bot) && !IsInstanceTimerManager(botAI, bot))
         return false;
 
     Unit* netherspite = AI_VALUE2(Unit*, "find target", "netherspite");
@@ -370,11 +370,12 @@ bool NightbaneBossIsFlyingTrigger::IsActive()
     if (!nightbane || nightbane->GetPositionZ() <= NIGHTBANE_FLIGHT_Z)
         return false;
 
+    const uint32 instanceId = nightbane->GetMap()->GetInstanceId();
     const time_t now = std::time(nullptr);
     const uint8 flightPhaseDurationSeconds = 35;
 
-    return nightbaneFlightPhaseStartTimer.find(KARAZHAN_MAP_ID) != nightbaneFlightPhaseStartTimer.end() &&
-           (now - nightbaneFlightPhaseStartTimer[KARAZHAN_MAP_ID] < flightPhaseDurationSeconds);
+    return nightbaneFlightPhaseStartTimer.find(instanceId) != nightbaneFlightPhaseStartTimer.end() &&
+           (now - nightbaneFlightPhaseStartTimer[instanceId] < flightPhaseDurationSeconds);
 }
 
 bool NightbaneNeedToManageTimersAndTrackersTrigger::IsActive()


### PR DESCRIPTION
I'm not 100% sure but think that the current implementation of timers for Attumen, Netherspite, and Nightbane with the instance's map id as the key would result in the timers being shared across separate raids running the instance at the same time. I've refactored to use the instance id as the key for all shared timers so to the extent this was an issue, it shouldn't be anymore.

I also made some minor tweaks to the tank positioning for BBW and Curator as I noticed there was some weirdness in the logic that I neglected to address with the refactor.