### PR TITLE
Hotfix after recent changes related to the refactoring of IsMovingAllowed

### DIFF
--- a/src/strategy/actions/MovementActions.cpp
+++ b/src/strategy/actions/MovementActions.cpp
@@ -972,8 +972,7 @@ bool MovementAction::IsMovingAllowed()
     // Vehicle state: is in the vehicle and can control it (rare, content-specific).
     // We need to check charmed state AFTER vehicle one, cuz that's how it works:
     // passengers are set to charmed by vehicle with CHARM_TYPE_VEHICLE.
-    if ((bot->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && !botAI->IsInVehicle(true)) ||
-        bot->IsCharmed())
+    if ((bot->GetVehicle() && !botAI->IsInVehicle(true)) || bot->IsCharmed())
         return false;
 
     return true;


### PR DESCRIPTION
Hotfix for the issue where bots can't enter/move on transports (elevators, zeppelins, ships, etc.). Change the logic to determine if bot is on a vehicle. According to the current implementation in AzerothCore, `GetVehicle()` is the most common approach for this. Additionally, other checks related to the vehicle: `GetBase`, `IsAlive`, `GetVehicleInfo`, and `GetSeatForPassenger` -- are processed inside `IsInVehicle`.

This should be more than enough to determine if the bot is on a vehicle and can/cant control it.

Issue: https://github.com/mod-playerbots/mod-playerbots/issues/1927