### PR TITLE
Fix deprecated vsprintf usage in Engine logging

### DIFF
--- a/src/strategy/Engine.cpp
+++ b/src/strategy/Engine.cpp
@@ -602,7 +602,7 @@ void Engine::LogAction(char const* format, ...)
 
     va_list ap;
     va_start(ap, format);
-    vsprintf(buf, format, ap);
+    vsnprintf(buf, sizeof(buf), format, ap);
     va_end(ap);
 
     lastAction += "|";


### PR DESCRIPTION
Replace deprecated vsprintf with vsnprintf to eliminate compiler warning and prevent potential buffer overflow.