### PR TITLE
Exclude additional test enchants from bots

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -121,8 +121,11 @@ void PlayerbotFactory::Init()
     uint32 maxStoreSize = sSpellMgr->GetSpellInfoStoreSize();
     for (uint32 id = 1; id < maxStoreSize; ++id)
     {
-        if (id == 7218 || id == 19927 || id == 35791 || id == 44119 || id == 47147 || id == 47181 ||
-            id == 47242 || id == 50358 || id == 52639)  // Test Enchants
+        if (id == 7218 || id == 19927 || id == 44119 || id == 47147 || id == 47181 ||
+            id == 47242 || id == 50358 || id == 52639) // Test Enchants
+            continue;
+
+        if (id == 35791 || id == 39405) // Grandfathered TBC Enchants
             continue;
 
         if (id == 15463 || id == 15490) // Legendary Arcane Amalgamation


### PR DESCRIPTION
Added two test enchants to exclude from the list of enchants that bots can apply: 19927 and 44119. I also reordered the list to be in alphanumeric order.

The important exclusion to add is 44119: https://www.wowhead.com/wotlk/spell=44119/enchant-bracer-template

It is a test enchant that gives 34 AP on bracers; this is stronger than any other bracer enchant for level 70 physical attackers so bots are applying it.