### PR TITLE
Magtheridon timer keys fix

### DIFF
--- a/src/strategy/raids/magtheridon/RaidMagtheridonActions.cpp
+++ b/src/strategy/raids/magtheridon/RaidMagtheridonActions.cpp
@@ -401,11 +401,15 @@ std::unordered_map<ObjectGuid, bool> MagtheridonSpreadRangedAction::hasReachedIn
 
 bool MagtheridonSpreadRangedAction::Execute(Event event)
 {
+    Unit* magtheridon = AI_VALUE2(Unit*, "find target", "magtheridon");
+    if (!magtheridon)
+        return false;
+
     Group* group = bot->GetGroup();
     if (!group)
         return false;
 
-    const uint32 instanceId = magtheridon->GetMap()->GetInstanceId()
+    const uint32 instanceId = magtheridon->GetMap()->GetInstanceId();
 
     // Wait for 6 seconds after Magtheridon activates to spread
     const uint8 spreadWaitSeconds = 6;
@@ -511,7 +515,7 @@ bool MagtheridonUseManticronCubeAction::Execute(Event event)
     if (!magtheridon)
         return false;
 
-    auto it = botToCubeAssignment.find(magtheridon->GetMap()->GetInstanceId());
+    auto it = botToCubeAssignment.find(bot->GetGUID());
     const CubeInfo& cubeInfo = it->second;
     GameObject* cube = botAI->GetGameObject(cubeInfo.guid);
     if (!cube)
@@ -653,27 +657,27 @@ bool MagtheridonManageTimersAndAssignmentsAction::Execute(Event event)
         return false;
 
     const uint32 instanceId = magtheridon->GetMap()->GetInstanceId();
+    const time_t now = time(nullptr);
 
     bool blastNovaActive = magtheridon->HasUnitState(UNIT_STATE_CASTING) &&
                            magtheridon->FindCurrentSpellBySpellId(SPELL_BLAST_NOVA);
     bool lastBlastNova = lastBlastNovaState[instanceId];
 
     if (lastBlastNova && !blastNovaActive && IsInstanceTimerManager(botAI, bot))
-        blastNovaTimer[instanceId] = time(nullptr);
+        blastNovaTimer[instanceId] = now;
 
     lastBlastNovaState[instanceId] = blastNovaActive;
 
-    if (IsInstanceTimerManager(botAI, bot))
+    if (!magtheridon->HasAura(SPELL_SHADOW_CAGE))
     {
-        if (!magtheridon->HasAura(SPELL_SHADOW_CAGE))
+        if (IsInstanceTimerManager(botAI, bot))
         {
-            spreadWaitTimer.try_emplace(instanceId, time(nullptr));
-            blastNovaTimer.try_emplace(instanceId, time(nullptr));
-            dpsWaitTimer.try_emplace(instanceId, time(nullptr));
+            spreadWaitTimer.try_emplace(instanceId, now);
+            blastNovaTimer.try_emplace(instanceId, now);
+            dpsWaitTimer.try_emplace(instanceId, now);
         }
     }
-
-    if (magtheridon->HasAura(SPELL_SHADOW_CAGE))
+    else
     {
         MagtheridonSpreadRangedAction::initialPositions.clear();
         MagtheridonSpreadRangedAction::hasReachedInitialPosition.clear();

--- a/src/strategy/raids/magtheridon/RaidMagtheridonHelpers.cpp
+++ b/src/strategy/raids/magtheridon/RaidMagtheridonHelpers.cpp
@@ -172,7 +172,7 @@ namespace MagtheridonHelpers
     std::unordered_map<uint32, bool> lastBlastNovaState;
     std::unordered_map<uint32, time_t> blastNovaTimer;
     std::unordered_map<uint32, time_t> spreadWaitTimer;
-    std::unordered_map<uint32, time_t> aggroWaitTimer;
+    std::unordered_map<uint32, time_t> dpsWaitTimer;
 
     bool IsSafeFromMagtheridonHazards(PlayerbotAI* botAI, Player* bot, float x, float y, float z)
     {

--- a/src/strategy/raids/magtheridon/RaidMagtheridonHelpers.h
+++ b/src/strategy/raids/magtheridon/RaidMagtheridonHelpers.h
@@ -84,7 +84,7 @@ namespace MagtheridonHelpers
     extern std::unordered_map<uint32, bool> lastBlastNovaState;
     extern std::unordered_map<uint32, time_t> blastNovaTimer;
     extern std::unordered_map<uint32, time_t> spreadWaitTimer;
-    extern std::unordered_map<uint32, time_t> aggroWaitTimer;
+    extern std::unordered_map<uint32, time_t> dpsWaitTimer;
 }
 
 #endif

--- a/src/strategy/raids/magtheridon/RaidMagtheridonMultipliers.cpp
+++ b/src/strategy/raids/magtheridon/RaidMagtheridonMultipliers.cpp
@@ -41,10 +41,10 @@ float MagtheridonWaitToAttackMultiplier::GetValue(Action* action)
     if (!magtheridon || magtheridon->HasAura(SPELL_SHADOW_CAGE))
         return 1.0f;
 
-    const uint8 aggroWaitSeconds = 6;
-    auto it = aggroWaitTimer.find(magtheridon->GetMap()->GetInstanceId());
-    if (it == aggroWaitTimer.end() ||
-        (time(nullptr) - it->second) < aggroWaitSeconds)
+    const uint8 dpsWaitSeconds = 6;
+    auto it = dpsWaitTimer.find(magtheridon->GetMap()->GetInstanceId());
+    if (it == dpsWaitTimer.end() ||
+        (time(nullptr) - it->second) < dpsWaitSeconds)
     {
         if (!botAI->IsMainTank(bot) && (dynamic_cast<AttackAction*>(action) ||
             (!botAI->IsHeal(bot) && dynamic_cast<CastSpellAction*>(action))))


### PR DESCRIPTION
Same deal as Karazhan--changing map id to instance id for timer keys to prevent conflicts from multiple groups (plus other tweaks with respect to the timers). This strategy could use a broader refactor, but that's for another day--this PR is just to address the timer logic.