### PR TITLE
Add pvp gear to bots in bg and arena

### DIFF
--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -119,6 +119,45 @@ namespace
     static uint32 GetQueuedRealPlayersMatchmakerTarget(BattlegroundQueueTypeId queueTypeId, BattlegroundBracketId bracketId,
                                                        ArenaType arenaType)
     {
+        // This scan over bgQueue.m_QueuedPlayers can be quite expensive when called frequently
+        // (e.g. 2000 bots evaluating arena queues). Cache for a short TTL to avoid N-times-per-tick work.
+        struct Key
+        {
+            uint32 q = 0;
+            uint8 bracket = 0;
+            uint8 arena = 0;
+
+            bool operator==(Key const& o) const { return q == o.q && bracket == o.bracket && arena == o.arena; }
+        };
+
+        struct KeyHash
+        {
+            size_t operator()(Key const& k) const
+            {
+                // Simple mix: q uses low bits, then bracket/arena.
+                return (size_t(k.q) * 1315423911u) ^ (size_t(k.bracket) << 8) ^ size_t(k.arena);
+            }
+        };
+
+        struct CacheEntry
+        {
+            uint32 target = 0;
+            uint32 tsMs = 0;
+        };
+
+        static std::unordered_map<Key, CacheEntry, KeyHash> s_cache;
+        static uint32 s_lastPruneMs = 0;
+        constexpr uint32 kTtlMs = 1000;
+        constexpr uint32 kPruneEveryMs = 5000;
+        constexpr size_t kMaxEntries = 64;
+
+        uint32 nowMs = getMSTime();
+        Key key{uint32(queueTypeId), uint8(bracketId), uint8(arenaType)};
+
+        auto itCached = s_cache.find(key);
+        if (itCached != s_cache.end() && (nowMs - itCached->second.tsMs) <= kTtlMs)
+            return itCached->second.target;
+
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
 
         uint64 sum = 0;
@@ -164,10 +203,24 @@ namespace
             ++count;
         }
 
-        if (!count)
-            return 0;
+        uint32 target = count ? uint32(sum / count) : 0;
 
-        return uint32(sum / count);
+        s_cache[key] = CacheEntry{target, nowMs};
+
+        // Opportunistic prune to keep the cache tiny.
+        if (s_cache.size() > kMaxEntries && (nowMs - s_lastPruneMs) > kPruneEveryMs)
+        {
+            s_lastPruneMs = nowMs;
+            for (auto it = s_cache.begin(); it != s_cache.end();)
+            {
+                if ((nowMs - it->second.tsMs) > kPruneEveryMs)
+                    it = s_cache.erase(it);
+                else
+                    ++it;
+            }
+        }
+
+        return target;
     }
 
     static uint16 ClampArenaRating(int32 rating)
@@ -1368,21 +1421,43 @@ bool BGStrategyCheckAction::Execute(Event event)
         return false;
 
     // Random bots: generate PvP gear + enchants after fully entering BG/arena.
-    // - Wild random bots use RandomGear* limits (AiPlayerbot.RandomGearQualityLimit/RandomGearScoreLimit).
-    // - Random bots with a real player master use AutoGear* limits (AiPlayerbot.AutoGearQualityLimit/AutoGearScoreLimit).
-    // Alt bots are not affected by this logic.
     bool hasRealMaster = botAI->HasRealPlayerMaster();
 
-    uint32 qualityLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearQualityLimit
-                                        : sPlayerbotAIConfig->randomGearQualityLimit;
+    // Do not touch player-controlled (real master) bots here. This logic is for wild random bots only.
+    if (hasRealMaster)
+        return false;
 
-    uint32 scoreLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearScoreLimit
-                                      : sPlayerbotAIConfig->randomGearScoreLimit;
+    uint32 qualityLimit = sPlayerbotAIConfig->randomGearQualityLimit;
+    uint32 scoreLimit = sPlayerbotAIConfig->randomGearScoreLimit;
 
     uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
 
     bool isArena = bg->isArena();
     bool isRatedArena = isArena && bg->isRated();
+
+    // Battleground gear cap for wild random bots (level 80 only).
+    // Deterministic per-bot item-level cap in [200..300] based on bot GUID low.
+    // This is an extra restriction on top of the configured gear limit.
+    if (bot->GetLevel() == 80 && !isArena)
+    {
+        uint32 x = botLow;
+        x ^= x >> 16;
+        x *= 0x7feb352d;
+        x ^= x >> 15;
+        x *= 0x846ca68b;
+        x ^= x >> 16;
+
+        uint32 ilvlCap = 200u + (x % 101u); // 200..300
+
+        // Convert item-level cap to the same "mixed gear score" scale used by PlayerbotFactory.
+        uint32 bgGsCap = PlayerbotFactory::CalcMixedGearScore(ilvlCap, ITEM_QUALITY_EPIC);
+        if (bgGsCap == 0)
+            bgGsCap = 1;
+
+        if (gs == 0 || bgGsCap < gs)
+            gs = bgGsCap;
+    }
+
 
     // Additional arena rating-based gear cap (level 80 only).
     // 1000 rating => ilvl 200, 2400 rating => ilvl 300 (hard cap).

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -1123,11 +1123,54 @@ bool BGStrategyCheckAction::Execute(Event event)
 
             uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
 
+            // Additional arena rating-based gear cap (level 80 only).
+            // 1000 rating => ilvl 200, 2400 rating => ilvl 300 (hard cap).
+            // This is an extra restriction on top of the configured gear limit.
+            if (bot->GetLevel() == 80 && bot->InArena())
+            {
+                uint32 rating = 0;
+
+                if (Battleground* bg = bot->GetBattleground())
+                {
+                    if (bg->isArena())
+                    {
+                        uint8 arenaType = bg->GetArenaType(); // 2,3,5
+                        uint8 slot = ArenaTeam::GetSlotByType(arenaType);
+                        uint32 teamId = bot->GetArenaTeamId(slot);
+                        if (teamId)
+                        {
+                            if (ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(teamId))
+                                rating = team->GetRating();
+                        }
+                    }
+                }
+
+                // Treat unrated/skirmish/unknown as low rating.
+                if (rating == 0)
+                    rating = 1000;
+
+                float ilvlCapF = 200.0f;
+                if (rating >= 2400)
+                    ilvlCapF = 300.0f;
+                else if (rating > 1000)
+                    ilvlCapF = 200.0f + float(rating - 1000) * (100.0f / 1400.0f);
+
+                uint32 ilvlCap = uint32(ilvlCapF + 0.5f);
+
+                // Convert item-level cap to the same "mixed gear score" scale used by PlayerbotFactory.
+                uint32 ratingGsCap = PlayerbotFactory::CalcMixedGearScore(ilvlCap, ITEM_QUALITY_EPIC);
+                if (ratingGsCap == 0)
+                    ratingGsCap = 1;
+
+                if (gs == 0 || ratingGsCap < gs)
+                    gs = ratingGsCap;
+            }
+
             uint8 savedLevel = bot->GetLevel();
             PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
 
             // Force gear generation; do not touch talents/level/spells/etc.
-            factory.InitEquipment(false);
+            factory.InitEquipment(false, bot->InArena());
 
             // Apply enchants/gems only.
             if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -6,6 +6,7 @@
 #include "BattleGroundJoinAction.h"
 
 #include <unordered_map>
+#include <algorithm>
 
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
@@ -17,6 +18,99 @@
 #include "PositionValue.h"
 #include "UpdateTime.h"
 #include "PlayerbotFactory.h"
+
+namespace
+{
+    // For Random Battleground queue (RB), the template BG is typically 10v10 and does not reflect the
+    // actual battleground that will be selected (10/15/40). For queue filling we want a safe upper bound
+    // that matches the largest possible battleground size for the current level bracket, while keeping
+    // "bots only queue with real players" behavior unchanged (that logic is controlled elsewhere).
+    static uint32 GetRandomBgMaxPlayersPerTeam(Player* bot, BattlegroundBracketId bracketId)
+    {
+        // Cache per bracket to avoid scanning every tick.
+        static uint32 sCachedSize[MAX_BATTLEGROUND_BRACKETS] = {};
+        static bool sCachedValid[MAX_BATTLEGROUND_BRACKETS] = {};
+
+        uint32 br = uint32(bracketId);
+        if (br < MAX_BATTLEGROUND_BRACKETS && sCachedValid[br] && sCachedSize[br])
+            return sCachedSize[br];
+
+        uint32 level = bot ? bot->GetLevel() : 0;
+        uint32 maxTeamSize = 0;
+
+        // Scan battleground queue types (non-arena, non-RB) and pick the largest team size that is valid
+        // for this bracket and accessible for the bot's level.
+        for (int qt = BATTLEGROUND_QUEUE_AV; qt < MAX_BATTLEGROUND_QUEUE_TYPES; ++qt)
+        {
+            BattlegroundQueueTypeId qid = BattlegroundQueueTypeId(qt);
+
+            // Ignore random battleground and all-arenas pseudo queues.
+            if (qid == BATTLEGROUND_QUEUE_RB)
+                continue;
+
+            // Ignore arenas.
+            if (BattlegroundMgr::BGArenaType(qid) != ARENA_TYPE_NONE)
+                continue;
+
+            BattlegroundTypeId tid = BattlegroundMgr::BGTemplateId(qid);
+            if (tid == BATTLEGROUND_RB)
+                continue;
+
+            if (bot && !bot->GetBGAccessByLevel(tid))
+                continue;
+
+            Battleground* tmpl = sBattlegroundMgr->GetBattlegroundTemplate(tid);
+            if (!tmpl)
+                continue;
+
+            PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(tmpl->GetMapId(), level);
+            if (!pvpDiff || pvpDiff->GetBracketId() != bracketId)
+                continue;
+
+            maxTeamSize = std::max<uint32>(maxTeamSize, tmpl->GetMaxPlayersPerTeam());
+        }
+
+        // Fallback: use RB template size (usually 10) if nothing matched.
+        if (!maxTeamSize)
+        {
+            Battleground* rbTmpl = sBattlegroundMgr->GetBattlegroundTemplate(BATTLEGROUND_RB);
+            maxTeamSize = rbTmpl ? rbTmpl->GetMaxPlayersPerTeam() : 10;
+        }
+
+        // Safety clamp (WotLK max is 40).
+        if (maxTeamSize > 40)
+            maxTeamSize = 40;
+        if (!maxTeamSize)
+            maxTeamSize = 10;
+
+        if (br < MAX_BATTLEGROUND_BRACKETS)
+        {
+            sCachedSize[br] = maxTeamSize;
+            sCachedValid[br] = true;
+        }
+
+        return maxTeamSize;
+    }
+
+    static uint32 GetEffectiveMaxPlayersPerTeam(Player* bot, BattlegroundTypeId bgTypeId, BattlegroundBracketId bracketId, Battleground* bgTemplate)
+    {
+        if (!bgTemplate)
+            return 0;
+
+        uint32 teamSize = bgTemplate->GetMaxPlayersPerTeam();
+
+        // Random BG template size is not representative; use bracket-aware upper bound.
+        if (bgTypeId == BATTLEGROUND_RB)
+            teamSize = GetRandomBgMaxPlayersPerTeam(bot, bracketId);
+
+        if (teamSize > 40)
+            teamSize = 40;
+        if (!teamSize)
+            teamSize = 10;
+
+        return teamSize;
+    }
+} // namespace
 
 bool BGJoinAction::Execute(Event event)
 {
@@ -238,8 +332,8 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
         return false;
 
     TeamId teamId = bot->GetTeamId();
-    uint32 BracketSize = bg->GetMaxPlayersPerTeam() * 2;
-    uint32 TeamSize = bg->GetMaxPlayersPerTeam();
+    uint32 TeamSize = GetEffectiveMaxPlayersPerTeam(bot, bgTypeId, bracketId, bg);
+    uint32 BracketSize = TeamSize * 2;
 
     // If the bot is in a group, only the leader can queue
     if (bot->GetGroup() && !bot->GetGroup()->IsLeader(bot->GetGUID()))
@@ -411,9 +505,8 @@ bool BGJoinAction::JoinQueue(uint32 type)
         return false;
 
     bracketId = pvpDiff->GetBracketId();
-
-    uint32 BracketSize = bg->GetMaxPlayersPerTeam() * 2;
-    uint32 TeamSize = bg->GetMaxPlayersPerTeam();
+    uint32 TeamSize = GetEffectiveMaxPlayersPerTeam(bot, bgTypeId, bracketId, bg);
+    uint32 BracketSize = TeamSize * 2;
     TeamId teamId = bot->GetTeamId();
 
     // check if already in queue
@@ -575,9 +668,8 @@ bool FreeBGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battleg
         return false;
 
     TeamId teamId = bot->GetTeamId();
-
-    uint32 BracketSize = bg->GetMaxPlayersPerTeam() * 2;
-    uint32 TeamSize = bg->GetMaxPlayersPerTeam();
+    uint32 TeamSize = GetEffectiveMaxPlayersPerTeam(bot, bgTypeId, bracketId, bg);
+    uint32 BracketSize = TeamSize * 2;
 
     // If the bot is in a group, only the leader can queue
     if (bot->GetGroup() && !bot->GetGroup()->IsLeader(bot->GetGUID()))
@@ -963,7 +1055,19 @@ bool BGStatusAction::Execute(Event event)
         if (isArena)
             timer = TIME_TO_AUTOREMOVE;
         else
-            timer = TIME_TO_AUTOREMOVE + 1000 * (bg->GetMaxPlayersPerTeam() * 8);
+        {
+            uint32 teamSize = bg->GetMaxPlayersPerTeam();
+
+            // For Random Battleground queue, use bracket-aware upper bound so bots don't leave too early
+            // when a 15v15 or 40v40 battleground is selected.
+            if (_bgTypeId == BATTLEGROUND_RB)
+            {
+                if (PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(bg->GetMapId(), bot->GetLevel()))
+                    teamSize = GetEffectiveMaxPlayersPerTeam(bot, _bgTypeId, pvpDiff->GetBracketId(), bg);
+            }
+
+            timer = TIME_TO_AUTOREMOVE + 1000 * (teamSize * 8);
+        }
 
         if (Time2 > timer && isArena)  // disabled for BG
             leaveQ = true;

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -5,6 +5,8 @@
 
 #include "BattleGroundJoinAction.h"
 
+#include <unordered_map>
+
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "BattlegroundMgr.h"
@@ -1096,88 +1098,134 @@ bool BGStatusCheckAction::isUseful() { return bot->InBattlegroundQueue(); }
 
 bool BGStrategyCheckAction::Execute(Event event)
 {
-    bool inside_bg = bot->InBattleground() && bot->GetBattleground();
-    ;
-    if (!inside_bg && botAI->HasStrategy("battleground", BOT_STATE_NON_COMBAT))
-    {
-        botAI->ResetStrategies();
-        return true;
-    }
-    if (inside_bg && !botAI->HasStrategy("battleground", BOT_STATE_NON_COMBAT))
-    {
-        botAI->ResetStrategies();
+    static std::unordered_map<uint32, uint32> s_lastSeenInstanceIdByBot;
+    static std::unordered_map<uint32, uint32> s_lastSwapInstanceIdByBot;
 
-        // Random bots: generate PvP gear + enchants after fully entering BG/arena.
-        // - Wild random bots use RandomGear* limits (AiPlayerbot.RandomGearQualityLimit/RandomGearScoreLimit).
-        // - Random bots with a real player master use AutoGear* limits (AiPlayerbot.AutoGearQualityLimit/AutoGearScoreLimit).
-        // Alt bots are not affected by this logic.
-        if (sRandomPlayerbotMgr->IsRandomBot(bot))
+    uint32 botLow = bot->GetGUID().GetCounter();
+
+    // Note: InBattleground() can be true for a short moment while GetBattleground() is still null during transfer.
+    // Never treat a temporary null Battleground* as "left the battleground", or bots may lose their BG tactics and idle.
+    bool inBg = bot->InBattleground();
+
+    Battleground* bg = bot->GetBattleground();
+    bool inside_bg = inBg && bg;
+
+    // If we left BG/arena, restore normal strategies exactly once.
+    if (!inBg)
+    {
+        auto itSeen = s_lastSeenInstanceIdByBot.find(botLow);
+        auto itSwap = s_lastSwapInstanceIdByBot.find(botLow);
+        if (itSeen != s_lastSeenInstanceIdByBot.end() || itSwap != s_lastSwapInstanceIdByBot.end())
         {
-            bool hasRealMaster = botAI->HasRealPlayerMaster();
-
-            uint32 qualityLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearQualityLimit
-                                                : sPlayerbotAIConfig->randomGearQualityLimit;
-
-            uint32 scoreLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearScoreLimit
-                                              : sPlayerbotAIConfig->randomGearScoreLimit;
-
-            uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
-
-            // Additional arena rating-based gear cap (level 80 only).
-            // 1000 rating => ilvl 200, 2400 rating => ilvl 300 (hard cap).
-            // This is an extra restriction on top of the configured gear limit.
-            if (bot->GetLevel() == 80 && bot->InArena())
-            {
-                uint32 rating = 0;
-
-                if (Battleground* bg = bot->GetBattleground())
-                {
-                    if (bg->isArena())
-                    {
-                        uint8 arenaType = bg->GetArenaType(); // 2,3,5
-                        uint8 slot = ArenaTeam::GetSlotByType(arenaType);
-                        uint32 teamId = bot->GetArenaTeamId(slot);
-                        if (teamId)
-                        {
-                            if (ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(teamId))
-                                rating = team->GetRating();
-                        }
-                    }
-                }
-
-                // Treat unrated/skirmish/unknown as low rating.
-                if (rating == 0)
-                    rating = 1000;
-
-                float ilvlCapF = 200.0f;
-                if (rating >= 2400)
-                    ilvlCapF = 300.0f;
-                else if (rating > 1000)
-                    ilvlCapF = 200.0f + float(rating - 1000) * (100.0f / 1400.0f);
-
-                uint32 ilvlCap = uint32(ilvlCapF + 0.5f);
-
-                // Convert item-level cap to the same "mixed gear score" scale used by PlayerbotFactory.
-                uint32 ratingGsCap = PlayerbotFactory::CalcMixedGearScore(ilvlCap, ITEM_QUALITY_EPIC);
-                if (ratingGsCap == 0)
-                    ratingGsCap = 1;
-
-                if (gs == 0 || ratingGsCap < gs)
-                    gs = ratingGsCap;
-            }
-
-            uint8 savedLevel = bot->GetLevel();
-            PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
-
-            // Force gear generation; do not touch talents/level/spells/etc.
-            factory.InitEquipment(false, bot->InArena());
-
-            // Apply enchants/gems only.
-            if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
-                factory.ApplyEnchantAndGemsNew();
+            s_lastSeenInstanceIdByBot.erase(botLow);
+            s_lastSwapInstanceIdByBot.erase(botLow);
+            botAI->ResetStrategies();
+            return true;
         }
 
         return false;
     }
+
+    // Still entering/loading: wait until Battleground* becomes available.
+    if (!inside_bg)
+        return false;
+
+    uint32 instanceId = bg->GetInstanceID();
+    if (!instanceId)
+        return false;
+
+    // Apply BG/arena tactics once per BG/arena instance.
+    auto itSeen = s_lastSeenInstanceIdByBot.find(botLow);
+    if (itSeen == s_lastSeenInstanceIdByBot.end() || itSeen->second != instanceId)
+    {
+        s_lastSeenInstanceIdByBot[botLow] = instanceId;
+        s_lastSwapInstanceIdByBot.erase(botLow);  // allow swap in this new instance
+        botAI->ResetStrategies();
+        // Do not return: we may swap gear in the same tick once the bot is fully on the BG map.
+    }
+
+    // Wild random bots only.
+    if (!sRandomPlayerbotMgr || !sRandomPlayerbotMgr->IsRandomBot(bot))
+        return false;
+
+    // Wait until the bot is actually on the BG/arena map (avoid swapping during transfer).
+    if (!bot->IsInWorld() || bot->IsBeingTeleported() || bot->IsDuringRemoveFromWorld() || bot->GetMapId() != bg->GetMapId())
+        return false;
+
+    auto itSwap = s_lastSwapInstanceIdByBot.find(botLow);
+    if (itSwap != s_lastSwapInstanceIdByBot.end() && itSwap->second == instanceId)
+        return false;
+
+    // Random bots: generate PvP gear + enchants after fully entering BG/arena.
+    // - Wild random bots use RandomGear* limits (AiPlayerbot.RandomGearQualityLimit/RandomGearScoreLimit).
+    // - Random bots with a real player master use AutoGear* limits (AiPlayerbot.AutoGearQualityLimit/AutoGearScoreLimit).
+    // Alt bots are not affected by this logic.
+    bool hasRealMaster = botAI->HasRealPlayerMaster();
+
+    uint32 qualityLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearQualityLimit
+                                        : sPlayerbotAIConfig->randomGearQualityLimit;
+
+    uint32 scoreLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearScoreLimit
+                                      : sPlayerbotAIConfig->randomGearScoreLimit;
+
+    uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
+
+    bool isArena = bg->isArena();
+    bool isRatedArena = isArena && bg->isRated();
+
+    // Additional arena rating-based gear cap (level 80 only).
+    // 1000 rating => ilvl 200, 2400 rating => ilvl 300 (hard cap).
+    // This is an extra restriction on top of the configured gear limit.
+    if (bot->GetLevel() == 80 && isArena)
+    {
+        uint32 rating = 0;
+
+        // Only rated arenas have meaningful team rating. Skirmish stays at rating=0 and will fall back to 1000.
+        if (isRatedArena)
+        {
+            uint8 arenaType = bg->GetArenaType();  // 2,3,5
+            uint8 slot = ArenaTeam::GetSlotByType(arenaType);
+            uint32 teamId = bot->GetArenaTeamId(slot);
+            if (teamId)
+            {
+                if (ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(teamId))
+                    rating = team->GetRating();
+            }
+        }
+
+        // Treat unrated/skirmish/unknown as low rating.
+        if (rating == 0)
+            rating = 1000;
+
+        float ilvlCapF = 200.0f;
+        if (rating >= 2400)
+            ilvlCapF = 300.0f;
+        else if (rating > 1000)
+            ilvlCapF = 200.0f + float(rating - 1000) * (100.0f / 1400.0f);
+
+        uint32 ilvlCap = uint32(ilvlCapF + 0.5f);
+
+        // Convert item-level cap to the same "mixed gear score" scale used by PlayerbotFactory.
+        uint32 ratingGsCap = PlayerbotFactory::CalcMixedGearScore(ilvlCap, ITEM_QUALITY_EPIC);
+        if (ratingGsCap == 0)
+            ratingGsCap = 1;
+
+        if (gs == 0 || ratingGsCap < gs)
+            gs = ratingGsCap;
+    }
+
+    uint8 savedLevel = bot->GetLevel();
+    PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
+
+    // Force gear generation; do not touch talents/level/spells/etc.
+    factory.InitEquipment(false, true);
+
+    // Apply enchants/gems only.
+    if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
+        factory.ApplyEnchantAndGemsNew();
+
+    // Remember that this bot already swapped gear for this BG/arena instance.
+    s_lastSwapInstanceIdByBot[botLow] = instanceId;
+
     return false;
 }

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -6,6 +6,7 @@
 #include "BattleGroundJoinAction.h"
 
 #include <unordered_map>
+#include <unordered_set>
 #include <algorithm>
 
 #include "ArenaTeam.h"
@@ -13,6 +14,7 @@
 #include "BattlegroundMgr.h"
 #include "Event.h"
 #include "GroupMgr.h"
+#include "ObjectAccessor.h"
 #include "PlayerbotAI.h"
 #include "Playerbots.h"
 #include "PositionValue.h"
@@ -110,6 +112,93 @@ namespace
 
         return teamSize;
     }
+
+
+    // For rated arenas we want bot teams to be near the rating/MMR of real players currently queued
+    // for the same bracket and arena type.
+    static uint32 GetQueuedRealPlayersMatchmakerTarget(BattlegroundQueueTypeId queueTypeId, BattlegroundBracketId bracketId,
+                                                       ArenaType arenaType)
+    {
+        BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
+
+        uint64 sum = 0;
+        uint32 count = 0;
+        std::unordered_set<uint32> seenArenaTeams;
+
+        for (auto const& qp : bgQueue.m_QueuedPlayers)
+        {
+            ObjectGuid guid = qp.first;
+            Player* player = ObjectAccessor::FindConnectedPlayer(guid);
+            if (!player || !player->GetSession())
+                continue;
+
+            // Only use real players as target source
+            if (player->GetSession()->IsBot())
+                continue;
+
+            GroupQueueInfo ginfo;
+            if (!bgQueue.GetPlayerGroupInfoData(guid, &ginfo))
+                continue;
+
+            if (!ginfo.IsRated)
+                continue;
+
+            if (ginfo.BracketId != uint8(bracketId))
+                continue;
+
+            if (ginfo.ArenaType != uint8(arenaType))
+                continue;
+
+            // De-duplicate by arena team id so a premade group doesn't overweight the average
+            if (ginfo.ArenaTeamId)
+            {
+                if (!seenArenaTeams.insert(ginfo.ArenaTeamId).second)
+                    continue;
+            }
+
+            uint32 mmr = ginfo.ArenaMatchmakerRating ? ginfo.ArenaMatchmakerRating : ginfo.ArenaTeamRating;
+            if (!mmr)
+                continue;
+
+            sum += mmr;
+            ++count;
+        }
+
+        if (!count)
+            return 0;
+
+        return uint32(sum / count);
+    }
+
+    static uint16 ClampArenaRating(int32 rating)
+    {
+        if (rating < 0)
+            return 0;
+        if (rating > 2600)
+            return 2600;
+        return uint16(rating);
+    }
+
+    static void ApplyArenaTeamRatingInMemory(ArenaTeam* team, uint16 rating)
+    {
+        if (!team)
+            return;
+
+        ArenaTeamStats stats = team->GetStats();
+        stats.Rating = rating;
+        team->SetArenaTeamStats(stats);
+
+        for (auto& m : team->GetMembers())
+        {
+            m.PersonalRating = rating;
+            m.MatchMakerRating = rating;
+            m.MaxMMR = rating;
+        }
+
+        team->NotifyStatsChanged();
+    }
+
+
 } // namespace
 
 bool BGJoinAction::Execute(Event event)
@@ -651,6 +740,24 @@ bool BGJoinAction::JoinQueue(uint32 type)
     }
     else
     {
+        // Rated arenas: dynamically align random-bot arena-team rating/MMR close to real players currently queued.
+        // This helps bots face opponents near the player's current bracket/skill without recreating teams.
+        if (isRated && sRandomPlayerbotMgr && sRandomPlayerbotMgr->IsRandomBot(bot) && !sRandomPlayerbotMgr->IsAddclassBot(bot))
+        {
+            uint32 target = GetQueuedRealPlayersMatchmakerTarget(queueTypeId, bracketId, arenaType);
+            if (target)
+            {
+                uint16 desired = ClampArenaRating(int32(target) + irand(-100, 100));
+                if (ArenaTeam* team = sArenaTeamMgr->GetArenaTeamByCaptain(bot->GetGUID(), arenaType))
+                {
+                    ApplyArenaTeamRatingInMemory(team, desired);
+                    LOG_DEBUG("playerbots", "Bot {} <{}>: set arena team #{} ({}) rating/MMR to {} (target {})",
+                              bot->GetGUID().ToString().c_str(), bot->GetName(), team->GetId(), team->GetName().c_str(),
+                              desired, target);
+                }
+            }
+        }
+
         WorldPacket arena_packet(CMSG_BATTLEMASTER_JOIN_ARENA, 20);
         arena_packet << unit->GetGUID() << arenaslot << asGroup << uint8(isRated);
         bot->GetSession()->HandleBattlemasterJoinArena(arena_packet);

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -113,7 +113,6 @@ namespace
         return teamSize;
     }
 
-
     // For rated arenas we want bot teams to be near the rating/MMR of real players currently queued
     // for the same bracket and arena type.
     static uint32 GetQueuedRealPlayersMatchmakerTarget(BattlegroundQueueTypeId queueTypeId, BattlegroundBracketId bracketId,
@@ -250,7 +249,6 @@ namespace
 
         team->NotifyStatsChanged();
     }
-
 
 } // namespace
 
@@ -984,7 +982,6 @@ bool BGStatusAction::LeaveBG(PlayerbotAI* botAI)
     bool isArena = bg->isArena();
     bool isRandomBot = sRandomPlayerbotMgr->IsRandomBot(bot);
 
-
     // Snapshot before we clear master (we need it to pick the correct gear limits).
     bool hadRealMaster = false;
     if (isRandomBot)
@@ -1031,7 +1028,6 @@ bool BGStatusAction::LeaveBG(PlayerbotAI* botAI)
     PositionInfo pos = botAI->GetAiObjectContext()->GetValue<PositionMap&>("position")->Get()["bg objective"];
     pos.Reset();
     posMap["bg objective"] = pos;
-
 
     // Random bots only: schedule PvE re-equip after leaving BG/arena.
     // Leaving a battleground/arena usually involves a map transfer, so we defer the actual re-equip
@@ -1492,7 +1488,6 @@ bool BGStrategyCheckAction::Execute(Event event)
         if (gs == 0 || bgGsCap < gs)
             gs = bgGsCap;
     }
-
 
     // Additional arena rating-based gear cap (level 80 only).
     // 1000 rating => ilvl 200, 2400 rating => ilvl 300 (hard cap).

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -540,6 +540,15 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
     uint32 activeBgQueue = sRandomPlayerbotMgr->BattlegroundData[queueTypeId][bracketId].activeBgQueue;
     uint32 bgInstanceCount = sRandomPlayerbotMgr->BattlegroundData[queueTypeId][bracketId].bgInstanceCount;
 
+    // Wild random-bots: do not join battleground queues unless there is at least one real player queued/inside.
+    // (Real players in BG still count because they remain in battleground queue.)
+    if (sRandomPlayerbotMgr && sRandomPlayerbotMgr->IsRandomBot(bot))
+    {
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI && !botAI->HasRealPlayerMaster() && (bgAlliancePlayerCount + bgHordePlayerCount) == 0)
+            return false;
+    }
+
     if (teamId == TEAM_ALLIANCE)
     {
         if ((bgAllianceBotCount + bgAlliancePlayerCount) < TeamSize * (activeBgQueue + bgInstanceCount))
@@ -894,6 +903,15 @@ bool FreeBGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battleg
     uint32 activeBgQueue = sRandomPlayerbotMgr->BattlegroundData[queueTypeId][bracketId].activeBgQueue;
     uint32 bgInstanceCount = sRandomPlayerbotMgr->BattlegroundData[queueTypeId][bracketId].bgInstanceCount;
 
+    // Wild random-bots: do not join battleground queues unless there is at least one real player queued/inside.
+    // (Real players in BG still count because they remain in battleground queue.)
+    if (sRandomPlayerbotMgr && sRandomPlayerbotMgr->IsRandomBot(bot))
+    {
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (botAI && !botAI->HasRealPlayerMaster() && (bgAlliancePlayerCount + bgHordePlayerCount) == 0)
+            return false;
+    }
+
     if (teamId == TEAM_ALLIANCE)
     {
         if ((bgAllianceBotCount + bgAlliancePlayerCount) < TeamSize * (activeBgQueue + bgInstanceCount))
@@ -1000,6 +1018,11 @@ bool BGStatusAction::LeaveBG(PlayerbotAI* botAI)
 
     bot->GetSession()->HandleBattlefieldLeaveOpcode(packet);
 
+    // Wild random-bots: never keep Deserter. It can appear due to forced leaves, bugs or edge cases.
+    // Removing it here keeps bots from getting stuck unable to queue again.
+    if (isRandomBot && !hadRealMaster && bot->HasAura(26013))
+        bot->RemoveAurasDueToSpell(26013);
+
     botAI->ResetStrategies(!isRandomBot);
     botAI->GetAiObjectContext()->GetValue<uint32>("bg type")->Set(0);
     botAI->GetAiObjectContext()->GetValue<uint32>("bg role")->Set(0);
@@ -1079,12 +1102,19 @@ bool BGStatusAction::Execute(Event event)
     if (!queueTypeId)
         return false;
 
-    BattlegroundBracketId bracketId;
+    BattlegroundBracketId bracketId = BG_BRACKET_ID_FIRST;
+
     Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(_bgTypeId);
+    if (!bg)
+        return false;
+
     mapId = bg->GetMapId();
+
     PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
-    if (pvpDiff)
-        bracketId = pvpDiff->GetBracketId();
+    if (!pvpDiff)
+        return false;
+
+    bracketId = pvpDiff->GetBracketId();
 
     bool isArena = false;
     uint8 type = false;  // arenatype if arena
@@ -1165,6 +1195,8 @@ bool BGStatusAction::Execute(Event event)
         GroupQueueInfo ginfo;
         if (bgQueue.GetPlayerGroupInfoData(bot->GetGUID(), &ginfo))
         {
+            // Wild random-bots: do not stay queued for battlegrounds when there are no real players queued.
+            // This prevents bot-only battleground instances from starting when real players leave the queue.
             if (ginfo.IsInvitedToBGInstanceGUID && !bot->InBattleground())
             {
                 // BattlegroundMgr::GetBattleground() does not return battleground if bgTypeId==BATTLEGROUND_AA
@@ -1309,7 +1341,9 @@ bool BGStatusAction::Execute(Event event)
             }
         }
 
-        LOG_INFO("playerbots", "Bot {} {}:{} <{}> joined {} - {}", bot->GetGUID().ToString().c_str(),
+        // Wild random-bots: avoid re-joining recently evacuated empty battleground instances.
+        // This prevents "leave -> immediate re-invite -> join" loops on bot-only BGs.
+                LOG_INFO("playerbots", "Bot {} {}:{} <{}> joined {} - {}", bot->GetGUID().ToString().c_str(),
                  bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName(),
                  isArena ? "Arena" : "BG", _bgType);
 
@@ -1362,10 +1396,6 @@ bool BGStatusCheckAction::isUseful() { return bot->InBattlegroundQueue(); }
 
 bool BGStrategyCheckAction::Execute(Event event)
 {
-    static std::unordered_map<uint32, uint32> s_lastSeenInstanceIdByBot;
-    static std::unordered_map<uint32, uint32> s_lastSwapInstanceIdByBot;
-
-    uint32 botLow = bot->GetGUID().GetCounter();
 
     // Note: InBattleground() can be true for a short moment while GetBattleground() is still null during transfer.
     // Never treat a temporary null Battleground* as "left the battleground", or bots may lose their BG tactics and idle.
@@ -1377,12 +1407,9 @@ bool BGStrategyCheckAction::Execute(Event event)
     // If we left BG/arena, restore normal strategies exactly once.
     if (!inBg)
     {
-        auto itSeen = s_lastSeenInstanceIdByBot.find(botLow);
-        auto itSwap = s_lastSwapInstanceIdByBot.find(botLow);
-        if (itSeen != s_lastSeenInstanceIdByBot.end() || itSwap != s_lastSwapInstanceIdByBot.end())
+        if (botAI->GetLastSeenBgInstanceId() || botAI->GetLastSwapBgInstanceId())
         {
-            s_lastSeenInstanceIdByBot.erase(botLow);
-            s_lastSwapInstanceIdByBot.erase(botLow);
+            botAI->ResetBgStrategyState();
             botAI->ResetStrategies();
             return true;
         }
@@ -1399,11 +1426,17 @@ bool BGStrategyCheckAction::Execute(Event event)
         return false;
 
     // Apply BG/arena tactics once per BG/arena instance.
-    auto itSeen = s_lastSeenInstanceIdByBot.find(botLow);
-    if (itSeen == s_lastSeenInstanceIdByBot.end() || itSeen->second != instanceId)
+    if (botAI->GetLastSeenBgInstanceId() != instanceId)
     {
-        s_lastSeenInstanceIdByBot[botLow] = instanceId;
-        s_lastSwapInstanceIdByBot.erase(botLow);  // allow swap in this new instance
+        botAI->SetLastSeenBgInstanceId(instanceId);
+
+        // If we are already in PvP gear (e.g. quick re-invite), do not rebuild it again.
+        // Just mark the swap as done for this instance.
+        if (botAI->IsPvpGearActive())
+            botAI->SetLastSwapBgInstanceId(instanceId);
+        else
+            botAI->SetLastSwapBgInstanceId(0); // allow swap in this new instance
+
         botAI->ResetStrategies();
         // Do not return: we may swap gear in the same tick once the bot is fully on the BG map.
     }
@@ -1412,14 +1445,16 @@ bool BGStrategyCheckAction::Execute(Event event)
     if (!sRandomPlayerbotMgr || !sRandomPlayerbotMgr->IsRandomBot(bot))
         return false;
 
+    // Addclass (summoned) bots must never auto-generate/swap PvP gear.
+    if (sRandomPlayerbotMgr->IsAddclassBot(bot))
+        return false;
+
     // Wait until the bot is actually on the BG/arena map (avoid swapping during transfer).
     if (!bot->IsInWorld() || bot->IsBeingTeleported() || bot->IsDuringRemoveFromWorld() || bot->GetMapId() != bg->GetMapId())
         return false;
 
-    auto itSwap = s_lastSwapInstanceIdByBot.find(botLow);
-    if (itSwap != s_lastSwapInstanceIdByBot.end() && itSwap->second == instanceId)
+    if (botAI->IsPvpGearActive() && botAI->GetLastSwapBgInstanceId() == instanceId)
         return false;
-
     // Random bots: generate PvP gear + enchants after fully entering BG/arena.
     bool hasRealMaster = botAI->HasRealPlayerMaster();
 
@@ -1500,6 +1535,9 @@ bool BGStrategyCheckAction::Execute(Event event)
             gs = ratingGsCap;
     }
 
+    // Bank-first PvE stash: save the currently equipped PvE set to bank so leaving BG/arena can restore it cheaply.
+    botAI->StashPveGearToBankForNextPvpSwap();
+
     uint8 savedLevel = bot->GetLevel();
     PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
 
@@ -1511,7 +1549,7 @@ bool BGStrategyCheckAction::Execute(Event event)
         factory.ApplyEnchantAndGemsNew();
 
     // Remember that this bot already swapped gear for this BG/arena instance.
-    s_lastSwapInstanceIdByBot[botLow] = instanceId;
+    botAI->OnPvpGearEquipped(instanceId);
 
     return false;
 }

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -14,6 +14,7 @@
 #include "Playerbots.h"
 #include "PositionValue.h"
 #include "UpdateTime.h"
+#include "PlayerbotFactory.h"
 
 bool BGJoinAction::Execute(Event event)
 {
@@ -711,6 +712,12 @@ bool BGStatusAction::LeaveBG(PlayerbotAI* botAI)
     bool isArena = bg->isArena();
     bool isRandomBot = sRandomPlayerbotMgr->IsRandomBot(bot);
 
+
+    // Snapshot before we clear master (we need it to pick the correct gear limits).
+    bool hadRealMaster = false;
+    if (isRandomBot)
+        hadRealMaster = botAI->HasRealPlayerMaster();
+
     if (isRandomBot)
         botAI->SetMaster(nullptr);
 
@@ -747,6 +754,13 @@ bool BGStatusAction::LeaveBG(PlayerbotAI* botAI)
     PositionInfo pos = botAI->GetAiObjectContext()->GetValue<PositionMap&>("position")->Get()["bg objective"];
     pos.Reset();
     posMap["bg objective"] = pos;
+
+
+    // Random bots only: schedule PvE re-equip after leaving BG/arena.
+    // Leaving a battleground/arena usually involves a map transfer, so we defer the actual re-equip
+    // until the bot is back in world (handled in PlayerbotAI::UpdateAI).
+    if (isRandomBot)
+        botAI->SetPendingPveGearReequip(hadRealMaster);
     return true;
 }
 
@@ -1092,6 +1106,34 @@ bool BGStrategyCheckAction::Execute(Event event)
     if (inside_bg && !botAI->HasStrategy("battleground", BOT_STATE_NON_COMBAT))
     {
         botAI->ResetStrategies();
+
+        // Random bots: generate PvP gear + enchants after fully entering BG/arena.
+        // - Wild random bots use RandomGear* limits (AiPlayerbot.RandomGearQualityLimit/RandomGearScoreLimit).
+        // - Random bots with a real player master use AutoGear* limits (AiPlayerbot.AutoGearQualityLimit/AutoGearScoreLimit).
+        // Alt bots are not affected by this logic.
+        if (sRandomPlayerbotMgr->IsRandomBot(bot))
+        {
+            bool hasRealMaster = botAI->HasRealPlayerMaster();
+
+            uint32 qualityLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearQualityLimit
+                                                : sPlayerbotAIConfig->randomGearQualityLimit;
+
+            uint32 scoreLimit = hasRealMaster ? sPlayerbotAIConfig->autoGearScoreLimit
+                                              : sPlayerbotAIConfig->randomGearScoreLimit;
+
+            uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
+
+            uint8 savedLevel = bot->GetLevel();
+            PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
+
+            // Force gear generation; do not touch talents/level/spells/etc.
+            factory.InitEquipment(false);
+
+            // Apply enchants/gems only.
+            if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
+                factory.ApplyEnchantAndGemsNew();
+        }
+
         return false;
     }
     return false;

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -1471,7 +1471,7 @@ bool BGStrategyCheckAction::Execute(Event event)
     // This is an extra restriction on top of the configured gear limit.
     if (bot->GetLevel() == 80 && !isArena)
     {
-        uint32 x = botLow;
+        uint32 x = static_cast<uint32>(bot->GetGUID().GetCounter());
         x ^= x >> 16;
         x *= 0x7feb352d;
         x ^= x >> 15;

--- a/src/Ai/Base/Actions/EquipAction.cpp
+++ b/src/Ai/Base/Actions/EquipAction.cpp
@@ -5,6 +5,7 @@
 
 #include "EquipAction.h"
 #include <utility>
+#include <string>
 
 #include "Event.h"
 #include "ItemCountValue.h"
@@ -13,6 +14,17 @@
 #include "Playerbots.h"
 #include "StatsWeightCalculator.h"
 #include "ItemPackets.h"
+
+namespace
+{
+    bool IsPotentiallyEquipable(ItemTemplate const* itemProto)
+    {
+        // Most reliable/cheap check across all item classes: any non-zero inventory type means the item can be equipped.
+        // (Includes unusual equipables like relics, offhands, etc., without depending on item class values.)
+        return itemProto && itemProto->InventoryType != INVTYPE_NON_EQUIP;
+    }
+}
+
 
 bool EquipAction::Execute(Event event)
 {
@@ -344,25 +356,105 @@ bool EquipUpgradesAction::Execute(Event event)
             return false;
     }
 
+    // The "item push result" event fires whenever an item is added to the bot inventory (loot, quest reward, mail, etc).
+    // Doing a full bag scan + item usage evaluation for every push is extremely expensive and produces lag spikes.
+    // Instead, evaluate only the pushed item and equip it if needed.
     if (event.GetSource() == "item push result")
     {
         WorldPacket p(event.getPacket());
         p.rpos(0);
-        ObjectGuid playerGuid;
-        uint32 received, created, sendChatMessage, itemSlot, itemId;
+
+        ObjectGuid guid;
+        uint32 received, created, sendChatMessage;
         uint8 bagSlot;
+        uint32 itemSlot, itemEntry;
 
-        p >> playerGuid;
-        p >> received;
-        p >> created;
-        p >> sendChatMessage;
-        p >> bagSlot;
-        p >> itemSlot;
-        p >> itemId;
+        // Optional fields (SMSG_ITEM_PUSH_RESULT can differ by core build).
+        uint32 itemSuffixFactor = 0;
+        int32 itemRandomPropertyId = 0;
+        uint32 count = 0;
+        uint32 itemCount = 0;
 
-        ItemTemplate const* item = sObjectMgr->GetItemTemplate(itemId);
-        if (item->Class == ITEM_CLASS_TRADE_GOODS && item->SubClass == ITEM_SUBCLASS_MEAT)
+        p >> guid >> received >> created >> sendChatMessage;
+        p >> bagSlot >> itemSlot >> itemEntry;
+
+        // Try to read extra fields only if they exist to avoid buffer overrun.
+        if (p.rpos() + sizeof(uint32) + sizeof(int32) <= p.size())
+            p >> itemSuffixFactor >> itemRandomPropertyId;
+
+        if (p.rpos() + sizeof(uint32) <= p.size())
+            p >> count;
+
+        if (p.rpos() + sizeof(uint32) <= p.size())
+            p >> itemCount;
+
+        (void)received;
+        (void)created;
+        (void)sendChatMessage;
+        (void)itemSuffixFactor;
+        (void)count;
+        (void)itemCount;
+if (guid != bot->GetGUID())
+            return true;
+
+        ItemTemplate const* itemProto = sObjectMgr->GetItemTemplate(itemEntry);
+        if (!itemProto)
+            return true;
+
+        // Keep legacy behavior: do not auto-equip cooking meat.
+        if (itemProto->Class == ITEM_CLASS_TRADE_GOODS && itemProto->SubClass == ITEM_SUBCLASS_MEAT)
             return false;
+
+        // Fast path: ignore non-equipable items.
+        if (!IsPotentiallyEquipable(itemProto))
+            return true;
+
+        Item* pushedItem = bot->GetItemByPos(bagSlot, static_cast<uint8>(itemSlot));
+        if (!pushedItem || pushedItem->GetTemplate()->ItemId != itemEntry ||
+            (itemRandomPropertyId != 0 && pushedItem->GetItemRandomPropertyId() != itemRandomPropertyId))
+        {
+            // Fallback: locate by entry + random property (still much cheaper than evaluating every item).
+            pushedItem = nullptr;
+
+            CollectItemsVisitor pushedVisitor;
+            IterateItems(&pushedVisitor, ITERATE_ITEMS_IN_BAGS);
+
+            for (auto it = pushedVisitor.items.begin(); it != pushedVisitor.items.end(); ++it)
+            {
+                Item* item = *it;
+                if (!item)
+                    break;
+
+                ItemTemplate const* proto = item->GetTemplate();
+                if (!proto || proto->ItemId != itemEntry)
+                    continue;
+
+                if (itemRandomPropertyId != 0 && item->GetItemRandomPropertyId() != itemRandomPropertyId)
+                    continue;
+
+                pushedItem = item;
+                break;
+            }
+        }
+
+        if (!pushedItem)
+            return true;
+
+        int32 randomProperty = pushedItem->GetItemRandomPropertyId();
+        std::string itemUsageParam;
+        if (randomProperty != 0)
+            itemUsageParam = std::to_string(itemEntry) + "," + std::to_string(randomProperty);
+        else
+            itemUsageParam = std::to_string(itemEntry);
+
+        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
+        if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
+        {
+            // Equip the exact pushed item instance to avoid ambiguity when multiple copies exist.
+            EquipItem(pushedItem);
+        }
+
+        return true;
     }
 
     CollectItemsVisitor visitor;
@@ -374,28 +466,29 @@ bool EquipUpgradesAction::Execute(Event event)
         Item* item = *i;
         if (!item)
             break;
+
+        ItemTemplate const* itemProto = item->GetTemplate();
+        if (!IsPotentiallyEquipable(itemProto))
+            continue;
+
         int32 randomProperty = item->GetItemRandomPropertyId();
-        uint32 itemId = item->GetTemplate()->ItemId;
+        uint32 itemId = itemProto->ItemId;
+
         std::string itemUsageParam;
         if (randomProperty != 0)
-        {
             itemUsageParam = std::to_string(itemId) + "," + std::to_string(randomProperty);
-        }
         else
-        {
             itemUsageParam = std::to_string(itemId);
-        }
-        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
 
+        ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", itemUsageParam);
         if (usage == ITEM_USAGE_EQUIP || usage == ITEM_USAGE_REPLACE || usage == ITEM_USAGE_BAD_EQUIP)
-        {
             items.insert(itemId);
-        }
     }
 
     EquipItems(items);
     return true;
 }
+
 
 bool EquipUpgradeAction::Execute(Event event)
 {

--- a/src/Ai/Base/Actions/EquipAction.cpp
+++ b/src/Ai/Base/Actions/EquipAction.cpp
@@ -25,7 +25,6 @@ namespace
     }
 }
 
-
 bool EquipAction::Execute(Event event)
 {
     std::string const text = event.getParam();
@@ -488,7 +487,6 @@ if (guid != bot->GetGUID())
     EquipItems(items);
     return true;
 }
-
 
 bool EquipUpgradeAction::Execute(Event event)
 {

--- a/src/Ai/Base/Actions/EquipAction.h
+++ b/src/Ai/Base/Actions/EquipAction.h
@@ -21,10 +21,12 @@ public:
     bool Execute(Event event) override;
     void EquipItems(ItemIds ids);
 
+protected:
+    void EquipItem(Item* item);
+
 private:
     void EquipItem(FindItemVisitor* visitor);
     uint8 GetSmallestBagSlot();
-    void EquipItem(Item* item);
 };
 
 class EquipUpgradesAction : public EquipAction

--- a/src/Ai/Base/Actions/UseMeetingStoneAction.cpp
+++ b/src/Ai/Base/Actions/UseMeetingStoneAction.cpp
@@ -153,6 +153,15 @@ bool SummonAction::Teleport(Player* summoner, Player* player, bool preserveAuras
     if (!summoner)
         return false;
 
+    // Do not allow teleport/summon inside battlegrounds or arenas.
+    // This prevents using the "summon" command (and any other SummonAction-based teleports)
+    // to move bots around in PvP instances.
+    if (summoner->InBattleground() || summoner->InArena())
+    {
+        botAI->TellError("You cannot summon me in battlegrounds or arenas");
+        return false;
+    }
+
     if (player->GetVehicle())
     {
         botAI->TellError("You cannot summon me while I'm on a vehicle");

--- a/src/Ai/Base/SharedValueContext.h
+++ b/src/Ai/Base/SharedValueContext.h
@@ -47,17 +47,25 @@ public:
         return &instance;
     }
 
+private:
+    static PlayerbotAI* GetGlobalBotAI()
+    {
+        // Global (shared) values need a stable AI instance and a stable storage.
+        // Using NamedObjectContextList here would allocate values and then delete them
+        // at end of scope, returning a dangling pointer. We instead use the built-in
+        // caching of NamedObjectContext(true) on this singleton.
+        static PlayerbotAI* s_ai = nullptr;
+        if (!s_ai)
+            s_ai = new PlayerbotAI();
+        return s_ai;
+    }
+
+public:
     template <class T>
     Value<T>* getGlobalValue(std::string const name)
     {
-        // should never reach here
-        SharedNamedObjectContextList<UntypedValue> sValueContexts;
-        sValueContexts.Add(this);
-        NamedObjectContextList<UntypedValue> valueContexts(sValueContexts);
-        PlayerbotAI* botAI = new PlayerbotAI();
-
-        UntypedValue* value = valueContexts.GetContextObject(name, botAI);
-        delete botAI;
+        PlayerbotAI* botAI = GetGlobalBotAI();
+        UntypedValue* value = this->create(name, botAI);
         return dynamic_cast<Value<T>*>(value);
     }
 

--- a/src/Ai/Base/Value/CollisionValue.h
+++ b/src/Ai/Base/Value/CollisionValue.h
@@ -15,8 +15,9 @@ class CollisionValue : public BoolCalculatedValue, public Qualified
 {
 public:
     CollisionValue(PlayerbotAI* botAI, std::string const name = "collision")
-        : BoolCalculatedValue(botAI, name), Qualified()
+        : BoolCalculatedValue(botAI, name, 200), Qualified()
     {
+        // Throttle collision checks to avoid expensive grid scans every evaluation.
     }
 
     bool Calculate() override;

--- a/src/Ai/Raid/Icecrown/Action/RaidIccActions.cpp
+++ b/src/Ai/Raid/Icecrown/Action/RaidIccActions.cpp
@@ -9,8 +9,100 @@
 #include "GenericSpellActions.h"
 #include "GenericActions.h"
 #include <fstream>
+#include <unordered_map>
 #include "RaidIccTriggers.h"
 #include "Multiplier.h"
+
+
+namespace
+{
+static inline int32 QuantizeToBucket(float value, float bucketSize)
+{
+    // Equivalent to floor(value / bucketSize) without requiring <cmath>.
+    float q = value / bucketSize;
+    int32 i = static_cast<int32>(q);
+    if (q < 0.0f && static_cast<float>(i) != q)
+        --i;
+    return i;
+}
+
+struct SindragosaUnitScanKey
+{
+    uint32 mapId = 0;
+    uint32 instanceId = 0;
+    int32 bucketX = 0;
+    int32 bucketY = 0;
+
+    bool operator==(SindragosaUnitScanKey const& other) const
+    {
+        return mapId == other.mapId && instanceId == other.instanceId &&
+               bucketX == other.bucketX && bucketY == other.bucketY;
+    }
+};
+
+struct SindragosaUnitScanKeyHash
+{
+    std::size_t operator()(SindragosaUnitScanKey const& k) const noexcept
+    {
+        // Basic hash combine.
+        std::size_t h = std::size_t(k.mapId);
+        h ^= (std::size_t(k.instanceId) + 0x9e3779b9 + (h << 6) + (h >> 2));
+        h ^= (std::size_t(k.bucketX) + 0x9e3779b9 + (h << 6) + (h >> 2));
+        h ^= (std::size_t(k.bucketY) + 0x9e3779b9 + (h << 6) + (h >> 2));
+        return h;
+    }
+};
+
+struct SindragosaUnitScanCacheEntry
+{
+    uint32 lastUpdateMs = 0;
+    std::vector<ObjectGuid> unitGuids;
+};
+
+static thread_local std::unordered_map<SindragosaUnitScanKey, SindragosaUnitScanCacheEntry, SindragosaUnitScanKeyHash> s_sindragosaUnitScanCache;
+
+static std::vector<ObjectGuid> const& GetUnitsInRangeCached(Player* bot, float range, uint32 ttlMs)
+{
+    static constexpr float kBucketSize = 50.0f; // yards
+    SindragosaUnitScanKey key;
+
+    if (bot)
+    {
+        key.mapId = bot->GetMapId();
+        key.instanceId = bot->GetInstanceId();
+        key.bucketX = QuantizeToBucket(bot->GetPositionX(), kBucketSize);
+        key.bucketY = QuantizeToBucket(bot->GetPositionY(), kBucketSize);
+    }
+
+    auto& entry = s_sindragosaUnitScanCache[key];
+    uint32 now = getMSTime();
+
+    if (!entry.lastUpdateMs || GetMSTimeDiffToNow(entry.lastUpdateMs) >= ttlMs)
+    {
+        entry.unitGuids.clear();
+
+        if (bot)
+        {
+            std::list<Unit*> units;
+            Acore::AnyUnitInObjectRangeCheck u_check(bot, range);
+            Acore::UnitListSearcher<Acore::AnyUnitInObjectRangeCheck> searcher(bot, units, u_check);
+            Cell::VisitObjects(bot, searcher, range);
+
+            entry.unitGuids.reserve(units.size());
+            for (Unit* unit : units)
+            {
+                if (unit)
+                    entry.unitGuids.push_back(unit->GetGUID());
+            }
+        }
+
+        entry.lastUpdateMs = now;
+    }
+
+    return entry.unitGuids;
+}
+} // namespace
+
 
 // Lord Marrowgwar
 bool IccLmTankPositionAction::Execute(Event event)
@@ -6534,14 +6626,14 @@ bool IccSindragosaFrostBombAction::Execute(Event event)
     std::vector<ObjectGuid> tombGuids;
 
     // Manually search for units with frost bomb aura (SPELL_FROST_BOMB_VISUAL) using NearestHostileNpcsValue logic
-    std::list<Unit*> units;
-    float range = 200.0f;
-    Acore::AnyUnitInObjectRangeCheck u_check(bot, range);
-    Acore::UnitListSearcher<Acore::AnyUnitInObjectRangeCheck> searcher(bot, units, u_check);
-    Cell::VisitObjects(bot, searcher, range);
+        float range = 200.0f;
+    static constexpr uint32 kScanCacheTtlMs = 0; // Disabled for ultra-safety (always refresh)
+// Shared per map/instance bucket
+    auto const& unitGuids = GetUnitsInRangeCached(bot, range, kScanCacheTtlMs);
 
-    for (Unit* unit : units)
+    for (ObjectGuid const& unitGuid : unitGuids)
     {
+        Unit* unit = ObjectAccessor::GetUnit(*bot, unitGuid);
         if (!unit || !unit->IsAlive())
             continue;
 

--- a/src/Ai/Raid/Icecrown/Action/RaidIccActions.cpp
+++ b/src/Ai/Raid/Icecrown/Action/RaidIccActions.cpp
@@ -13,7 +13,6 @@
 #include "RaidIccTriggers.h"
 #include "Multiplier.h"
 
-
 namespace
 {
 static inline int32 QuantizeToBucket(float value, float bucketSize)
@@ -102,7 +101,6 @@ static std::vector<ObjectGuid> const& GetUnitsInRangeCached(Player* bot, float r
     return entry.unitGuids;
 }
 } // namespace
-
 
 // Lord Marrowgwar
 bool IccLmTankPositionAction::Execute(Event event)

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4473,7 +4473,6 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool destroyOld)
                     continue;
 
                 //SpellItemEnchantmentEntry const* enchant = sSpellItemEnchantmentStore.LookupEntry(enchant_id); //not used, line marked for removal.
-                StatsWeightCalculator calculator(bot);
                 float score = calculator.CalculateEnchant(enchant_id);
                 if (curCount[0] != 0)
                 {

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -62,8 +62,8 @@ std::vector<uint32> PlayerbotFactory::enchantSpellIdCache;
 std::vector<uint32> PlayerbotFactory::enchantGemIdCache;
 std::unordered_map<uint32, std::vector<uint32>> PlayerbotFactory::trainerIdCache;
 
-PlayerbotFactory::PlayerbotFactory(Player* bot, uint32 level, uint32 itemQuality, uint32 gearScoreLimit)
-    : level(level), itemQuality(itemQuality), gearScoreLimit(gearScoreLimit), bot(bot)
+PlayerbotFactory::PlayerbotFactory(Player* bot, uint32 level, uint32 itemQuality, uint32 gearScoreLimit, bool lockLevel)
+    : level(level), itemQuality(itemQuality), gearScoreLimit(gearScoreLimit), lockLevel(lockLevel), bot(bot)
 {
     botAI = GET_PLAYERBOT_AI(bot);
     if (!this->itemQuality)
@@ -212,11 +212,21 @@ void PlayerbotFactory::Prepare()
         bot->ResurrectPlayer(1.0f, false);
 
     bot->CombatStop(true);
-    uint32 currentLevel = bot->GetLevel();
-    bot->GiveLevel(level);
-    if (level != currentLevel)
+
+    if (!lockLevel)
     {
-        bot->SetUInt32Value(PLAYER_XP, 0);
+        uint32 currentLevel = bot->GetLevel();
+        bot->GiveLevel(level);
+        if (level != currentLevel)
+        {
+            bot->SetUInt32Value(PLAYER_XP, 0);
+        }
+    }
+    else
+    {
+        // This factory instance must not touch bot level/XP.
+        // Keep internal target level consistent with actual bot level.
+        level = bot->GetLevel();
     }
     if (!sPlayerbotAIConfig->randomBotShowHelmet || !urand(0, 4))
     {
@@ -259,7 +269,11 @@ void PlayerbotFactory::Randomize(bool incremental)
     bot->RemoveAllSpellCooldown();
     UnbindInstance();
 
-    bot->GiveLevel(level);
+    if (!lockLevel)
+        bot->GiveLevel(level);
+    else
+        level = bot->GetLevel();
+
     bot->InitStatsForLevel(true);
     CancelAuras();
     // bot->SaveToDB(false, false);
@@ -452,14 +466,17 @@ void PlayerbotFactory::Randomize(bool incremental)
     // bot->SaveToDB(false, false);
     if (pmo)
         pmo->finish();
-
-    if (bot->GetLevel() >= 70)
     {
-        pmo = sPerfMonitor->start(PERF_MON_RNDBOT, "PlayerbotFactory_Arenas");
-        // LOG_INFO("playerbots", "Initializing arena teams...");
-        InitArenaTeam();
-        if (pmo)
-            pmo->finish();
+        uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
+        // Create/assign random-bot arena teams only for max-level characters, and only for 70/80 realms.
+        if ((maxLevel == 70 || maxLevel == 80) && bot->GetLevel() == maxLevel)
+        {
+            pmo = sPerfMonitor->start(PERF_MON_RNDBOT, "PlayerbotFactory_Arenas");
+            // LOG_INFO("playerbots", "Initializing arena teams...");
+            InitArenaTeam();
+            if (pmo)
+                pmo->finish();
+        }
     }
 
     if (!incremental)
@@ -4069,6 +4086,17 @@ void PlayerbotFactory::InitArenaTeam()
     if (!sPlayerbotAIConfig->IsInRandomAccountList(bot->GetSession()->GetAccountId()))
         return;
 
+    // Safety: only random bots should ever get random-bot arena teams.
+    if (!sRandomPlayerbotMgr || !sRandomPlayerbotMgr->IsRandomBot(bot))
+        return;
+
+    uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
+    // Create/assign random-bot arena teams only for max-level characters, and only for 70/80 realms.
+    if (maxLevel != 70 && maxLevel != 80)
+        return;
+    if (bot->GetLevel() != maxLevel)
+        return;
+
     // Currently the teams are only remade after a server restart and if deleteRandomBotArenaTeams = 1
     // This is because randomBotArenaTeams is only empty on server restart.
     // A manual reinitalization (.playerbots rndbot init) is also required after the teams have been deleted.
@@ -4127,7 +4155,7 @@ void PlayerbotFactory::InitArenaTeam()
             continue;
         }
 
-        if (arenateam->GetMembersSize() < ((uint32)arenateam->GetType()) && bot->GetLevel() >= 70)
+        if (arenateam->GetMembersSize() < ((uint32)arenateam->GetType()))
         {
             ObjectGuid capt = arenateam->GetCaptain();
             Player* botcaptain = ObjectAccessor::FindPlayer(capt);

--- a/src/Bot/Factory/PlayerbotFactory.h
+++ b/src/Bot/Factory/PlayerbotFactory.h
@@ -48,7 +48,7 @@ enum spec : uint8
 class PlayerbotFactory
 {
 public:
-    PlayerbotFactory(Player* bot, uint32 level, uint32 itemQuality = 0, uint32 gearScoreLimit = 0);
+    PlayerbotFactory(Player* bot, uint32 level, uint32 itemQuality = 0, uint32 gearScoreLimit = 0, bool lockLevel = false);
 
     static ObjectGuid GetRandomBot();
     static void Init();
@@ -134,6 +134,7 @@ private:
     uint32 level;
     uint32 itemQuality;
     uint32 gearScoreLimit;
+    bool lockLevel; // If true, factory must not change bot level/XP.
     static std::list<uint32> specialQuestIds;
     static std::unordered_map<uint32, std::vector<uint32>> trainerIdCache;
     static std::vector<uint32> enchantSpellIdCache;

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -12,6 +12,7 @@
 #include "PlayerbotFactory.h"
 #include "Playerbots.h"
 #include "PlayerbotGuildMgr.h"
+#include "World.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "SocialMgr.h"
@@ -788,6 +789,9 @@ std::string const RandomPlayerbotFactory::CreateRandomGuildName()
 
 void RandomPlayerbotFactory::CreateRandomArenaTeams(ArenaType type, uint32 count)
 {
+    uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
+    bool allowArenaTeams = (maxLevel == 70 || maxLevel == 80);
+
     std::vector<uint32> randomBots;
 
     PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RANDOM_BOTS_BOT);
@@ -817,7 +821,7 @@ void RandomPlayerbotFactory::CreateRandomArenaTeams(ArenaType type, uint32 count
         {
             Player* player = ObjectAccessor::FindConnectedPlayer(captain);
 
-            if (!arenateam && player && player->GetLevel() >= 70)
+            if (allowArenaTeams && !arenateam && player && player->GetLevel() == maxLevel)
                 availableCaptains.push_back(captain);
         }
     }
@@ -843,9 +847,9 @@ void RandomPlayerbotFactory::CreateRandomArenaTeams(ArenaType type, uint32 count
             continue;
         }
 
-        if (player->GetLevel() < 70)
+        if (player->GetLevel() != maxLevel)
         {
-            LOG_ERROR("playerbots", "Bot {} must be level 70 to create an arena team", captain.ToString().c_str());
+            LOG_ERROR("playerbots", "Bot {} must be level {} to create an arena team", captain.ToString().c_str(), maxLevel);
             continue;
         }
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -5,10 +5,13 @@
 
 #include "PlayerbotAI.h"
 
+#include <algorithm>
+
 #include <cmath>
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #include "AiFactory.h"
 #include "BudgetValues.h"
@@ -60,6 +63,59 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "Vehicle.h"
+
+namespace
+{
+struct SpellInterruptMeta
+{
+    bool isHeal = false;
+    bool isSingleTarget = true;
+};
+
+SpellInterruptMeta GetSpellInterruptMeta(SpellInfo const* spellInfo)
+{
+    static thread_local std::unordered_map<uint32, SpellInterruptMeta> cache;
+
+    if (!spellInfo)
+        return SpellInterruptMeta();
+
+    auto it = cache.find(spellInfo->Id);
+    if (it != cache.end())
+        return it->second;
+
+    SpellInterruptMeta meta;
+    meta.isHeal = false;
+    meta.isSingleTarget = true;
+
+    // Preserve the exact logic previously used in UpdateAI():
+    // - Heal if any effect is HEAL / HEAL_MAX_HEALTH / HEAL_MECHANICAL
+    // - Single-target if all non-empty effects target TARGET_UNIT_TARGET_ALLY
+    for (uint8 i = 0; i < 3; ++i)
+    {
+        if (!spellInfo->Effects[i].Effect)
+            continue;
+
+        if (spellInfo->Effects[i].Effect == SPELL_EFFECT_HEAL ||
+            spellInfo->Effects[i].Effect == SPELL_EFFECT_HEAL_MAX_HEALTH ||
+            spellInfo->Effects[i].Effect == SPELL_EFFECT_HEAL_MECHANICAL)
+        {
+            meta.isHeal = true;
+        }
+
+        if ((spellInfo->Effects[i].TargetA.GetTarget() &&
+             spellInfo->Effects[i].TargetA.GetTarget() != TARGET_UNIT_TARGET_ALLY) ||
+            (spellInfo->Effects[i].TargetB.GetTarget() &&
+             spellInfo->Effects[i].TargetB.GetTarget() != TARGET_UNIT_TARGET_ALLY))
+        {
+            meta.isSingleTarget = false;
+        }
+    }
+
+    cache.emplace(spellInfo->Id, meta);
+    return meta;
+}
+} // namespace
+
 
 const int SPELL_TITAN_GRIP = 49152;
 
@@ -257,6 +313,13 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
         bot->GetSession()->isLogingOut() || bot->IsDuringRemoveFromWorld())
         return;
 
+
+    // Playerbots must never send MOVEMENTFLAG_ROOT in movement packets (e.g. MSG_MOVE_HEARTBEAT).
+    // If this flag becomes stale, core will spam: "Attempted sending heartbeat with root flag for guid ..."
+    // Rooting is enforced server-side via auras/unit states, so it is safe to always strip the flag here.
+    if (bot->m_movementInfo.HasMovementFlag(MOVEMENTFLAG_ROOT))
+        bot->m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_ROOT);
+
     // Delayed PvE re-equip after leaving BG/arena.
     // Leaving a battleground/arena usually involves a map transfer; avoid rebuilding gear during loading.
     if (pendingPveGearReequip_)
@@ -310,6 +373,23 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
     if (!CanUpdateAI())
         return;
 
+    auto yieldReact = [&]()
+    {
+        uint32 delay = GetReactDelay();
+
+        // Avoid "lockstep" CPU spikes when many bots tick/cast at the same time (e.g. boss fights).
+        // Use a small deterministic per-bot jitter so behavior stays stable while updates are spread over time.
+        if (bot && (bot->IsInCombat() || bot->InBattleground() || bot->InArena() || currentState == BOT_STATE_COMBAT))
+        {
+            uint32 jitterMax = std::min<uint32>(50u, std::max<uint32>(10u, sPlayerbotAIConfig->reactDelay / 2));
+            if (jitterMax)
+                delay += bot->GetGUID().GetCounter() % jitterMax;
+        }
+
+        YieldThread(delay);
+    };
+
+
     // Handle the current spell
     Spell* currentSpell = bot->GetCurrentSpell(CURRENT_GENERIC_SPELL);
     if (!currentSpell)
@@ -325,7 +405,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
             if (spellTarget && !spellTarget->IsAlive() && !spellInfo->IsAllowingDeadTarget())
             {
                 InterruptSpell();
-                YieldThread(GetReactDelay());
+                yieldReact();
                 return;
             }
 
@@ -334,39 +414,20 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
             if (goSpellTarget && !goSpellTarget->isSpawned())
             {
                 InterruptSpell();
-                YieldThread(GetReactDelay());
+                yieldReact();
                 return;
             }
 
-            bool isHeal = false;
-            bool isSingleTarget = true;
+            SpellInterruptMeta const meta = GetSpellInterruptMeta(spellInfo);
 
-            for (uint8 i = 0; i < 3; ++i)
-            {
-                if (!spellInfo->Effects[i].Effect)
-                    continue;
-
-                // Check if spell is a heal
-                if (spellInfo->Effects[i].Effect == SPELL_EFFECT_HEAL ||
-                    spellInfo->Effects[i].Effect == SPELL_EFFECT_HEAL_MAX_HEALTH ||
-                    spellInfo->Effects[i].Effect == SPELL_EFFECT_HEAL_MECHANICAL)
-                    isHeal = true;
-
-                // Check if spell is single-target
-                if ((spellInfo->Effects[i].TargetA.GetTarget() &&
-                     spellInfo->Effects[i].TargetA.GetTarget() != TARGET_UNIT_TARGET_ALLY) ||
-                    (spellInfo->Effects[i].TargetB.GetTarget() &&
-                     spellInfo->Effects[i].TargetB.GetTarget() != TARGET_UNIT_TARGET_ALLY))
-                {
-                    isSingleTarget = false;
-                }
-            }
+            bool isHeal = meta.isHeal;
+            bool isSingleTarget = meta.isSingleTarget;
 
             // Interrupt if target ally has full health (heal by other member)
             if (isHeal && isSingleTarget && spellTarget && spellTarget->IsFullHealth())
             {
                 InterruptSpell();
-                YieldThread(GetReactDelay());
+                yieldReact();
                 return;
             }
 
@@ -378,7 +439,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
             }
 
             // Wait for spell cast
-            YieldThread(GetReactDelay());
+            yieldReact();
             return;
         }
     }
@@ -414,7 +475,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 
     // Update internal AI
     UpdateAIInternal(elapsed, minimal);
-    YieldThread(GetReactDelay());
+    yieldReact();
 }
 
 // Helper function for UpdateAI to check group membership and handle removal if necessary
@@ -491,9 +552,12 @@ void PlayerbotAI::UpdateAIInternal([[maybe_unused]] uint32 elapsed, bool minimal
     if (!bot->GetMap())
         return; // instances are created and destroyed on demand
 
-    std::string const mapString = WorldPosition(bot).isOverworld() ? std::to_string(bot->GetMapId()) : "I";
-    PerfMonitorOperation* pmo =
-        sPerfMonitor->start(PERF_MON_TOTAL, "PlayerbotAI::UpdateAIInternal " + mapString);
+    PerfMonitorOperation* pmo = nullptr;
+    if (sPlayerbotAIConfig->perfMonEnabled)
+    {
+        std::string const mapString = WorldPosition(bot).isOverworld() ? std::to_string(bot->GetMapId()) : "I";
+        pmo = sPerfMonitor->start(PERF_MON_TOTAL, "PlayerbotAI::UpdateAIInternal " + mapString);
+    }
     ExternalEventHelper helper(aiObjectContext);
 
     // chat replies
@@ -1267,15 +1331,15 @@ void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)
         case SMSG_FORCE_MOVE_ROOT:      // CMSG_FORCE_MOVE_ROOT_ACK
         case SMSG_FORCE_MOVE_UNROOT:    // CMSG_FORCE_MOVE_UNROOT_ACK
         {
-            // Quick fix for CMSG_FORCE_MOVE_ROOT_ACK and CMSG_FORCE_MOVE_UNROOT_ACK:
-            // this should resolve issues with MOVEMENTFLAG_ROOT being permanently set
-            // when rooted during lost client control (charm + root effects)
+            // Keep MovementInfo free of MOVEMENTFLAG_ROOT for playerbots.
+            // A stale root flag can trigger core warnings like: "Attempted sending heartbeat with root flag for guid ..."
+            // Rooting is enforced server-side (auras/unit states), so we only stop movement and strip the flag locally.
             // @see https://github.com/azerothcore/azerothcore-wotlk/pull/23147
             bool forceRoot = (packet.GetOpcode() == SMSG_FORCE_MOVE_ROOT);
             if (forceRoot)
             {
                 bot->m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_MASK_MOVING_FLY);
-                bot->m_movementInfo.AddMovementFlag(MOVEMENTFLAG_ROOT);
+                bot->m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_ROOT);
                 bot->StopMoving();
             }
             else

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -279,7 +279,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
             PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
 
             // Force gear generation; do not touch talents/level/spells/etc.
-            factory.InitEquipment(false);
+            factory.InitEquipment(false, true);
 
             // Apply enchants/gems only.
             if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -84,7 +84,6 @@ namespace
     }
 }
 
-
 namespace
 {
 struct SpellInterruptMeta
@@ -136,7 +135,6 @@ SpellInterruptMeta GetSpellInterruptMeta(SpellInfo const* spellInfo)
     return meta;
 }
 } // namespace
-
 
 const int SPELL_TITAN_GRIP = 49152;
 
@@ -348,7 +346,6 @@ PlayerbotAI::~PlayerbotAI()
         sPlayerbotsMgr->RemovePlayerBotData(bot->GetGUID(), true);
 }
 
-
 void PlayerbotAI::SetPendingPveGearReequip(bool hadRealMaster)
 {
     // Schedule a single PvE restore only if this bot actually equipped PvP gear before.
@@ -364,7 +361,6 @@ void PlayerbotAI::SetPendingPveGearReequip(bool hadRealMaster)
     pendingPveGearReequipHadRealMaster_ = hadRealMaster;
     pendingPveGearReequipNextTryMs_ = getMSTime() + urand(0, 500);
 }
-
 
 bool PlayerbotAI::ShouldLeaveEmptyBgQueue(uint32 queueTypeId, uint8 bracketId, bool hasRealPlayers,
                                          uint32 minEmptyMs, uint32 attemptCooldownMs)
@@ -404,7 +400,6 @@ bool PlayerbotAI::ShouldLeaveEmptyBgQueue(uint32 queueTypeId, uint8 bracketId, b
     return true;
 }
 
-
 void PlayerbotAI::OnPvpGearEquipped(uint32 instanceId)
 {
     // Mark that the bot is now in PvP gear and advance the epoch.
@@ -412,7 +407,6 @@ void PlayerbotAI::OnPvpGearEquipped(uint32 instanceId)
     pvpGearActive_ = true;
     lastSwapBgInstanceId_ = instanceId;
 }
-
 
 bool PlayerbotAI::IsWildRandomBotForAutoGearSwap() const
 {
@@ -433,7 +427,6 @@ bool PlayerbotAI::IsWildRandomBotForAutoGearSwap() const
     return true;
 }
 
-
 bool PlayerbotAI::ItemTemplateHasResilience(ItemTemplate const* proto)
 {
     if (!proto)
@@ -447,7 +440,6 @@ bool PlayerbotAI::ItemTemplateHasResilience(ItemTemplate const* proto)
 
     return false;
 }
-
 
 bool PlayerbotAI::LooksLikePvpGearEquipped() const
 {
@@ -470,7 +462,6 @@ bool PlayerbotAI::LooksLikePvpGearEquipped() const
 
     return false;
 }
-
 
 bool PlayerbotAI::FindFirstFreeBankSlot(uint8& outBag, uint8& outSlot) const
 {
@@ -507,7 +498,6 @@ bool PlayerbotAI::FindFirstFreeBankSlot(uint8& outBag, uint8& outSlot) const
     return false;
 }
 
-
 uint32 PlayerbotAI::CountFreeBankSlots() const
 {
     uint32 free = 0;
@@ -530,7 +520,6 @@ uint32 PlayerbotAI::CountFreeBankSlots() const
 
     return free;
 }
-
 
 void PlayerbotAI::HardPurgeBankContents()
 {
@@ -556,7 +545,6 @@ void PlayerbotAI::HardPurgeBankContents()
         }
     }
 }
-
 
 Item* PlayerbotAI::FindItemInBankByGuidRaw(uint64 guidRaw, uint8& outBag, uint8& outSlot) const
 {
@@ -595,13 +583,11 @@ Item* PlayerbotAI::FindItemInBankByGuidRaw(uint64 guidRaw, uint8& outBag, uint8&
     return nullptr;
 }
 
-
 void PlayerbotAI::ClearPveBankStash()
 {
     pveBankStashEpoch_ = 0;
     pveBankStashedGuidRawBySlot_.fill(0);
 }
-
 
 void PlayerbotAI::PurgeResilienceItemsFromBankAndBags(uint32 maxToDestroy)
 {
@@ -673,7 +659,6 @@ void PlayerbotAI::PurgeResilienceItemsFromBankAndBags(uint32 maxToDestroy)
     }
 }
 
-
 bool PlayerbotAI::StashPveGearToBankForNextPvpSwap()
 {
     if (!IsWildRandomBotForAutoGearSwap())
@@ -734,7 +719,6 @@ bool PlayerbotAI::StashPveGearToBankForNextPvpSwap()
     return true;
 }
 
-
 bool PlayerbotAI::TryRestorePveGearFromBankStash(uint32 epoch)
 {
     if (!IsWildRandomBotForAutoGearSwap())
@@ -780,7 +764,6 @@ bool PlayerbotAI::TryRestorePveGearFromBankStash(uint32 epoch)
 
     return restoredAny;
 }
-
 
 bool PlayerbotAI::TryRecoverPveGearFromBankHeuristic()
 {
@@ -873,7 +856,6 @@ bool PlayerbotAI::TryRecoverPveGearFromBankHeuristic()
     return swappedAny;
 }
 
-
 void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 {
     // Handle the AI check delay
@@ -886,7 +868,6 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
     if (!bot || !bot->GetSession() || !bot->IsInWorld() || bot->IsBeingTeleported() ||
         bot->GetSession()->isLogingOut() || bot->IsDuringRemoveFromWorld())
         return;
-
 
     // Playerbots must never send MOVEMENTFLAG_ROOT in movement packets (e.g. MSG_MOVE_HEARTBEAT).
     // If this flag becomes stale, core will spam: "Attempted sending heartbeat with root flag for guid ..."
@@ -1036,7 +1017,6 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
         }
     }
 
-
     // Handle cheat options (set bot health and power if cheats are enabled)
     if (bot->IsAlive() &&
         (static_cast<uint32>(GetCheat()) > 0 || static_cast<uint32>(sPlayerbotAIConfig->botCheatMask) > 0))
@@ -1071,7 +1051,6 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 
         YieldThread(delay);
     };
-
 
     // Handle the current spell
     Spell* currentSpell = bot->GetCurrentSpell(CURRENT_GENERIC_SPELL);

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -43,6 +43,7 @@
 #include "PlayerbotAIConfig.h"
 #include "PlayerbotRepository.h"
 #include "PlayerbotMgr.h"
+#include "PlayerbotFactory.h"
 #include "PlayerbotGuildMgr.h"
 #include "Playerbots.h"
 #include "PointMovementGenerator.h"
@@ -236,6 +237,13 @@ PlayerbotAI::~PlayerbotAI()
         sPlayerbotsMgr->RemovePlayerBotData(bot->GetGUID(), true);
 }
 
+
+void PlayerbotAI::SetPendingPveGearReequip(bool hadRealMaster)
+{
+    pendingPveGearReequip_ = true;
+    pendingPveGearReequipHadRealMaster_ = hadRealMaster;
+}
+
 void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 {
     // Handle the AI check delay
@@ -248,6 +256,40 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
     if (!bot || !bot->GetSession() || !bot->IsInWorld() || bot->IsBeingTeleported() ||
         bot->GetSession()->isLogingOut() || bot->IsDuringRemoveFromWorld())
         return;
+
+    // Delayed PvE re-equip after leaving BG/arena.
+    // Leaving a battleground/arena usually involves a map transfer; avoid rebuilding gear during loading.
+    if (pendingPveGearReequip_)
+    {
+        // Safety: only random bots use this path.
+        if (!sRandomPlayerbotMgr || !sRandomPlayerbotMgr->IsRandomBot(bot))
+        {
+            pendingPveGearReequip_ = false;
+            pendingPveGearReequipHadRealMaster_ = false;
+        }
+        else if (!bot->IsInCombat() && !bot->InBattleground() && !bot->InArena() && !bot->GetBattleground())
+        {
+            uint32 qualityLimit = pendingPveGearReequipHadRealMaster_ ? sPlayerbotAIConfig->autoGearQualityLimit
+                                                                     : sPlayerbotAIConfig->randomGearQualityLimit;
+            uint32 scoreLimit = pendingPveGearReequipHadRealMaster_ ? sPlayerbotAIConfig->autoGearScoreLimit
+                                                                    : sPlayerbotAIConfig->randomGearScoreLimit;
+            uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
+
+            uint8 savedLevel = bot->GetLevel();
+            PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
+
+            // Force gear generation; do not touch talents/level/spells/etc.
+            factory.InitEquipment(false);
+
+            // Apply enchants/gems only.
+            if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
+                factory.ApplyEnchantAndGemsNew();
+
+            pendingPveGearReequip_ = false;
+            pendingPveGearReequipHadRealMaster_ = false;
+        }
+    }
+
 
     // Handle cheat options (set bot health and power if cheats are enabled)
     if (bot->IsAlive() &&

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "Bag.h"
+
 #include "AiFactory.h"
 #include "BudgetValues.h"
 #include "ChannelMgr.h"
@@ -63,6 +65,25 @@
 #include "Unit.h"
 #include "UpdateTime.h"
 #include "Vehicle.h"
+
+namespace
+{
+    // Local throttle for expensive PvE re-equip rebuilds.
+    // Some cores/branches do not expose RandomPlayerbotMgr::TryAcquirePveReequipPermit().
+    // We keep it simple: allow at most one rebuild every 100ms globally.
+    static bool TryAcquirePveReequipPermitLocal()
+    {
+        static uint32 sNextPermitMs = 0;
+        uint32 nowMs = getMSTime();
+
+        if (sNextPermitMs && nowMs < sNextPermitMs)
+            return false;
+
+        sNextPermitMs = nowMs + 100;
+        return true;
+    }
+}
+
 
 namespace
 {
@@ -278,6 +299,40 @@ PlayerbotAI::PlayerbotAI(Player* bot)
     botOutgoingPacketHandlers.AddHandler(SMSG_QUEST_CONFIRM_ACCEPT, "confirm quest");
 }
 
+void PlayerbotAI::SetMaster(Player* newMaster)
+{
+    if (master == newMaster)
+        return;
+
+    Player* oldMaster = master;
+    master = newMaster;
+
+    // Maintain fast master->controlled random/addclass bots index so real players without bots
+    // do not pay O(N_random_bots) cost on each outgoing packet.
+    if (bot && (sRandomPlayerbotMgr->IsRandomBot(bot) || sRandomPlayerbotMgr->IsAddclassBot(bot)))
+    {
+        ObjectGuid botGuid = bot->GetGUID();
+
+        ObjectGuid oldMasterGuid;
+        if (oldMaster)
+        {
+            PlayerbotAI* oldMasterAI = GET_PLAYERBOT_AI(oldMaster);
+            if (!oldMasterAI || oldMasterAI->IsRealPlayer())
+                oldMasterGuid = oldMaster->GetGUID();
+        }
+
+        ObjectGuid newMasterGuid;
+        if (newMaster)
+        {
+            PlayerbotAI* newMasterAI = GET_PLAYERBOT_AI(newMaster);
+            if (!newMasterAI || newMasterAI->IsRealPlayer())
+                newMasterGuid = newMaster->GetGUID();
+        }
+
+        sRandomPlayerbotMgr->OnRandomBotMasterChanged(botGuid, oldMasterGuid, newMasterGuid);
+    }
+}
+
 PlayerbotAI::~PlayerbotAI()
 {
     for (uint8 i = 0; i < BOT_STATE_MAX; i++)
@@ -296,9 +351,528 @@ PlayerbotAI::~PlayerbotAI()
 
 void PlayerbotAI::SetPendingPveGearReequip(bool hadRealMaster)
 {
-    pendingPveGearReequip_ = true;
+    // Schedule a single PvE restore only if this bot actually equipped PvP gear before.
+    // (Bots that never swapped to PvP should not trigger a heavy PvE re-equip.)
+    if (!pvpGearActive_ || pvpSwapEpoch_ == 0)
+        return;
+
+    // Idempotent: do not schedule the same epoch twice.
+    if (pendingPveGearReequipEpoch_ >= pvpSwapEpoch_)
+        return;
+
+    pendingPveGearReequipEpoch_ = pvpSwapEpoch_;
     pendingPveGearReequipHadRealMaster_ = hadRealMaster;
+    pendingPveGearReequipNextTryMs_ = getMSTime() + urand(0, 500);
 }
+
+
+bool PlayerbotAI::ShouldLeaveEmptyBgQueue(uint32 queueTypeId, uint8 bracketId, bool hasRealPlayers,
+                                         uint32 minEmptyMs, uint32 attemptCooldownMs)
+{
+    // This is a per-bot, low-cost limiter to prevent churn and packet spam:
+    // - Leave as soon as the queue has no real players (minEmptyMs defaults to 0 for strict mode).
+    // - Do not spam leave packets if the bot remains in queue and keeps receiving WAIT_QUEUE updates.
+    uint64 key = (uint64(queueTypeId) << 32) | uint64(bracketId);
+    uint32 nowMs = getMSTime();
+
+    if (hasRealPlayers)
+    {
+        if (emptyBgQueueKey_ == key)
+            emptyBgQueueSinceMs_ = 0;
+
+        return false;
+    }
+
+    if (emptyBgQueueKey_ != key || emptyBgQueueSinceMs_ == 0)
+    {
+        emptyBgQueueKey_ = key;
+        emptyBgQueueSinceMs_ = nowMs;
+        return false;
+    }
+
+    // Require the queue to be empty for a short time before leaving.
+    if (nowMs - emptyBgQueueSinceMs_ < minEmptyMs)
+        return false;
+
+    // Cooldown between leave attempts for the same queue.
+    if (lastEmptyBgQueueLeaveKey_ == key && lastEmptyBgQueueLeaveAttemptMs_ &&
+        (nowMs - lastEmptyBgQueueLeaveAttemptMs_) < attemptCooldownMs)
+        return false;
+
+    lastEmptyBgQueueLeaveKey_ = key;
+    lastEmptyBgQueueLeaveAttemptMs_ = nowMs;
+    return true;
+}
+
+
+void PlayerbotAI::OnPvpGearEquipped(uint32 instanceId)
+{
+    // Mark that the bot is now in PvP gear and advance the epoch.
+    ++pvpSwapEpoch_;
+    pvpGearActive_ = true;
+    lastSwapBgInstanceId_ = instanceId;
+}
+
+
+bool PlayerbotAI::IsWildRandomBotForAutoGearSwap() const
+{
+    if (!bot || !sRandomPlayerbotMgr)
+        return false;
+
+    if (!sRandomPlayerbotMgr->IsRandomBot(bot))
+        return false;
+
+    // Addclass (summoned) bots must never auto-stash/auto-swap.
+    if (sRandomPlayerbotMgr->IsAddclassBot(bot))
+        return false;
+
+    // Player-controlled or group-master bots are handled by the player.
+    if (HasRealPlayerMaster())
+        return false;
+
+    return true;
+}
+
+
+bool PlayerbotAI::ItemTemplateHasResilience(ItemTemplate const* proto)
+{
+    if (!proto)
+        return false;
+
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_STATS; ++i)
+    {
+        if (proto->ItemStat[i].ItemStatType == ITEM_MOD_RESILIENCE_RATING && proto->ItemStat[i].ItemStatValue > 0)
+            return true;
+    }
+
+    return false;
+}
+
+
+bool PlayerbotAI::LooksLikePvpGearEquipped() const
+{
+    if (!bot)
+        return false;
+
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+    {
+        if (slot == EQUIPMENT_SLOT_BODY || slot == EQUIPMENT_SLOT_TABARD)
+            continue;
+
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (!item)
+            continue;
+
+        ItemTemplate const* proto = item->GetTemplate();
+        if (ItemTemplateHasResilience(proto))
+            return true;
+    }
+
+    return false;
+}
+
+
+bool PlayerbotAI::FindFirstFreeBankSlot(uint8& outBag, uint8& outSlot) const
+{
+    // Main bank slots
+    for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+    {
+        if (!bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+        {
+            outBag = INVENTORY_SLOT_BAG_0;
+            outSlot = slot;
+            return true;
+        }
+    }
+
+    // Bank bags
+    for (uint8 bagSlot = BANK_SLOT_BAG_START; bagSlot < BANK_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!item || !item->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)item;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+        {
+            if (!bag->GetItemByPos(i))
+            {
+                outBag = bagSlot;
+                outSlot = i;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+
+uint32 PlayerbotAI::CountFreeBankSlots() const
+{
+    uint32 free = 0;
+
+    for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+        if (!bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+            ++free;
+
+    for (uint8 bagSlot = BANK_SLOT_BAG_START; bagSlot < BANK_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!item || !item->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)item;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+            if (!bag->GetItemByPos(i))
+                ++free;
+    }
+
+    return free;
+}
+
+
+void PlayerbotAI::HardPurgeBankContents()
+{
+    // Main bank items
+    for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+    {
+        if (bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+            bot->DestroyItem(INVENTORY_SLOT_BAG_0, slot, true);
+    }
+
+    // Bank bag contents (do NOT destroy the bank bags themselves)
+    for (uint8 bagSlot = BANK_SLOT_BAG_START; bagSlot < BANK_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!item || !item->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)item;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+        {
+            if (bot->GetItemByPos(bagSlot, i))
+                bot->DestroyItem(bagSlot, i, true);
+        }
+    }
+}
+
+
+Item* PlayerbotAI::FindItemInBankByGuidRaw(uint64 guidRaw, uint8& outBag, uint8& outSlot) const
+{
+    // Main bank slots
+    for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+    {
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (item && item->GetGUID().GetRawValue() == guidRaw)
+        {
+            outBag = INVENTORY_SLOT_BAG_0;
+            outSlot = slot;
+            return item;
+        }
+    }
+
+    // Bank bags
+    for (uint8 bagSlot = BANK_SLOT_BAG_START; bagSlot < BANK_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* bagItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!bagItem || !bagItem->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)bagItem;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+        {
+            Item* item = bot->GetItemByPos(bagSlot, i);
+            if (item && item->GetGUID().GetRawValue() == guidRaw)
+            {
+                outBag = bagSlot;
+                outSlot = i;
+                return item;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+
+void PlayerbotAI::ClearPveBankStash()
+{
+    pveBankStashEpoch_ = 0;
+    pveBankStashedGuidRawBySlot_.fill(0);
+}
+
+
+void PlayerbotAI::PurgeResilienceItemsFromBankAndBags(uint32 maxToDestroy)
+{
+    uint32 destroyed = 0;
+
+    auto maybeDestroy = [&](uint8 bag, uint8 slot)
+    {
+        if (maxToDestroy && destroyed >= maxToDestroy)
+            return;
+
+        Item* item = bot->GetItemByPos(bag, slot);
+        if (!item)
+            return;
+
+        ItemTemplate const* proto = item->GetTemplate();
+        if (!ItemTemplateHasResilience(proto))
+            return;
+
+        bot->DestroyItem(bag, slot, true);
+        ++destroyed;
+    };
+
+    // Inventory (main)
+    for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+    {
+        maybeDestroy(INVENTORY_SLOT_BAG_0, slot);
+        if (maxToDestroy && destroyed >= maxToDestroy)
+            return;
+    }
+
+    // Bags
+    for (uint8 bagSlot = INVENTORY_SLOT_BAG_START; bagSlot < INVENTORY_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* bagItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!bagItem || !bagItem->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)bagItem;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+        {
+            maybeDestroy(bagSlot, i);
+            if (maxToDestroy && destroyed >= maxToDestroy)
+                return;
+        }
+    }
+
+    // Bank (main)
+    for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+    {
+        maybeDestroy(INVENTORY_SLOT_BAG_0, slot);
+        if (maxToDestroy && destroyed >= maxToDestroy)
+            return;
+    }
+
+    // Bank bags
+    for (uint8 bagSlot = BANK_SLOT_BAG_START; bagSlot < BANK_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* bagItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!bagItem || !bagItem->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)bagItem;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+        {
+            maybeDestroy(bagSlot, i);
+            if (maxToDestroy && destroyed >= maxToDestroy)
+                return;
+        }
+    }
+}
+
+
+bool PlayerbotAI::StashPveGearToBankForNextPvpSwap()
+{
+    if (!IsWildRandomBotForAutoGearSwap())
+        return false;
+
+    // If we already consider ourselves in PvP gear, do not stash.
+    if (pvpGearActive_)
+        return false;
+
+    uint32 targetEpoch = pvpSwapEpoch_ + 1;
+    if (pveBankStashEpoch_ == targetEpoch)
+        return true; // already stashed for this upcoming swap
+
+    // Reset stash map
+    pveBankStashedGuidRawBySlot_.fill(0);
+    pveBankStashEpoch_ = targetEpoch;
+
+    uint32 needSlots = 0;
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+    {
+        if (slot == EQUIPMENT_SLOT_BODY || slot == EQUIPMENT_SLOT_TABARD)
+            continue;
+        if (bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+            ++needSlots;
+    }
+
+    if (!needSlots)
+        return true;
+
+    // Ensure we have enough free bank space; otherwise, purge the bank.
+    if (CountFreeBankSlots() < needSlots)
+        HardPurgeBankContents();
+
+    // Move each equipped item into a free bank slot.
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+    {
+        if (slot == EQUIPMENT_SLOT_BODY || slot == EQUIPMENT_SLOT_TABARD)
+            continue;
+
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (!item)
+            continue;
+
+        uint8 dstBag = 0;
+        uint8 dstSlot = 0;
+        if (!FindFirstFreeBankSlot(dstBag, dstSlot))
+            break; // no more space (should not happen after purge)
+
+        uint64 guidRaw = item->GetGUID().GetRawValue();
+        uint16 src = (uint16(INVENTORY_SLOT_BAG_0) << 8) | uint16(slot);
+        uint16 dst = (uint16(dstBag) << 8) | uint16(dstSlot);
+
+        bot->SwapItem(src, dst);
+
+        pveBankStashedGuidRawBySlot_[slot] = guidRaw;
+    }
+
+    return true;
+}
+
+
+bool PlayerbotAI::TryRestorePveGearFromBankStash(uint32 epoch)
+{
+    if (!IsWildRandomBotForAutoGearSwap())
+        return false;
+
+    if (!epoch || pveBankStashEpoch_ != epoch)
+        return false;
+
+    bool restoredAny = false;
+
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+    {
+        if (slot == EQUIPMENT_SLOT_BODY || slot == EQUIPMENT_SLOT_TABARD)
+            continue;
+
+        uint64 guidRaw = pveBankStashedGuidRawBySlot_[slot];
+        if (!guidRaw)
+            continue;
+
+        uint8 srcBag = 0;
+        uint8 srcSlot = 0;
+        Item* bankItem = FindItemInBankByGuidRaw(guidRaw, srcBag, srcSlot);
+        if (!bankItem)
+            continue;
+
+        uint16 src = (uint16(srcBag) << 8) | uint16(srcSlot);
+        uint16 dst = (uint16(INVENTORY_SLOT_BAG_0) << 8) | uint16(slot);
+
+        bot->SwapItem(src, dst);
+        restoredAny = true;
+
+        // Destroy the swapped-out item if it looks like PvP gear (we don't want to keep PvP leftovers).
+        Item* swappedOut = bot->GetItemByPos(srcBag, srcSlot);
+        if (swappedOut && ItemTemplateHasResilience(swappedOut->GetTemplate()))
+            bot->DestroyItem(srcBag, srcSlot, true);
+    }
+
+    // One attempt per epoch is enough; if some items weren't found, we will fall back to heuristic/rebuild.
+    ClearPveBankStash();
+
+    if (restoredAny)
+        PurgeResilienceItemsFromBankAndBags(200);
+
+    return restoredAny;
+}
+
+
+bool PlayerbotAI::TryRecoverPveGearFromBankHeuristic()
+{
+    if (!IsWildRandomBotForAutoGearSwap())
+        return false;
+
+    // Only run if the bot currently looks like it is in PvP gear.
+    if (!LooksLikePvpGearEquipped())
+        return false;
+
+    std::array<uint16, EQUIPMENT_SLOT_END> bestPos{};
+    std::array<uint32, EQUIPMENT_SLOT_END> bestIlvl{};
+
+    auto consider = [&](Item* item)
+    {
+        if (!item)
+            return;
+
+        ItemTemplate const* proto = item->GetTemplate();
+        if (!proto)
+            return;
+
+        if (proto->InventoryType == INVTYPE_NON_EQUIP)
+            return;
+
+        if (ItemTemplateHasResilience(proto))
+            return;
+
+        uint8 equipSlot = FindEquipSlot(proto, NULL_SLOT, true);
+        if (equipSlot >= EQUIPMENT_SLOT_END)
+            return;
+
+        if (equipSlot == EQUIPMENT_SLOT_BODY || equipSlot == EQUIPMENT_SLOT_TABARD)
+            return;
+
+        uint32 ilvl = proto->ItemLevel;
+        if (!bestPos[equipSlot] || ilvl > bestIlvl[equipSlot])
+        {
+            bestPos[equipSlot] = item->GetPos();
+            bestIlvl[equipSlot] = ilvl;
+        }
+    };
+
+    // Scan bank main slots
+    for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+        consider(bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot));
+
+    // Scan bank bag contents
+    for (uint8 bagSlot = BANK_SLOT_BAG_START; bagSlot < BANK_SLOT_BAG_END; ++bagSlot)
+    {
+        Item* bagItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bagSlot);
+        if (!bagItem || !bagItem->IsBag())
+            continue;
+
+        Bag* bag = (Bag*)bagItem;
+        for (uint8 i = 0; i < bag->GetBagSize(); ++i)
+            consider(bot->GetItemByPos(bagSlot, i));
+    }
+
+    bool swappedAny = false;
+
+    for (uint8 equipSlot = EQUIPMENT_SLOT_START; equipSlot < EQUIPMENT_SLOT_END; ++equipSlot)
+    {
+        if (equipSlot == EQUIPMENT_SLOT_BODY || equipSlot == EQUIPMENT_SLOT_TABARD)
+            continue;
+
+        Item* cur = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, equipSlot);
+        if (!cur || !ItemTemplateHasResilience(cur->GetTemplate()))
+            continue;
+
+        uint16 src = bestPos[equipSlot];
+        if (!src)
+            continue;
+
+        uint8 srcBag = uint8(src >> 8);
+        uint8 srcSlot = uint8(src & 0xFF);
+
+        uint16 dst = (uint16(INVENTORY_SLOT_BAG_0) << 8) | uint16(equipSlot);
+        bot->SwapItem(src, dst);
+        swappedAny = true;
+
+        Item* swappedOut = bot->GetItemByPos(srcBag, srcSlot);
+        if (swappedOut && ItemTemplateHasResilience(swappedOut->GetTemplate()))
+            bot->DestroyItem(srcBag, srcSlot, true);
+    }
+
+    if (swappedAny)
+        PurgeResilienceItemsFromBankAndBags(200);
+
+    return swappedAny;
+}
+
 
 void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 {
@@ -320,36 +894,145 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
     if (bot->m_movementInfo.HasMovementFlag(MOVEMENTFLAG_ROOT))
         bot->m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_ROOT);
 
-    // Delayed PvE re-equip after leaving BG/arena.
-    // Leaving a battleground/arena usually involves a map transfer; avoid rebuilding gear during loading.
-    if (pendingPveGearReequip_)
+    // Delayed PvE restore after leaving BG/arena.
+    // Leaving a battleground/arena usually involves a map transfer; avoid any heavy work during loading.
+    // For wild random bots we first try a cheap bank-first restore (swap back the stashed PvE set).
+    // Only if that fails (or we have no stash) we fall back to a throttled full PvE gear rebuild.
+    if (pendingPveGearReequipEpoch_ > donePveGearReequipEpoch_)
     {
-        // Safety: only random bots use this path.
+        // Safety: if this isn't a random bot, just finalize the pending epoch.
         if (!sRandomPlayerbotMgr || !sRandomPlayerbotMgr->IsRandomBot(bot))
         {
-            pendingPveGearReequip_ = false;
+            donePveGearReequipEpoch_ = pendingPveGearReequipEpoch_;
             pendingPveGearReequipHadRealMaster_ = false;
+            pvpGearActive_ = false;
+            pendingPveGearReequipNextTryMs_ = 0;
+            ClearPveBankStash();
         }
-        else if (!bot->IsInCombat() && !bot->InBattleground() && !bot->InArena() && !bot->GetBattleground())
+        else if (bot->IsInWorld() && !bot->IsDuringRemoveFromWorld() && bot->GetMap() &&
+                 !bot->IsBeingTeleported() && !bot->IsBeingTeleportedFar() && !bot->IsInCombat() &&
+                 !bot->InBattleground() && !bot->InArena() && !bot->GetBattleground())
         {
-            uint32 qualityLimit = pendingPveGearReequipHadRealMaster_ ? sPlayerbotAIConfig->autoGearQualityLimit
-                                                                     : sPlayerbotAIConfig->randomGearQualityLimit;
-            uint32 scoreLimit = pendingPveGearReequipHadRealMaster_ ? sPlayerbotAIConfig->autoGearScoreLimit
-                                                                    : sPlayerbotAIConfig->randomGearScoreLimit;
-            uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
+            uint32 nowMs = getMSTime();
 
-            uint8 savedLevel = bot->GetLevel();
-            PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
+            // Backoff: do not spin every tick while waiting for permits / next attempt.
+            if (pendingPveGearReequipNextTryMs_ && nowMs < pendingPveGearReequipNextTryMs_)
+            {
+                // Waiting.
+            }
+            else
+            {
+                pendingPveGearReequipNextTryMs_ = 0;
 
-            // Force gear generation; do not touch talents/level/spells/etc.
-            factory.InitEquipment(false, true);
+                // Only wild random bots are auto-restored; addclass and player-controlled bots are excluded.
+                if (!IsWildRandomBotForAutoGearSwap())
+                {
+                    donePveGearReequipEpoch_ = pendingPveGearReequipEpoch_;
+                    pendingPveGearReequipHadRealMaster_ = false;
+                    pvpGearActive_ = false;
+                    ClearPveBankStash();
+                }
+                else
+                {
+                    // Cheap path #1: restore exact PvE set stashed before PvP equip.
+                    TryRestorePveGearFromBankStash(pendingPveGearReequipEpoch_);
 
-            // Apply enchants/gems only.
-            if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
-                factory.ApplyEnchantAndGemsNew();
+                    // Cheap path #2: if still looks like PvP gear (e.g. stash missing), try a best-effort bank heuristic.
+                    if (LooksLikePvpGearEquipped())
+                        TryRecoverPveGearFromBankHeuristic();
 
-            pendingPveGearReequip_ = false;
-            pendingPveGearReequipHadRealMaster_ = false;
+                    // If we no longer look like we're in PvP gear, we are done.
+                    if (!LooksLikePvpGearEquipped())
+                    {
+                        donePveGearReequipEpoch_ = pendingPveGearReequipEpoch_;
+                        pendingPveGearReequipHadRealMaster_ = false;
+                        pvpGearActive_ = false;
+                    }
+                    else
+                    {
+                        // Still in PvP gear => fallback to throttled full rebuild.
+                        if (!TryAcquirePveReequipPermitLocal())
+                        {
+                            pendingPveGearReequipNextTryMs_ = nowMs + urand(150, 300);
+                        }
+                        else
+                        {
+                            uint32 qualityLimit = pendingPveGearReequipHadRealMaster_ ? sPlayerbotAIConfig->autoGearQualityLimit
+                                                                                     : sPlayerbotAIConfig->randomGearQualityLimit;
+                            uint32 scoreLimit = pendingPveGearReequipHadRealMaster_ ? sPlayerbotAIConfig->autoGearScoreLimit
+                                                                                    : sPlayerbotAIConfig->randomGearScoreLimit;
+                            uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
+
+                            uint8 savedLevel = bot->GetLevel();
+                            PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
+
+                            // Force gear generation; do not touch talents/level/spells/etc.
+                            factory.InitEquipment(false, true);
+
+                            // Apply enchants/gems only.
+                            if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
+                                factory.ApplyEnchantAndGemsNew();
+
+                            PurgeResilienceItemsFromBankAndBags(500);
+
+                            donePveGearReequipEpoch_ = pendingPveGearReequipEpoch_;
+                            pendingPveGearReequipHadRealMaster_ = false;
+                            pvpGearActive_ = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Post-restart safety: if server crashed/restarted while a bot was in PvP gear, pvpGearActive_ resets.
+    // If the bot is now outside BG/arena but still looks like PvP-geared, try a single recovery pass.
+    if (!postRestartPveRecoveryDone_ && !pvpGearActive_ && IsWildRandomBotForAutoGearSwap() &&
+        bot->IsInWorld() && !bot->IsDuringRemoveFromWorld() && bot->GetMap() &&
+        !bot->IsBeingTeleported() && !bot->IsBeingTeleportedFar() && !bot->IsInCombat() &&
+        !bot->InBattleground() && !bot->InArena() && !bot->GetBattleground())
+    {
+        uint32 nowMs = getMSTime();
+        if (!postRestartPveRecoveryNextTryMs_ || nowMs >= postRestartPveRecoveryNextTryMs_)
+        {
+            if (LooksLikePvpGearEquipped())
+            {
+                // Prefer cheap heuristic restore from bank.
+                TryRecoverPveGearFromBankHeuristic();
+
+                if (!LooksLikePvpGearEquipped())
+                {
+                    postRestartPveRecoveryDone_ = true;
+                    postRestartPveRecoveryNextTryMs_ = 0;
+                }
+                else if (sRandomPlayerbotMgr && TryAcquirePveReequipPermitLocal())
+                {
+                    uint32 qualityLimit = sPlayerbotAIConfig->randomGearQualityLimit;
+                    uint32 scoreLimit = sPlayerbotAIConfig->randomGearScoreLimit;
+                    uint32 gs = scoreLimit == 0 ? 0 : PlayerbotFactory::CalcMixedGearScore(scoreLimit, qualityLimit);
+
+                    uint8 savedLevel = bot->GetLevel();
+                    PlayerbotFactory factory(bot, savedLevel, qualityLimit, gs, true);
+                    factory.InitEquipment(false, true);
+                    if (savedLevel >= sPlayerbotAIConfig->minEnchantingBotLevel)
+                        factory.ApplyEnchantAndGemsNew();
+
+                    PurgeResilienceItemsFromBankAndBags(500);
+
+                    postRestartPveRecoveryDone_ = true;
+                    postRestartPveRecoveryNextTryMs_ = 0;
+                }
+                else
+                {
+                    // Retry later.
+                    postRestartPveRecoveryNextTryMs_ = nowMs + urand(500, 1000);
+                }
+            }
+            else
+            {
+                postRestartPveRecoveryDone_ = true;
+                postRestartPveRecoveryNextTryMs_ = 0;
+            }
         }
     }
 
@@ -518,7 +1201,6 @@ void PlayerbotAI::UpdateAIGroupMaster()
         Player* newMaster = FindNewMaster();
         if (newMaster)
         {
-            master = newMaster;
             botAI->SetMaster(newMaster);
             botAI->ResetStrategies();
 
@@ -4383,7 +5065,7 @@ Player* PlayerbotAI::FindNewMaster()
     return nullptr;
 }
 
-bool PlayerbotAI::HasRealPlayerMaster()
+bool PlayerbotAI::HasRealPlayerMaster() const
 {
     if (master)
     {

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -6,6 +6,7 @@
 #ifndef _PLAYERBOT_PLAYERbotAI_H
 #define _PLAYERBOT_PLAYERbotAI_H
 
+#include <array>
 #include <queue>
 #include <stack>
 
@@ -394,6 +395,32 @@ public:
     // Schedule a delayed PvE re-equip after leaving BG/arena (teleport/loading safe).
     // Used by PvP gear swap logic to avoid re-gearing during map transfer.
     void SetPendingPveGearReequip(bool hadRealMaster);
+    // PvP/PvE gear swap tracking:
+    // - PvP swap increments an epoch counter (pvpSwapEpoch_). Leaving BG/arena schedules a single PvE restore for that epoch.
+    // - This avoids duplicate PvE re-equip even if LeaveBG() fires multiple times, and does not depend on BG instanceId reuse.
+    void OnPvpGearEquipped(uint32 instanceId);
+    bool IsPvpGearActive() const { return pvpGearActive_; }
+    uint32 GetPvpSwapEpoch() const { return pvpSwapEpoch_; }
+
+    // Bank-first PvE stash: move current equipped PvE items into bank before generating PvP gear.
+    // This makes leaving BG/arena cheap: we can restore PvE by swapping items back from bank.
+    // Only applies to wild random bots (no real master, not addclass).
+    bool StashPveGearToBankForNextPvpSwap();
+
+    // Anti-churn: decide whether a wild random-bot should leave a BG queue that has no real players.
+    // Returns true at most once per short interval, and only after the queue has been empty long enough.
+    bool ShouldLeaveEmptyBgQueue(uint32 queueTypeId, uint8 bracketId, bool hasRealPlayers,
+                               uint32 minEmptyMs = 0, uint32 attemptCooldownMs = 5000);
+    // BG/arena strategy / gear swap state (per-bot; avoids global static maps in BGStrategyCheckAction).
+    uint32 GetLastSeenBgInstanceId() const { return lastSeenBgInstanceId_; }
+    uint32 GetLastSwapBgInstanceId() const { return lastSwapBgInstanceId_; }
+    void SetLastSeenBgInstanceId(uint32 id) { lastSeenBgInstanceId_ = id; }
+    void SetLastSwapBgInstanceId(uint32 id) { lastSwapBgInstanceId_ = id; }
+    void ResetBgStrategyState()
+    {
+        lastSeenBgInstanceId_ = 0;
+        lastSwapBgInstanceId_ = 0;
+    }
 
     std::string const HandleRemoteCommand(std::string const command);
     void HandleCommand(uint32 type, std::string const text, Player* fromPlayer);
@@ -538,7 +565,7 @@ public:
     // Checks if the bot is really a player. Players always have themselves as master.
     bool IsRealPlayer() { return master ? (master == bot) : false; }
     // Bot has a master that is a player.
-    bool HasRealPlayerMaster();
+    bool HasRealPlayerMaster() const;
     // Bot has a master that is activly playing.
     bool HasActivePlayerMaster();
     // Get the group leader or the master of the bot.
@@ -571,7 +598,7 @@ public:
     BotCheatMask GetCheat() { return cheatMask; }
     void SetCheat(BotCheatMask mask) { cheatMask = mask; }
 
-    void SetMaster(Player* newMaster) { master = newMaster; }
+    void SetMaster(Player* newMaster);
     AiObjectContext* GetAiObjectContext() { return aiObjectContext; }
     ChatHelper* GetChatHelper() { return &chatHelper; }
     bool IsOpposing(Player* player);
@@ -622,8 +649,55 @@ private:
     bool _isBotInitializing = false;
 
     // Pending PvE re-equip after leaving BG/arena (deferred until bot is back in world).
-    bool pendingPveGearReequip_ = false;
+    uint32 pendingPveGearReequipEpoch_ = 0;
     bool pendingPveGearReequipHadRealMaster_ = false;
+
+    uint32 pendingPveGearReequipNextTryMs_ = 0;
+
+    uint32 donePveGearReequipEpoch_ = 0;
+
+    // Indicates whether the bot is currently in its PvP gear set (from BG/arena swap logic).
+    bool pvpGearActive_ = false;
+
+    // Epoch counter incremented each time the bot successfully equips PvP gear.
+    uint32 pvpSwapEpoch_ = 0;
+
+    // Bank-first PvE stash state (wild random bots only):
+    // - Before equipping PvP gear, we move current equipped PvE items into bank and remember their GUIDs by slot.
+    // - After leaving BG/arena, we restore by swapping those items back from bank.
+    // The epoch is aligned with pvpSwapEpoch_ (stash is prepared for pvpSwapEpoch_+1).
+    uint32 pveBankStashEpoch_ = 0;
+    std::array<uint64, EQUIPMENT_SLOT_END> pveBankStashedGuidRawBySlot_{};
+
+    // Post-restart safety: if a bot is stuck in PvP gear outside BG/arena (pvpGearActive_ reset), try to recover once.
+    bool postRestartPveRecoveryDone_ = false;
+    uint32 postRestartPveRecoveryNextTryMs_ = 0;
+
+    bool IsWildRandomBotForAutoGearSwap() const;
+    static bool ItemTemplateHasResilience(ItemTemplate const* proto);
+    bool LooksLikePvpGearEquipped() const;
+
+    bool FindFirstFreeBankSlot(uint8& outBag, uint8& outSlot) const;
+    uint32 CountFreeBankSlots() const;
+    void HardPurgeBankContents();
+    Item* FindItemInBankByGuidRaw(uint64 guidRaw, uint8& outBag, uint8& outSlot) const;
+    void ClearPveBankStash();
+
+    bool TryRestorePveGearFromBankStash(uint32 epoch);
+    bool TryRecoverPveGearFromBankHeuristic();
+    void PurgeResilienceItemsFromBankAndBags(uint32 maxToDestroy);
+
+    // BG queue empty-queue tracking (to avoid bot-only battlegrounds).
+    uint64 emptyBgQueueKey_ = 0;
+    uint32 emptyBgQueueSinceMs_ = 0;
+    uint64 lastEmptyBgQueueLeaveKey_ = 0;
+    uint32 lastEmptyBgQueueLeaveAttemptMs_ = 0;
+
+    // BG/arena instance tracking for BGStrategyCheckAction (per-bot state).
+    uint32 lastSeenBgInstanceId_ = 0;
+    uint32 lastSwapBgInstanceId_ = 0;
+
+
     inline bool IsValidUnit(const Unit* unit) const
     {
         return unit && unit->IsInWorld() && !unit->IsDuringRemoveFromWorld();

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -391,6 +391,10 @@ public:
     void UpdateAI(uint32 elapsed, bool minimal = false) override;
     void UpdateAIInternal(uint32 elapsed, bool minimal = false) override;
 
+    // Schedule a delayed PvE re-equip after leaving BG/arena (teleport/loading safe).
+    // Used by PvP gear swap logic to avoid re-gearing during map transfer.
+    void SetPendingPveGearReequip(bool hadRealMaster);
+
     std::string const HandleRemoteCommand(std::string const command);
     void HandleCommand(uint32 type, std::string const text, Player* fromPlayer);
     void QueueChatResponse(const ChatQueuedReply reply);
@@ -616,6 +620,10 @@ private:
     void HandleCommands();
     void HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);
     bool _isBotInitializing = false;
+
+    // Pending PvE re-equip after leaving BG/arena (deferred until bot is back in world).
+    bool pendingPveGearReequip_ = false;
+    bool pendingPveGearReequipHadRealMaster_ = false;
     inline bool IsValidUnit(const Unit* unit) const
     {
         return unit && unit->IsInWorld() && !unit->IsDuringRemoveFromWorld();

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -697,7 +697,6 @@ private:
     uint32 lastSeenBgInstanceId_ = 0;
     uint32 lastSwapBgInstanceId_ = 0;
 
-
     inline bool IsValidUnit(const Unit* unit) const
     {
         return unit && unit->IsInWorld() && !unit->IsDuringRemoveFromWorld();

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -43,7 +43,6 @@
 #include "WorldSessionMgr.h"
 #include "DatabaseEnv.h"
 
-
 namespace
 {
 template <class F>

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -10,6 +10,8 @@
 #include <istream>
 #include <string>
 #include <unordered_set>
+#include <deque>
+#include <unordered_map>
 #include <openssl/sha.h>
 #include <iomanip>
 #include <algorithm>
@@ -45,7 +47,7 @@ class BotInitGuard
 public:
     BotInitGuard(ObjectGuid guid) : guid(guid), active(false)
     {
-        if (!botsBeingInitialized.contains(guid))
+        if (botsBeingInitialized.find(guid) == botsBeingInitialized.end())
         {
             botsBeingInitialized.insert(guid);
             active = true;
@@ -69,7 +71,303 @@ private:
 std::unordered_set<ObjectGuid> BotInitGuard::botsBeingInitialized;
 std::unordered_set<ObjectGuid> PlayerbotHolder::botLoading;
 
+namespace
+{
+    static constexpr uint32 BOT_INIT_COOLDOWN_MS = 3000;          // Per-bot cooldown (request + successful init).
+    static constexpr uint32 BOT_INIT_QUEUE_STEP_MS = 250;         // Minimum delay between init executions.
+    static constexpr size_t BOT_INIT_QUEUE_MAX_SIZE = 200;        // Global queue size limit.
+    static constexpr size_t BOT_INIT_QUEUE_MAX_PER_MASTER = 40;   // Per-master queue size limit.
+    static constexpr uint8 BOT_INIT_QUEUE_MAX_POSTPONE = 20;      // Safety cap to avoid infinite requeue loops.
+
+    struct BotInitRequest
+    {
+        ObjectGuid botGuid;
+        ObjectGuid masterGuid;
+        std::string cmd;
+        bool admin = false;
+        uint8 postponeCount = 0;
+    };
+
+    class BotInitQueue
+    {
+    public:
+        static BotInitQueue& Instance()
+        {
+            static BotInitQueue instance;
+            return instance;
+        }
+
+        std::string Enqueue(ObjectGuid botGuid, ObjectGuid masterGuid, std::string const& cmd, bool admin)
+        {
+            if (botGuid.IsEmpty() || masterGuid.IsEmpty())
+                return "ERROR: Invalid init request.";
+
+            // Do not enqueue duplicates.
+            if (_queuedBots.find(botGuid) != _queuedBots.end())
+                return "ok (already queued)";
+            // Enforce per-bot cooldown (request + completion).
+            uint32 remainMs = 0;
+
+            auto itReq = _lastInitRequestMs.find(botGuid);
+            if (itReq != _lastInitRequestMs.end())
+            {
+                uint32 elapsed = GetMSTimeDiffToNow(itReq->second);
+                if (elapsed < BOT_INIT_COOLDOWN_MS)
+                    remainMs = std::max(remainMs, BOT_INIT_COOLDOWN_MS - elapsed);
+            }
+
+            auto itDone = _lastInitDoneMs.find(botGuid);
+            if (itDone != _lastInitDoneMs.end())
+            {
+                uint32 elapsed = GetMSTimeDiffToNow(itDone->second);
+                if (elapsed < BOT_INIT_COOLDOWN_MS)
+                    remainMs = std::max(remainMs, BOT_INIT_COOLDOWN_MS - elapsed);
+            }
+
+            if (remainMs > 0)
+            {
+                uint32 remain = (remainMs + 999) / 1000;
+                return "ERROR: Init cooldown, wait " + std::to_string(remain) + "s.";
+            }
+            // Prevent queue flooding.
+            if (!admin)
+            {
+                if (_queue.size() >= BOT_INIT_QUEUE_MAX_SIZE)
+                    return "ERROR: Init queue is full, please try again later.";
+
+                uint32 masterCount = 0;
+                auto it = _queuedPerMaster.find(masterGuid);
+                if (it != _queuedPerMaster.end())
+                    masterCount = it->second;
+
+                if (masterCount >= BOT_INIT_QUEUE_MAX_PER_MASTER)
+                    return "ERROR: Too many init requests queued for you, please wait.";
+
+                _queuedPerMaster[masterGuid] = masterCount + 1;
+            }
+
+            _lastInitRequestMs[botGuid] = getMSTime();
+
+            _queuedBots.insert(botGuid);
+            _queue.push_back(BotInitRequest{botGuid, masterGuid, cmd, admin, 0});
+            return "ok (queued)";
+        }
+
+        void Update([[maybe_unused]] uint32 diff)
+        {
+            if (_queue.empty())
+                return;
+
+            if (_lastExecMs && GetMSTimeDiffToNow(_lastExecMs) < BOT_INIT_QUEUE_STEP_MS)
+                return;
+
+            BotInitRequest request = _queue.front();
+
+            // Validate bot and master are still present.
+            Player* bot = nullptr;
+
+            bot = ObjectAccessor::FindPlayer(request.botGuid);
+            if (!bot)
+                bot = sRandomPlayerbotMgr->GetPlayerBot(request.botGuid);
+
+            Player* master = ObjectAccessor::FindConnectedPlayer(request.masterGuid);
+
+            // Drop invalid requests (bot offline / master offline).
+            if (!bot || !master)
+            {
+                PopFrontAndCleanup(request);
+                _lastExecMs = getMSTime();
+                return;
+            }
+
+            // Must still be an addclass bot.
+            if (!sRandomPlayerbotMgr->IsAddclassBot(request.botGuid.GetCounter()))
+            {
+                PopFrontAndCleanup(request);
+                _lastExecMs = getMSTime();
+                return;
+            }
+
+            PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+            if (!botAI)
+            {
+                PopFrontAndCleanup(request);
+                _lastExecMs = getMSTime();
+                return;
+            }
+
+            // Ensure the bot is still controlled by the same master.
+            if (Player* currentMaster = botAI->GetMaster())
+            {
+                if (currentMaster->GetGUID() != request.masterGuid)
+                {
+                    PopFrontAndCleanup(request);
+                    _lastExecMs = getMSTime();
+                    return;
+                }
+            }
+            else
+            {
+                PopFrontAndCleanup(request);
+                _lastExecMs = getMSTime();
+                return;
+            }
+
+            // Respect restrictions (combat / auto-init only).
+            std::string effectiveCmd = request.cmd;
+            if (effectiveCmd == "init")
+                effectiveCmd = "init=auto";
+
+            if (!request.admin)
+            {
+                if (master->IsInCombat() || bot->IsInCombat())
+                {
+                    PostponeOrDrop(request);
+                    return;
+                }
+
+                if (master->GetSession() && master->GetSession()->GetSecurity() <= SEC_PLAYER &&
+                    sPlayerbotAIConfig->autoInitOnly && effectiveCmd != "init=auto")
+                {
+                    // Not allowed - drop.
+                    PopFrontAndCleanup(request);
+                    _lastExecMs = getMSTime();
+                    return;
+                }
+            }
+
+            // Prevent parallel init for the same bot.
+            BotInitGuard guard(bot->GetGUID());
+            if (guard.IsLocked())
+            {
+                PostponeOrDrop(request);
+                return;
+            }
+
+            // Execute init.
+            ExecuteInit(bot, master, effectiveCmd);
+
+            // Start cooldown at the end of a successful init.
+            _lastInitDoneMs[request.botGuid] = getMSTime();
+
+            PopFrontAndCleanup(request);
+            _lastExecMs = getMSTime();
+        }
+
+    private:
+        BotInitQueue() = default;
+
+        void ExecuteInit(Player* bot, Player* master, std::string const& cmd)
+        {
+            if (!bot || !master)
+                return;
+
+            int gs = 0;
+            if (cmd == "init=white" || cmd == "init=common")
+            {
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_NORMAL);
+                factory.Randomize(false);
+            }
+            else if (cmd == "init=green" || cmd == "init=uncommon")
+            {
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_UNCOMMON);
+                factory.Randomize(false);
+            }
+            else if (cmd == "init=blue" || cmd == "init=rare")
+            {
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_RARE);
+                factory.Randomize(false);
+            }
+            else if (cmd == "init=epic" || cmd == "init=purple")
+            {
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_EPIC);
+                factory.Randomize(false);
+            }
+            else if (cmd == "init=legendary" || cmd == "init=yellow")
+            {
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY);
+                factory.Randomize(false);
+            }
+            else if (cmd == "init=auto")
+            {
+                uint32 mixedGearScore = PlayerbotAI::GetMixedGearScore(master, true, false, 12) *
+                                        sPlayerbotAIConfig->autoInitEquipLevelLimitRatio;
+
+                // Work around: distinguish from 0 if no gear.
+                if (mixedGearScore == 0)
+                    mixedGearScore = 1;
+
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
+                factory.Randomize(false);
+            }
+            else if (cmd.rfind("init=", 0) == 0 && sscanf(cmd.c_str(), "init=%d", &gs) == 1)
+            {
+                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, gs);
+                factory.Randomize(false);
+            }
+        }
+
+        void PostponeOrDrop(BotInitRequest const& request)
+        {
+            // Pop front.
+            _queue.pop_front();
+
+            BotInitRequest postponed = request;
+            postponed.postponeCount++;
+
+            if (postponed.postponeCount >= BOT_INIT_QUEUE_MAX_POSTPONE)
+            {
+                // Drop permanently.
+                CleanupBookkeeping(postponed);
+                _lastExecMs = getMSTime();
+                return;
+            }
+
+            // Requeue at the end.
+            _queue.push_back(postponed);
+            _lastExecMs = getMSTime();
+        }
+
+        void PopFrontAndCleanup(BotInitRequest const& request)
+        {
+            _queue.pop_front();
+            CleanupBookkeeping(request);
+        }
+
+        void CleanupBookkeeping(BotInitRequest const& request)
+        {
+            _queuedBots.erase(request.botGuid);
+
+            if (!request.admin)
+            {
+                auto it = _queuedPerMaster.find(request.masterGuid);
+                if (it != _queuedPerMaster.end())
+                {
+                    if (it->second > 0)
+                        it->second--;
+
+                    if (it->second == 0)
+                        _queuedPerMaster.erase(it);
+                }
+            }
+        }
+
+    private:
+        std::deque<BotInitRequest> _queue;
+        std::unordered_set<ObjectGuid> _queuedBots;
+        std::unordered_map<ObjectGuid, uint32> _lastInitRequestMs;
+        std::unordered_map<ObjectGuid, uint32> _lastInitDoneMs;
+        std::unordered_map<ObjectGuid, uint32> _queuedPerMaster;
+        uint32 _lastExecMs = 0;
+    };
+} // namespace
+
 PlayerbotHolder::PlayerbotHolder() : PlayerbotAIBase(false) {}
+
+void PlayerbotHolder::UpdateInitQueue(uint32 diff)
+{
+    BotInitQueue::Instance().Update(diff);
+}
 class PlayerbotLoginQueryHolder : public LoginQueryHolder
 {
 private:
@@ -771,67 +1069,21 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
     {
         if (Player* master = GET_PLAYERBOT_AI(bot)->GetMaster())
         {
-            if (master->GetSession()->GetSecurity() <= SEC_PLAYER && sPlayerbotAIConfig->autoInitOnly &&
-                cmd != "init=auto")
+            std::string effectiveCmd = cmd;
+            if (effectiveCmd == "init")
+                effectiveCmd = "init=auto";
+
+            // Keep the legacy restriction: when auto-init-only is enabled, non-GM players may only use init=auto.
+            if (master->GetSession() && master->GetSession()->GetSecurity() <= SEC_PLAYER &&
+                sPlayerbotAIConfig->autoInitOnly && effectiveCmd != "init=auto")
             {
                 return "The command is not allowed, use init=auto instead.";
             }
 
-            //  Use boot guard
-            BotInitGuard guard(bot->GetGUID());
-            if (guard.IsLocked())
+            // Throttle init requests: queue + per-bot cooldown to avoid server stalls from init spam.
+            if (effectiveCmd.rfind("init=", 0) == 0)
             {
-                return "Initialization already in progress, please wait.";
-            }
-
-            int gs;
-            if (cmd == "init=white" || cmd == "init=common")
-            {
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_NORMAL);
-                factory.Randomize(false);
-                return "ok";
-            }
-            else if (cmd == "init=green" || cmd == "init=uncommon")
-            {
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_UNCOMMON);
-                factory.Randomize(false);
-                return "ok";
-            }
-            else if (cmd == "init=blue" || cmd == "init=rare")
-            {
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_RARE);
-                factory.Randomize(false);
-                return "ok";
-            }
-            else if (cmd == "init=epic" || cmd == "init=purple")
-            {
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_EPIC);
-                factory.Randomize(false);
-                return "ok";
-            }
-            else if (cmd == "init=legendary" || cmd == "init=yellow")
-            {
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY);
-                factory.Randomize(false);
-                return "ok";
-            }
-            else if (cmd == "init=auto")
-            {
-                uint32 mixedGearScore = PlayerbotAI::GetMixedGearScore(master, true, false, 12) *
-                                        sPlayerbotAIConfig->autoInitEquipLevelLimitRatio;
-                // work around: distinguish from 0 if no gear
-                if (mixedGearScore == 0)
-                    mixedGearScore = 1;
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, mixedGearScore);
-                factory.Randomize(false);
-                return "ok, gear score limit: " + std::to_string(mixedGearScore / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) +
-                       "(for epic)";
-            }
-            else if (cmd.starts_with("init=") && sscanf(cmd.c_str(), "init=%d", &gs) != -1)
-            {
-                PlayerbotFactory factory(bot, master->GetLevel(), ITEM_QUALITY_LEGENDARY, gs);
-                factory.Randomize(false);
-                return "ok, gear score limit: " + std::to_string(gs / PlayerbotAI::GetItemScoreMultiplier(ItemQualities(ITEM_QUALITY_EPIC))) + "(for epic)";
+                return BotInitQueue::Instance().Enqueue(bot->GetGUID(), master->GetGUID(), effectiveCmd, admin);
             }
         }
 
@@ -1024,7 +1276,7 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             }
         }
         int32 gs;
-        if (sscanf(cmd, "initself=%d", &gs) != -1)
+        if (sscanf(cmd, "initself=%d", &gs) == 1)
         {
             if (master->GetSession()->GetSecurity() >= SEC_GAMEMASTER)
             {

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -15,6 +15,7 @@
 #include <openssl/sha.h>
 #include <iomanip>
 #include <algorithm>
+#include <vector>
 
 #include "ChannelMgr.h"
 #include "CharacterCache.h"
@@ -41,6 +42,42 @@
 #include "BroadcastHelper.h"
 #include "WorldSessionMgr.h"
 #include "DatabaseEnv.h"
+
+
+namespace
+{
+template <class F>
+void ForEachControlledRandomBot(Player* master, F&& fn)
+{
+    if (!master)
+        return;
+
+    static thread_local std::vector<ObjectGuid> tlsControlledGuids;
+
+    std::vector<ObjectGuid> controlledGuids;
+    controlledGuids.swap(tlsControlledGuids);
+    controlledGuids.clear();
+
+    sRandomPlayerbotMgr->GetMasterControlledRandomBotGuidsSnapshot(master->GetGUID(), controlledGuids);
+
+    for (ObjectGuid const& guid : controlledGuids)
+    {
+        Player* bot = sRandomPlayerbotMgr->GetPlayerBot(guid);
+        if (!bot)
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI || botAI->IsRealPlayer())
+            continue;
+
+        if (botAI->GetMaster() != master)
+            continue;
+        fn(bot, botAI);
+    }
+
+    tlsControlledGuids.swap(controlledGuids);
+}
+} // namespace
 
 class BotInitGuard
 {
@@ -610,23 +647,18 @@ void PlayerbotMgr::CancelLogout()
         }
     }
 
-    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
-         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    ForEachControlledRandomBot(master, [&](Player* bot, PlayerbotAI* /*botAI*/)
     {
-        Player* const bot = it->second;
-        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-        if (!botAI || botAI->IsRealPlayer())
-            continue;
+        WorldSession* botSession = bot->GetSession();
+        if (!botSession)
+            return;
 
-        if (botAI->GetMaster() != master)
-            continue;
-
-        if (bot->GetSession()->isLogingOut())
+        if (botSession->isLogingOut())
         {
             WorldPackets::Character::LogoutCancel data = WorldPacket(CMSG_LOGOUT_CANCEL);
-            bot->GetSession()->HandleLogoutCancelOpcode(data);
+            botSession->HandleLogoutCancelOpcode(data);
         }
-    }
+    });
 }
 
 void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
@@ -636,6 +668,9 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (!botAI)
             return;
+
+        // Keep master->controlled random-bots index clean (safe no-op if not tracked).
+        sRandomPlayerbotMgr->OnRandomBotLoggedOut(guid);
 
         // Queue group cleanup operation for world thread
         auto cleanupOp = std::make_unique<BotLogoutGroupCleanupOperation>(guid);
@@ -733,6 +768,8 @@ void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)
         {
             return;
         }
+        // Keep master->controlled random-bots index clean (safe no-op if not tracked).
+        sRandomPlayerbotMgr->OnRandomBotLoggedOut(guid);
         botAI->TellMaster("Goodbye!");
         bot->StopMoving();
         bot->GetMotionMaster()->Clear();
@@ -1781,14 +1818,10 @@ void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)
             botAI->HandleCommand(type, text, master);
     }
 
-    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
-         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    ForEachControlledRandomBot(master, [&](Player* /*bot*/, PlayerbotAI* botAI)
     {
-        Player* const bot = it->second;
-        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-        if (botAI && botAI->GetMaster() == master)
-            botAI->HandleCommand(type, text, master);
-    }
+        botAI->HandleCommand(type, text, master);
+    });
 }
 
 void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
@@ -1803,14 +1836,10 @@ void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
             botAI->HandleMasterIncomingPacket(packet);
     }
 
-    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
-         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    ForEachControlledRandomBot(GetMaster(), [&](Player* /*bot*/, PlayerbotAI* botAI)
     {
-        Player* const bot = it->second;
-        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-        if (botAI && botAI->GetMaster() == GetMaster())
-            botAI->HandleMasterIncomingPacket(packet);
-    }
+        botAI->HandleMasterIncomingPacket(packet);
+    });
 
     switch (packet.GetOpcode())
     {
@@ -1831,6 +1860,14 @@ void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
 
 void PlayerbotMgr::HandleMasterOutgoingPacket(WorldPacket const& packet)
 {
+    // If this master controls no bots at all, skip forwarding entirely (major perf win during raids without bots).
+    Player* masterPlayer = GetMaster();
+    if (!masterPlayer)
+        return;
+
+    if (GetPlayerbotsCount() == 0 && !sRandomPlayerbotMgr->HasMasterControlledRandomBots(masterPlayer->GetGUID()))
+        return;
+
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
         Player* const bot = it->second;
@@ -1839,14 +1876,10 @@ void PlayerbotMgr::HandleMasterOutgoingPacket(WorldPacket const& packet)
             botAI->HandleMasterOutgoingPacket(packet);
     }
 
-    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
-         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    ForEachControlledRandomBot(masterPlayer, [&](Player* /*bot*/, PlayerbotAI* botAI)
     {
-        Player* const bot = it->second;
-        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-        if (botAI && botAI->GetMaster() == GetMaster())
-            botAI->HandleMasterOutgoingPacket(packet);
-    }
+        botAI->HandleMasterOutgoingPacket(packet);
+    });
 }
 
 void PlayerbotMgr::SaveToDB()
@@ -1857,13 +1890,10 @@ void PlayerbotMgr::SaveToDB()
         bot->SaveToDB(false, false);
     }
 
-    for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr->GetPlayerBotsBegin();
-         it != sRandomPlayerbotMgr->GetPlayerBotsEnd(); ++it)
+    ForEachControlledRandomBot(GetMaster(), [&](Player* bot, PlayerbotAI* /*botAI*/)
     {
-        Player* const bot = it->second;
-        if (GET_PLAYERBOT_AI(bot) && GET_PLAYERBOT_AI(bot)->GetMaster() == GetMaster())
-            bot->SaveToDB(false, false);
-    }
+        bot->SaveToDB(false, false);
+    });
 }
 
 void PlayerbotMgr::OnBotLoginInternal(Player* const bot)

--- a/src/Bot/PlayerbotMgr.h
+++ b/src/Bot/PlayerbotMgr.h
@@ -56,6 +56,10 @@ public:
     uint32 GetPlayerbotsCount() { return playerBots.size(); }
     uint32 GetPlayerbotsCountByClass(uint32 cls);
 
+    // Throttled init requests to prevent server stalls from init command spam.
+    // Call this from a world update hook (e.g. PlayerbotsScript::OnPlayerbotUpdate).
+    static void UpdateInitQueue(uint32 diff);
+
 protected:
     virtual void OnBotLoginInternal(Player* const bot) = 0;
 

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -215,6 +215,34 @@ double botPIDImpl::calculate(double setpoint, double pv)
 
 botPIDImpl::~botPIDImpl() {}
 
+
+static inline void ResetBattlegroundInfo(BattlegroundInfo& info)
+{
+    // Preserve vector capacity to avoid periodic allocation spikes.
+    info.bgInstances.clear();
+    info.ratedArenaInstances.clear();
+    info.skirmishArenaInstances.clear();
+
+    info.bgInstanceCount = 0;
+    info.ratedArenaInstanceCount = 0;
+    info.skirmishArenaInstanceCount = 0;
+    info.minLevel = 0;
+    info.maxLevel = 0;
+    info.activeRatedArenaQueue = 0;
+    info.activeSkirmishArenaQueue = 0;
+    info.activeBgQueue = 0;
+
+    info.ratedArenaBotCount = 0;
+    info.skirmishArenaBotCount = 0;
+    info.bgHordeBotCount = 0;
+    info.bgAllianceBotCount = 0;
+
+    info.ratedArenaPlayerCount = 0;
+    info.skirmishArenaPlayerCount = 0;
+    info.bgHordePlayerCount = 0;
+    info.bgAlliancePlayerCount = 0;
+}
+
 RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
 {
     playersLevel = sPlayerbotAIConfig->randombotStartingLevel;
@@ -226,6 +254,11 @@ RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
 
     BattlegroundData.clear();  // Clear here and here only.
 
+    // Reserve to avoid rehash spikes when a large number of bots is used.
+    if (sPlayerbotAIConfig->maxRandomBots > 0)
+        eventCache.reserve(sPlayerbotAIConfig->maxRandomBots + 32);
+
+
     // Cleanup on server start: orphaned pet data that's often left behind by bot pets that no longer exist in the DB
     CharacterDatabase.Execute("DELETE FROM pet_aura WHERE guid NOT IN (SELECT id FROM character_pet)");
     CharacterDatabase.Execute("DELETE FROM pet_spell WHERE guid NOT IN (SELECT id FROM character_pet)");
@@ -235,12 +268,13 @@ RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
     {
         for (int queueType = BATTLEGROUND_QUEUE_AV; queueType < MAX_BATTLEGROUND_QUEUE_TYPES; ++queueType)
         {
-            BattlegroundData[queueType][bracket] = BattlegroundInfo();
-        }
+            ResetBattlegroundInfo(BattlegroundData[queueType][bracket]);
+}
     }
     BgCheckTimer = 0;
     LfgCheckTimer = 0;
     PlayersCheckTimer = 0;
+    _pendingEventLastFlushMs = getMSTime();
 }
 
 RandomPlayerbotMgr::~RandomPlayerbotMgr() {}
@@ -360,6 +394,60 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
         totalPmo->finish();
 
     totalPmo = sPerfMonitor->start(PERF_MON_TOTAL, "RandomPlayerbotMgr::FullTick");
+
+    // Flush batched event DB writes (keeps I/O spikes low under large bot counts).
+    FlushPendingEventDbWrites(false);
+
+    // Optional smoothing: split heavy random-bot ticks into smaller slices to avoid periodic stalls.
+    if (sPlayerbotAIConfig->randomBotSlicing)
+    {
+        uint32 sliceMs = sPlayerbotAIConfig->randomBotSliceMs;
+        if (sliceMs < 50)
+            sliceMs = 50;
+
+        // Always schedule the next slice quickly.
+        SetNextCheckDelay(sliceMs);
+
+        if (!_slicedCycleActive)
+            BeginSlicedCycle();
+
+        if (_slicedLogicalIntervalMs == 0)
+        {
+            // Fallback: behave like the original path if something went wrong.
+            EndSlicedCycle();
+        }
+        else
+        {
+            // Clamp to avoid catch-up spikes after a long stall and avoid overshooting the end of the logical tick.
+            uint32 dtMs = std::min(elapsed, sliceMs);
+            uint32 remaining = (_slicedLogicalIntervalMs > _slicedElapsedMs) ? (_slicedLogicalIntervalMs - _slicedElapsedMs) : 0;
+            if (remaining)
+                dtMs = std::min(dtMs, remaining);
+            else
+                dtMs = 0;
+
+            _slicedDtMs = dtMs;
+
+            if (dtMs)
+            {
+                _slicedElapsedMs += dtMs;
+                ProcessSlicedSlice();
+            }
+
+            if (_slicedElapsedMs >= _slicedLogicalIntervalMs)
+                EndSlicedCycle();
+        }
+
+        if (sPlayerbotAIConfig->hasLog("player_location.csv"))
+        {
+            // Keep the original behaviour: log at most once per full tick.
+            // In slicing mode we only log when a full cycle ends.
+            if (!_slicedCycleActive)
+                LogPlayerLocation();
+        }
+
+        return;
+    }
 
     if (!sPlayerbotAIConfig->randomBotAutologin || !sPlayerbotAIConfig->enabled)
         return;
@@ -535,6 +623,303 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
     {
         LogPlayerLocation();
     }
+}
+
+
+void RandomPlayerbotMgr::BeginSlicedCycle()
+{
+    // Initialize per-cycle state.
+    _slicedCycleActive = true;
+    _slicedPhase = SlicedPhase::Updating;
+    _slicedElapsedMs = 0;
+    _slicedLogicalIntervalMs = 0;
+
+    _slicedUpdateTarget = 0;
+    _slicedLoginTarget = 0;
+    _slicedLoginTargetInitial = 0;
+    _slicedUpdateTargetInitial = 0;
+    _slicedLoginTargetTotal = 0;
+
+    _slicedUpdateDone = 0;
+    _slicedLoginDone = 0;
+    _slicedMaxNewBots = 0;
+
+    _slicedRealPlayerIsLogged = false;
+    _slicedCanAttemptLogin = false;
+    _slicedDidAttemptLoginPhase = false;
+
+    _slicedUpdateBudgetAcc = 0;
+    _slicedLoginBudgetAcc = 0;
+
+    _slicedUpdateIndex = 0;
+    _slicedLoginIndex = 0;
+    _slicedBotSnapshot.clear();
+
+    // --- Begin: original full-tick setup (without doing the heavy loops) ---
+    uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
+    if (!maxAllowedBotCount ||
+        (maxAllowedBotCount < sPlayerbotAIConfig->minRandomBots || maxAllowedBotCount > sPlayerbotAIConfig->maxRandomBots))
+    {
+        maxAllowedBotCount = urand(sPlayerbotAIConfig->minRandomBots, sPlayerbotAIConfig->maxRandomBots);
+        SetEventValue(0, "bot_count", maxAllowedBotCount,
+            urand(sPlayerbotAIConfig->randomBotCountChangeMinInterval, sPlayerbotAIConfig->randomBotCountChangeMaxInterval));
+    }
+
+    GetBots();
+
+    // Snapshot current bots in a stable order for the whole logical cycle.
+    _slicedBotSnapshot.reserve(currentBots.size());
+    for (uint32 bot : currentBots)
+        _slicedBotSnapshot.push_back(bot);
+
+    uint32 availableBotCount = static_cast<uint32>(_slicedBotSnapshot.size());
+    uint32 onlineBotCount = static_cast<uint32>(playerBots.size());
+
+    uint32 onlineBotFocus = 75;
+    if (onlineBotCount < (uint32)(sPlayerbotAIConfig->minRandomBots * 90 / 100))
+        onlineBotFocus = 25;
+
+    // Only keep updating till initializing time has completed,
+    // which prevents unneeded expensive GameTime calls.
+    if (_isBotInitializing)
+    {
+        _isBotInitializing = GameTime::GetUptime().count() < sPlayerbotAIConfig->maxRandomBots * (0.11 + 0.4);
+    }
+
+    uint32 updateIntervalTurboBoost = _isBotInitializing ? 1 : sPlayerbotAIConfig->randomBotUpdateInterval;
+    _slicedLogicalIntervalMs = updateIntervalTurboBoost * (onlineBotFocus + 25) * 10;
+    if (_slicedLogicalIntervalMs == 0)
+        _slicedLogicalIntervalMs = 1;
+
+    time_t now = time(nullptr);
+
+    bool realPlayerIsLogged = false;
+    if (sPlayerbotAIConfig->disabledWithoutRealPlayer)
+    {
+        if (sWorldSessionMgr->GetActiveAndQueuedSessionCount() > 0)
+        {
+            RealPlayerLastTimeSeen = now;
+            realPlayerIsLogged = true;
+
+            if (DelayLoginBotsTimer == 0)
+                DelayLoginBotsTimer = now + sPlayerbotAIConfig->disabledWithoutRealPlayerLoginDelay;
+        }
+        else
+        {
+            if (DelayLoginBotsTimer)
+                DelayLoginBotsTimer = 0;
+
+            if (RealPlayerLastTimeSeen != 0 && onlineBotCount > 0 &&
+                now > RealPlayerLastTimeSeen + sPlayerbotAIConfig->disabledWithoutRealPlayerLogoutDelay)
+            {
+                LogoutAllBots();
+                LOG_INFO("playerbots", "Logout all bots due no real player session.");
+            }
+        }
+
+        if (availableBotCount < maxAllowedBotCount &&
+            (sPlayerbotAIConfig->disabledWithoutRealPlayer == false ||
+             (realPlayerIsLogged && DelayLoginBotsTimer != 0 && now >= DelayLoginBotsTimer)))
+        {
+            AddRandomBots();
+        }
+    }
+    else if (availableBotCount < maxAllowedBotCount)
+    {
+        AddRandomBots();
+    }
+
+    // Mirror periodic checks from the original code path (run at most once per logical tick).
+    if (sPlayerbotAIConfig->syncLevelWithPlayers && !players.empty())
+    {
+        if (now > (PlayersCheckTimer + 60))
+            sRandomPlayerbotMgr->CheckPlayers();
+    }
+
+    if (sPlayerbotAIConfig->randomBotJoinBG)
+    {
+        if (now > (BgCheckTimer + 35))
+            sRandomPlayerbotMgr->CheckBgQueue();
+    }
+
+    if (sPlayerbotAIConfig->randomBotJoinLfg)
+    {
+        if (now > (LfgCheckTimer + 30))
+            sRandomPlayerbotMgr->CheckLfgQueue();
+    }
+
+    if (sPlayerbotAIConfig->randomBotAutologin && now > (printStatsTimer + 300))
+    {
+        if (!printStatsTimer)
+            printStatsTimer = now;
+        else
+            sRandomPlayerbotMgr->PrintStats();
+    }
+
+    uint32 updateBots = sPlayerbotAIConfig->randomBotsPerInterval * onlineBotFocus / 100;
+
+    uint32 maxNewBots =
+        onlineBotCount < maxAllowedBotCount &&
+                (sPlayerbotAIConfig->disabledWithoutRealPlayer == false ||
+                 (realPlayerIsLogged && DelayLoginBotsTimer != 0 && now >= DelayLoginBotsTimer))
+            ? maxAllowedBotCount - onlineBotCount
+            : 0;
+
+    uint32 loginBots = std::min(sPlayerbotAIConfig->randomBotsPerInterval - updateBots, maxNewBots);
+
+    _slicedUpdateTarget = updateBots;
+    _slicedUpdateTargetInitial = updateBots;
+
+    _slicedLoginTargetInitial = loginBots;
+    _slicedLoginTarget = loginBots;
+    _slicedLoginTargetTotal = loginBots;
+
+    _slicedMaxNewBots = maxNewBots;
+    _slicedRealPlayerIsLogged = realPlayerIsLogged;
+    // --- End: original full-tick setup ---
+}
+
+void RandomPlayerbotMgr::ProcessSlicedSlice()
+{
+    if (!_slicedCycleActive || _slicedLogicalIntervalMs == 0)
+        return;
+
+    uint32 dtMs = _slicedDtMs ? _slicedDtMs : sPlayerbotAIConfig->randomBotSliceMs;
+
+    switch (_slicedPhase)
+    {
+        case SlicedPhase::Updating:
+        {
+            if (_slicedUpdateTargetInitial && _slicedUpdateTarget)
+            {
+                // Distribute the same total work across the full logical interval.
+                _slicedUpdateBudgetAcc += uint64(_slicedUpdateTargetInitial) * dtMs;
+                uint32 allowed = uint32(_slicedUpdateBudgetAcc / _slicedLogicalIntervalMs);
+                _slicedUpdateBudgetAcc %= _slicedLogicalIntervalMs;
+
+                while (allowed && _slicedUpdateTarget && _slicedUpdateIndex < _slicedBotSnapshot.size())
+                {
+                    uint32 bot = _slicedBotSnapshot[_slicedUpdateIndex++];
+                    if (!GetPlayerBot(bot))
+                        continue;
+
+                    if (ProcessBot(bot))
+                    {
+                        --_slicedUpdateTarget;
+                        ++_slicedUpdateDone;
+                        --allowed;
+                    }
+                }
+            }
+
+            // Transition to login preparation when budget is met or we ran out of candidates.
+            if (_slicedUpdateTarget == 0 || _slicedUpdateIndex >= _slicedBotSnapshot.size())
+                _slicedPhase = SlicedPhase::LoginPrep;
+
+            break;
+        }
+
+        case SlicedPhase::LoginPrep:
+        {
+            // Match original gating: only run the login pass if loginBots was non-zero and there is no ongoing bot loading.
+            _slicedCanAttemptLogin = (_slicedLoginTargetInitial != 0 && botLoading.empty());
+
+            if (_slicedCanAttemptLogin)
+            {
+                _slicedDidAttemptLoginPhase = true;
+
+                // Carry unused update budget into login budget, as in the original code.
+                uint32 carried = _slicedUpdateTarget;
+                uint32 newLoginTarget = _slicedLoginTarget + carried;
+                newLoginTarget = std::min(newLoginTarget, _slicedMaxNewBots);
+
+                _slicedLoginTarget = newLoginTarget;
+                _slicedLoginTargetTotal = newLoginTarget;
+
+                if (_slicedLoginTarget)
+                    LOG_DEBUG("playerbots", "{} new bots prepared to login", _slicedLoginTarget);
+
+                _slicedLoginIndex = 0;
+                _slicedPhase = SlicedPhase::LoggingIn;
+            }
+            else
+            {
+                // No login this cycle.
+                _slicedLoginTarget = 0;
+                _slicedLoginTargetTotal = 0;
+                _slicedPhase = SlicedPhase::None;
+            }
+
+            break;
+        }
+
+        case SlicedPhase::LoggingIn:
+        {
+            if (_slicedLoginTargetTotal && _slicedLoginTarget)
+            {
+                _slicedLoginBudgetAcc += uint64(_slicedLoginTargetTotal) * dtMs;
+                uint32 allowed = uint32(_slicedLoginBudgetAcc / _slicedLogicalIntervalMs);
+                _slicedLoginBudgetAcc %= _slicedLogicalIntervalMs;
+
+                while (allowed && _slicedLoginTarget && _slicedLoginIndex < _slicedBotSnapshot.size())
+                {
+                    uint32 bot = _slicedBotSnapshot[_slicedLoginIndex++];
+                    if (GetPlayerBot(bot))
+                        continue;
+
+                    if (ProcessBot(bot))
+                    {
+                        --_slicedLoginTarget;
+                        ++_slicedLoginDone;
+                        --allowed;
+                    }
+                }
+            }
+
+            if (_slicedLoginTarget == 0 || _slicedLoginIndex >= _slicedBotSnapshot.size())
+                _slicedPhase = SlicedPhase::None;
+
+            break;
+        }
+
+        case SlicedPhase::None:
+        default:
+            break;
+    }
+}
+
+void RandomPlayerbotMgr::EndSlicedCycle()
+{
+    // Match original behaviour: when the login pass is attempted, reset the delayed-login timer.
+    if (_slicedDidAttemptLoginPhase)
+        DelayLoginBotsTimer = 0;
+
+    _slicedCycleActive = false;
+    _slicedPhase = SlicedPhase::None;
+
+    _slicedLogicalIntervalMs = 0;
+    _slicedElapsedMs = 0;
+
+    _slicedUpdateTarget = 0;
+    _slicedLoginTarget = 0;
+    _slicedLoginTargetInitial = 0;
+    _slicedUpdateTargetInitial = 0;
+    _slicedLoginTargetTotal = 0;
+
+    _slicedUpdateDone = 0;
+    _slicedLoginDone = 0;
+    _slicedMaxNewBots = 0;
+
+    _slicedRealPlayerIsLogged = false;
+    _slicedCanAttemptLogin = false;
+    _slicedDidAttemptLoginPhase = false;
+
+    _slicedUpdateBudgetAcc = 0;
+    _slicedLoginBudgetAcc = 0;
+
+    _slicedUpdateIndex = 0;
+    _slicedLoginIndex = 0;
+    _slicedBotSnapshot.clear();
 }
 
 // void RandomPlayerbotMgr::ScaleBotActivity()
@@ -988,8 +1373,8 @@ void RandomPlayerbotMgr::CheckBgQueue()
     {
         for (int queueType = BATTLEGROUND_QUEUE_AV; queueType < MAX_BATTLEGROUND_QUEUE_TYPES; ++queueType)
         {
-            BattlegroundData[queueType][bracket] = BattlegroundInfo();
-        }
+            ResetBattlegroundInfo(BattlegroundData[queueType][bracket]);
+}
     }
 
     // Process real players and populate Battleground Data with player/queue count
@@ -2168,7 +2553,13 @@ void RandomPlayerbotMgr::Init()
     if (sPlayerbotAIConfig->randomBotJoinBG)
         sRandomPlayerbotMgr->LoadBattleMastersCache();
 
+    // Build fast lookup index for creature entry -> CreatureData
+    sRandomPlayerbotMgr->BuildCreatureDataEntryIndex();
+
     PlayerbotsDatabase.Execute("DELETE FROM playerbots_random_bots WHERE event = 'add'");
+    _pendingEventWrites.clear();
+    _pendingEventWritesCount = 0;
+    _pendingEventLastFlushMs = getMSTime();
 }
 
 void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
@@ -2782,52 +3173,106 @@ std::string RandomPlayerbotMgr::GetEventData(uint32 bot, std::string const& even
 uint32 RandomPlayerbotMgr::SetEventValue(uint32 bot, std::string const& event, uint32 value, uint32 validIn,
                                          std::string const& data)
 {
-    PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
-
-    PlayerbotsDatabasePreparedStatement* stmt =
-        PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_RANDOM_BOTS_BY_OWNER_AND_EVENT);
-    stmt->SetData(0, 0);
-    stmt->SetData(1, bot);
-    stmt->SetData(2, event.c_str());
-    trans->Append(stmt);
-
-    if (value)
-    {
-        stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_RANDOM_BOTS);
-        stmt->SetData(0, 0);
-        stmt->SetData(1, bot);
-        stmt->SetData(2, NowSeconds());
-        stmt->SetData(3, validIn);
-        stmt->SetData(4, event.c_str());
-        stmt->SetData(5, value);
-
-        if (!data.empty())
-            stmt->SetData(6, data.c_str());
-        else
-            stmt->SetData(6);  // NULL
-
-        trans->Append(stmt);
-    }
-
-    PlayerbotsDatabase.CommitTransaction(trans);
-
-    // Update in-memory cache
+    // Update in-memory cache first (fast path).
     BotEventCache& cache = eventCache[bot];
     cache.loaded = true;
 
     if (!value)
     {
         cache.events.erase(event);
-        return 0;
+    }
+    else
+    {
+        CachedEvent& e = cache.events[event];  // create-on-write is OK here
+        e.value = value;
+        e.lastChangeTime = NowSeconds();
+        e.validIn = validIn;
+        e.data = data;
     }
 
-    CachedEvent& e = cache.events[event];  // create-on-write is OK here
-    e.value = value;
-    e.lastChangeTime = NowSeconds();
-    e.validIn = validIn;
-    e.data = data;
+    // Queue persistence to DB (batched) to avoid commit-per-event I/O spikes under large bot counts.
+    auto& perBot = _pendingEventWrites[bot];
+    auto it = perBot.find(event);
+    if (it == perBot.end())
+    {
+        it = perBot.emplace(event, PendingBotEventWrite{}).first;
+        ++_pendingEventWritesCount;
+    }
+
+    PendingBotEventWrite& rec = it->second;
+    rec.value = value;
+    rec.validIn = validIn;
+    rec.changeTime = NowSeconds();
+    rec.data = data;
+
+    // Prevent unbounded queue growth in edge cases (e.g. mass initialization).
+    if (_pendingEventWritesCount >= 500)
+        FlushPendingEventDbWrites(true);
 
     return value;
+}
+
+void RandomPlayerbotMgr::FlushPendingEventDbWrites(bool force)
+{
+    if (_pendingEventWritesCount == 0)
+        return;
+
+    uint32 nowMs = getMSTime();
+    constexpr uint32 kFlushIntervalMs = 1000;
+    constexpr size_t kFlushThreshold = 400;
+
+    if (!force && (nowMs - _pendingEventLastFlushMs) < kFlushIntervalMs && _pendingEventWritesCount < kFlushThreshold)
+        return;
+
+    _pendingEventLastFlushMs = nowMs;
+
+    PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
+    size_t statements = 0;
+
+    for (auto& botPair : _pendingEventWrites)
+    {
+        uint32 bot = botPair.first;
+        auto& events = botPair.second;
+
+        for (auto& evPair : events)
+        {
+            std::string const& evName = evPair.first;
+            PendingBotEventWrite const& rec = evPair.second;
+
+            // Always delete existing record for (owner,event), then optionally insert the new one.
+            PlayerbotsDatabasePreparedStatement* stmt =
+                PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_RANDOM_BOTS_BY_OWNER_AND_EVENT);
+            stmt->SetData(0, 0);
+            stmt->SetData(1, bot);
+            stmt->SetData(2, evName.c_str());
+            trans->Append(stmt);
+            ++statements;
+
+            if (rec.value)
+            {
+                stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_RANDOM_BOTS);
+                stmt->SetData(0, 0);
+                stmt->SetData(1, bot);
+                stmt->SetData(2, rec.changeTime ? rec.changeTime : NowSeconds());
+                stmt->SetData(3, rec.validIn);
+                stmt->SetData(4, evName.c_str());
+                stmt->SetData(5, rec.value);
+                if (!rec.data.empty())
+                    stmt->SetData(6, rec.data.c_str());
+                else
+                    stmt->SetData(6);  // NULL
+
+                trans->Append(stmt);
+                ++statements;
+            }
+        }
+    }
+
+    if (statements)
+        PlayerbotsDatabase.CommitTransaction(trans);
+
+    _pendingEventWrites.clear();
+    _pendingEventWritesCount = 0;
 }
 
 uint32 RandomPlayerbotMgr::GetValue(uint32 bot, std::string const& type) { return GetEventValue(bot, type); }
@@ -2869,6 +3314,9 @@ bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* handler, cha
     {
         PlayerbotsDatabase.Execute(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_DEL_RANDOM_BOTS));
         sRandomPlayerbotMgr->eventCache.clear();
+        sRandomPlayerbotMgr->_pendingEventWrites.clear();
+        sRandomPlayerbotMgr->_pendingEventWritesCount = 0;
+        sRandomPlayerbotMgr->_pendingEventLastFlushMs = getMSTime();
         LOG_INFO("playerbots", "Random bots were reset for all players. Please restart the Server.");
         return true;
     }
@@ -3524,17 +3972,66 @@ void RandomPlayerbotMgr::Remove(Player* bot)
     uint32 botId = owner.GetCounter();
     eventCache.erase(botId);
 
+    // Drop any queued (batched) DB event writes for this bot to avoid re-inserting rows after removal.
+    auto pit = _pendingEventWrites.find(botId);
+    if (pit != _pendingEventWrites.end())
+    {
+        if (_pendingEventWritesCount >= pit->second.size())
+            _pendingEventWritesCount -= pit->second.size();
+        else
+            _pendingEventWritesCount = 0;
+
+        _pendingEventWrites.erase(pit);
+    }
+
+
     LogoutPlayerBot(owner);
+}
+
+void RandomPlayerbotMgr::BuildCreatureDataEntryIndex()
+{
+    _creatureDataByEntry.clear();
+
+    for (auto const& itr : sObjectMgr->GetAllCreatureData())
+    {
+        uint32 entry = itr.second.id1;
+        if (!entry)
+            continue;
+
+        // Keep the first instance; callers only need a representative spawn guid.
+        if (_creatureDataByEntry.find(entry) == _creatureDataByEntry.end())
+            _creatureDataByEntry.emplace(entry, ObjectGuid::LowType(itr.first));
+    }
+
+    _creatureEntryIndexBuilt = true;
 }
 
 CreatureData const* RandomPlayerbotMgr::GetCreatureDataByEntry(uint32 entry)
 {
-    if (entry != 0)
-    {
-        for (auto const& itr : sObjectMgr->GetAllCreatureData())
-            if (itr.second.id1 == entry)
-                return &itr.second;
-    }
+    if (!entry)
+        return nullptr;
+
+    if (!_creatureEntryIndexBuilt || _creatureDataByEntry.empty())
+        BuildCreatureDataEntryIndex();
+
+    auto it = _creatureDataByEntry.find(entry);
+    if (it == _creatureDataByEntry.end())
+        return nullptr;
+
+    auto const& store = sObjectMgr->GetAllCreatureData();
+    auto it2 = store.find(it->second);
+    if (it2 != store.end())
+        return &it2->second;
+
+    // If creature data was reloaded and the stored guid is no longer present, rebuild the index once.
+    BuildCreatureDataEntryIndex();
+    it = _creatureDataByEntry.find(entry);
+    if (it == _creatureDataByEntry.end())
+        return nullptr;
+
+    it2 = store.find(it->second);
+    if (it2 != store.end())
+        return &it2->second;
 
     return nullptr;
 }

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -48,7 +48,7 @@
 #include "RandomPlayerbotFactory.h"
 #include "ServerFacade.h"
 #include "SharedDefines.h"
-#include "strategy/actions/BattleGroundJoinAction.h"
+#include "Ai/Base/Actions/BattleGroundJoinAction.h"
 #include "TravelMgr.h"
 #include "Unit.h"
 #include "UpdateTime.h"

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -48,6 +48,7 @@
 #include "RandomPlayerbotFactory.h"
 #include "ServerFacade.h"
 #include "SharedDefines.h"
+#include "strategy/actions/BattleGroundJoinAction.h"
 #include "TravelMgr.h"
 #include "Unit.h"
 #include "UpdateTime.h"
@@ -397,6 +398,10 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
 
     // Flush batched event DB writes (keeps I/O spikes low under large bot counts).
     FlushPendingEventDbWrites(false);
+
+    // Keep empty battleground instances from being kept alive by "wild" random-bots.
+    // Must run even if randomBotAutologin is disabled, because bots can still be online.
+    UpdateWildBotBattlegroundMaintenance();
 
     // Optional smoothing: split heavy random-bot ticks into smaller slices to avoid periodic stalls.
     if (sPlayerbotAIConfig->randomBotSlicing)
@@ -1527,46 +1532,32 @@ void RandomPlayerbotMgr::CheckBgQueue()
 
             if (bot->InBattleground())
             {
+                // IMPORTANT: do NOT count battleground instances that contain only bots as "active instances".
+                // Otherwise bots can keep queueing into their own empty BGs forever.
+                if (!bot->InArena())
+                    continue;
+
                 std::vector<uint32>* instanceIds = nullptr;
                 uint32 instanceId = bot->GetBattleground()->GetInstanceID();
-                bool isArena = false;
                 bool isRated = false;
 
-                // Arena logic
-                if (bot->InArena())
+                if (bot->GetBattleground()->isRated())
                 {
-                    isArena = true;
-                    if (bot->GetBattleground()->isRated())
-                    {
-                        isRated = true;
-                        instanceIds = &BattlegroundData[queueTypeId][bracketId].ratedArenaInstances;
-                    }
-                    else
-                    {
-                        instanceIds = &BattlegroundData[queueTypeId][bracketId].skirmishArenaInstances;
-                    }
+                    isRated = true;
+                    instanceIds = &BattlegroundData[queueTypeId][bracketId].ratedArenaInstances;
                 }
-                // BG Logic
                 else
                 {
-                    instanceIds = &BattlegroundData[queueTypeId][bracketId].bgInstances;
+                    instanceIds = &BattlegroundData[queueTypeId][bracketId].skirmishArenaInstances;
                 }
 
-                if (instanceIds &&
-                    std::find(instanceIds->begin(), instanceIds->end(), instanceId) == instanceIds->end())
+                if (instanceIds && std::find(instanceIds->begin(), instanceIds->end(), instanceId) == instanceIds->end())
                     instanceIds->push_back(instanceId);
 
-                if (isArena)
-                {
-                    if (isRated)
-                        BattlegroundData[queueTypeId][bracketId].ratedArenaInstanceCount = instanceIds->size();
-                    else
-                        BattlegroundData[queueTypeId][bracketId].skirmishArenaInstanceCount = instanceIds->size();
-                }
+                if (isRated)
+                    BattlegroundData[queueTypeId][bracketId].ratedArenaInstanceCount = instanceIds->size();
                 else
-                {
-                    BattlegroundData[queueTypeId][bracketId].bgInstanceCount = instanceIds->size();
-                }
+                    BattlegroundData[queueTypeId][bracketId].skirmishArenaInstanceCount = instanceIds->size();
             }
         }
     }
@@ -1605,6 +1596,11 @@ void RandomPlayerbotMgr::CheckBgQueue()
         {
             for (uint32 bracket : brackets)
             {
+                // Do not auto-create bot-only battlegrounds. Only keep instances when real players are actually queueing.
+                if ((BattlegroundData[queueType][bracket].bgAlliancePlayerCount +
+                     BattlegroundData[queueType][bracket].bgHordePlayerCount) == 0)
+                    continue;
+
                 if (BattlegroundData[queueType][bracket].activeBgQueue == 0 &&
                     BattlegroundData[queueType][bracket].bgInstanceCount < minCount &&
                     BattlegroundData[queueType][bracket].bgInstances.size() < minCount)
@@ -3057,6 +3053,77 @@ bool RandomPlayerbotMgr::IsAddclassBot(ObjectGuid::LowType bot)
     return false;
 }
 
+bool RandomPlayerbotMgr::HasMasterControlledRandomBots(ObjectGuid const& masterGuid) const
+{
+    auto it = _controlledRandomBotsByMaster.find(masterGuid);
+    return it != _controlledRandomBotsByMaster.end() && !it->second.empty();
+}
+
+void RandomPlayerbotMgr::GetMasterControlledRandomBotGuidsSnapshot(ObjectGuid const& masterGuid, std::vector<ObjectGuid>& out) const
+{
+    out.clear();
+
+    auto it = _controlledRandomBotsByMaster.find(masterGuid);
+    if (it == _controlledRandomBotsByMaster.end() || it->second.empty())
+        return;
+
+    out.reserve(it->second.size());
+    out.insert(out.end(), it->second.begin(), it->second.end());
+}
+
+void RandomPlayerbotMgr::OnRandomBotMasterChanged(ObjectGuid const& botGuid, ObjectGuid const& oldMasterGuid, ObjectGuid const& newMasterGuid)
+{
+    // Remove bot from any previously tracked master (preferred source: per-bot mapping; fallback: oldMasterGuid).
+    ObjectGuid prevMasterGuid;
+
+    auto itPrev = _controlledRandomBotMaster.find(botGuid);
+    if (itPrev != _controlledRandomBotMaster.end())
+        prevMasterGuid = itPrev->second;
+
+    if (prevMasterGuid.IsEmpty())
+        prevMasterGuid = oldMasterGuid;
+
+    if (!prevMasterGuid.IsEmpty())
+    {
+        auto itOld = _controlledRandomBotsByMaster.find(prevMasterGuid);
+        if (itOld != _controlledRandomBotsByMaster.end())
+        {
+            itOld->second.erase(botGuid);
+            if (itOld->second.empty())
+                _controlledRandomBotsByMaster.erase(itOld);
+        }
+    }
+
+    if (!newMasterGuid.IsEmpty())
+    {
+        _controlledRandomBotMaster[botGuid] = newMasterGuid;
+        _controlledRandomBotsByMaster[newMasterGuid].insert(botGuid);
+    }
+    else
+    {
+        _controlledRandomBotMaster.erase(botGuid);
+    }
+}
+
+void RandomPlayerbotMgr::OnRandomBotLoggedOut(ObjectGuid const& botGuid)
+{
+    auto it = _controlledRandomBotMaster.find(botGuid);
+    if (it == _controlledRandomBotMaster.end())
+        return;
+
+    ObjectGuid masterGuid = it->second;
+    _controlledRandomBotMaster.erase(it);
+
+    auto itSet = _controlledRandomBotsByMaster.find(masterGuid);
+    if (itSet == _controlledRandomBotsByMaster.end())
+        return;
+
+    itSet->second.erase(botGuid);
+    if (itSet->second.empty())
+        _controlledRandomBotsByMaster.erase(itSet);
+}
+
+
 void RandomPlayerbotMgr::GetBots()
 {
     if (!currentBots.empty())
@@ -4102,4 +4169,208 @@ ObjectGuid RandomPlayerbotMgr::GetBattleMasterGUID(Player* bot, BattlegroundType
     }
 
     return battleMasterGUID;
+}
+
+bool RandomPlayerbotMgr::IsWildBgJoinBlocked(uint32 instanceId)
+{
+    if (!instanceId)
+        return false;
+
+    uint32 now = NowSeconds();
+    auto it = _wildBgJoinBlockedUntilSec.find(instanceId);
+    if (it == _wildBgJoinBlockedUntilSec.end())
+        return false;
+
+    if (now >= it->second)
+    {
+        _wildBgJoinBlockedUntilSec.erase(it);
+        return false;
+    }
+
+    return true;
+}
+
+void RandomPlayerbotMgr::ClearWildBgJoinBlock(uint32 instanceId)
+{
+    if (!instanceId)
+        return;
+
+    _wildBgJoinBlockedUntilSec.erase(instanceId);
+    _wildBgEmptySinceSec.erase(instanceId);
+}
+
+void RandomPlayerbotMgr::UpdateWildBotBattlegroundMaintenance()
+{
+    // Throttle: cheap periodic scan (1 pass over online random-bots) to avoid per-tick overhead.
+    uint32 now = NowSeconds();
+    if (_wildBgMaintenanceNextSec && now < _wildBgMaintenanceNextSec)
+        return;
+
+    _wildBgMaintenanceNextSec = now + 5; // run at most once per 5 seconds
+
+    // Prune expired join-block entries to keep memory bounded.
+    for (auto it = _wildBgJoinBlockedUntilSec.begin(); it != _wildBgJoinBlockedUntilSec.end(); )
+    {
+        if (now >= it->second)
+            it = _wildBgJoinBlockedUntilSec.erase(it);
+        else
+            ++it;
+    }
+
+    static constexpr uint32 kDeserterSpellId = 26013;
+    static constexpr uint32 kEmptyLeaveDelaySec = 60;
+    static constexpr uint32 kJoinBlockSec = 90; // avoid immediate re-join to recently evacuated instances
+
+    // Collect battleground instances that currently contain at least one "wild" random-bot.
+    // Store a sample bot pointer per instance for cheap map/player scanning.
+    std::unordered_map<uint32, Player*> instanceSampleBot;
+    instanceSampleBot.reserve(16);
+
+    for (auto const& [guid, bot] : playerBots)
+    {
+        if (!bot || !bot->IsInWorld() || !IsRandomBot(bot))
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI || botAI->HasRealPlayerMaster())
+            continue; // not a "wild" bot
+
+        // Always clear deserter if it ever ends up on a wild random-bot.
+        if (bot->HasAura(kDeserterSpellId))
+            bot->RemoveAurasDueToSpell(kDeserterSpellId);
+
+        if (!bot->InBattleground())
+            continue;
+
+        Battleground* bg = bot->GetBattleground();
+        if (!bg || bg->isArena())
+            continue;
+
+        // Skip transitional states: do not interfere with normal BG shutdown or map transfers.
+        if (bg->GetStatus() == STATUS_WAIT_LEAVE)
+            continue;
+
+        if (bot->IsBeingTeleported() || bot->IsDuringRemoveFromWorld())
+            continue;
+
+        uint32 instanceId = bg->GetInstanceID();
+        if (!instanceId)
+            continue;
+
+        // Keep one sample bot per instance so we can check player presence cheaply.
+        if (instanceSampleBot.find(instanceId) == instanceSampleBot.end())
+            instanceSampleBot.emplace(instanceId, bot);
+    }
+
+    // If an instance no longer contains wild bots, we don't need to keep its empty-timer entry.
+    for (auto it = _wildBgEmptySinceSec.begin(); it != _wildBgEmptySinceSec.end(); )
+    {
+        if (instanceSampleBot.find(it->first) == instanceSampleBot.end())
+            it = _wildBgEmptySinceSec.erase(it);
+        else
+            ++it;
+    }
+
+    if (instanceSampleBot.empty())
+        return;
+
+    // Determine which instances are empty of real players and should be evacuated.
+    std::vector<uint32> evacInstances;
+    evacInstances.reserve(instanceSampleBot.size());
+
+    for (auto const& [instanceId, sampleBot] : instanceSampleBot)
+    {
+        Battleground* bg = sampleBot ? sampleBot->GetBattleground() : nullptr;
+        Map* map = bg ? bg->GetBgMap() : nullptr;
+
+        if (!map)
+        {
+            // Map not available (transfer/shutdown). Do not treat as "empty".
+            // Keep any existing empty-timers / join-blocks (they auto-expire / get pruned) to avoid re-join loops.
+            continue;
+        }
+
+        bool hasRealPlayer = false;
+        {
+            for (auto const& itr : map->GetPlayers())
+            {
+                Player* plr = itr.GetSource();
+                if (!plr || !plr->IsInWorld())
+                    continue;
+
+                if (!GET_PLAYERBOT_AI(plr))
+                {
+                    hasRealPlayer = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasRealPlayer)
+        {
+            // Instance is active (real player present): clear any empty-tracking and join blocks.
+            _wildBgEmptySinceSec.erase(instanceId);
+            _wildBgJoinBlockedUntilSec.erase(instanceId);
+            continue;
+        }
+
+        // No real players: start / continue the empty timer.
+        uint32& since = _wildBgEmptySinceSec[instanceId];
+        if (!since)
+            since = now;
+
+        if (now >= since + kEmptyLeaveDelaySec)
+        {
+            // Mark this instance as blocked for re-join for a short period.
+            uint32 blockUntil = now + kJoinBlockSec;
+            auto it = _wildBgJoinBlockedUntilSec.find(instanceId);
+            if (it == _wildBgJoinBlockedUntilSec.end() || it->second < blockUntil)
+                _wildBgJoinBlockedUntilSec[instanceId] = blockUntil;
+
+            evacInstances.push_back(instanceId);
+        }
+    }
+
+    if (evacInstances.empty())
+        return;
+
+    // Second pass: evacuate wild bots from the identified empty instances.
+    // (Kept separate to avoid storing large per-instance bot lists.)
+    for (auto const& [guid, bot] : playerBots)
+    {
+        if (!bot || !bot->IsInWorld() || !IsRandomBot(bot))
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI || botAI->HasRealPlayerMaster())
+            continue;
+
+        if (!bot->InBattleground())
+            continue;
+
+        Battleground* bg = bot->GetBattleground();
+        if (!bg || bg->isArena())
+            continue;
+
+        // Skip transitional states: do not interfere with normal BG shutdown or map transfers.
+        if (bg->GetStatus() == STATUS_WAIT_LEAVE)
+            continue;
+
+        if (bot->IsBeingTeleported() || bot->IsDuringRemoveFromWorld())
+            continue;
+
+        uint32 instanceId = bg->GetInstanceID();
+        if (!instanceId)
+            continue;
+
+        if (std::find(evacInstances.begin(), evacInstances.end(), instanceId) == evacInstances.end())
+            continue;
+
+        // Leave BG (will also schedule PvE re-equip for random bots).
+        BGStatusAction::LeaveBG(botAI);
+
+        // Extra safety: remove deserter immediately if it is already applied.
+        if (bot->HasAura(kDeserterSpellId))
+            bot->RemoveAurasDueToSpell(kDeserterSpellId);
+    }
 }

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -216,7 +216,6 @@ double botPIDImpl::calculate(double setpoint, double pv)
 
 botPIDImpl::~botPIDImpl() {}
 
-
 static inline void ResetBattlegroundInfo(BattlegroundInfo& info)
 {
     // Preserve vector capacity to avoid periodic allocation spikes.
@@ -258,7 +257,6 @@ RandomPlayerbotMgr::RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
     // Reserve to avoid rehash spikes when a large number of bots is used.
     if (sPlayerbotAIConfig->maxRandomBots > 0)
         eventCache.reserve(sPlayerbotAIConfig->maxRandomBots + 32);
-
 
     // Cleanup on server start: orphaned pet data that's often left behind by bot pets that no longer exist in the DB
     CharacterDatabase.Execute("DELETE FROM pet_aura WHERE guid NOT IN (SELECT id FROM character_pet)");
@@ -629,7 +627,6 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
         LogPlayerLocation();
     }
 }
-
 
 void RandomPlayerbotMgr::BeginSlicedCycle()
 {
@@ -3123,7 +3120,6 @@ void RandomPlayerbotMgr::OnRandomBotLoggedOut(ObjectGuid const& botGuid)
         _controlledRandomBotsByMaster.erase(itSet);
 }
 
-
 void RandomPlayerbotMgr::GetBots()
 {
     if (!currentBots.empty())
@@ -4050,7 +4046,6 @@ void RandomPlayerbotMgr::Remove(Player* bot)
 
         _pendingEventWrites.erase(pit);
     }
-
 
     LogoutPlayerBot(owner);
 }

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -11,6 +11,8 @@
 #include "PlayerbotMgr.h"
 #include "GameTime.h"
 
+struct CreatureData;
+
 struct BattlegroundInfo
 {
     std::vector<uint32> bgInstances;
@@ -197,13 +199,55 @@ private:
     float activityMod = 0.25;
     bool _isBotInitializing = true;
     bool _isBotLogging = true;
+    // Optional smoothing of heavy random-bot ticks by splitting them into smaller slices.
+    enum class SlicedPhase : uint8
+    {
+        None = 0,
+        Updating,
+        LoginPrep,
+        LoggingIn
+    };
+
+    void BeginSlicedCycle();
+    void ProcessSlicedSlice();
+    void EndSlicedCycle();
+
+    bool _slicedCycleActive = false;
+    SlicedPhase _slicedPhase = SlicedPhase::None;
+    uint32 _slicedLogicalIntervalMs = 0;
+    uint32 _slicedElapsedMs = 0;
+
+    uint32 _slicedDtMs = 0;
+    uint64 _slicedUpdateBudgetAcc = 0;
+    uint64 _slicedLoginBudgetAcc = 0;
+    uint32 _slicedUpdateTargetInitial = 0;
+    uint32 _slicedLoginTargetTotal = 0;
+    bool _slicedDidAttemptLoginPhase = false;
+
+
+    uint32 _slicedUpdateTarget = 0;
+    uint32 _slicedLoginTarget = 0;
+    uint32 _slicedLoginTargetInitial = 0;
+    uint32 _slicedUpdateDone = 0;
+    uint32 _slicedLoginDone = 0;
+    uint32 _slicedMaxNewBots = 0;
+
+    bool _slicedRealPlayerIsLogged = false;
+    bool _slicedCanAttemptLogin = false;
+
+    std::vector<uint32> _slicedBotSnapshot;
+    size_t _slicedUpdateIndex = 0;
+    size_t _slicedLoginIndex = 0;
+
     NewRpgStatistic rpgStasticTotal;
     CachedEvent* FindEvent(uint32 bot, std::string const& event);
     uint32 GetEventValue(uint32 bot, std::string const& event);
     std::string GetEventData(uint32 bot, std::string const& event);
     uint32 SetEventValue(uint32 bot, std::string const& event, uint32 value, uint32 validIn,
                          std::string const& data = "");
+    void FlushPendingEventDbWrites(bool force = false);
     void GetBots();
+    void BuildCreatureDataEntryIndex();
     std::vector<uint32> GetBgBots(uint32 bracket);
     time_t BgCheckTimer;
     time_t LfgCheckTimer;
@@ -225,6 +269,25 @@ private:
     std::map<uint32, std::map<uint32, std::vector<WorldLocation>>> rpgLocsCacheLevel;
     std::map<TeamId, std::map<BattlegroundTypeId, std::vector<uint32>>> BattleMastersCache;
     std::unordered_map<uint32, BotEventCache> eventCache;
+
+    // Batched persistence of random-bot events to reduce DB commit overhead.
+    struct PendingBotEventWrite
+    {
+        uint32 value = 0;
+        uint32 validIn = 0;
+        uint32 changeTime = 0;     // NowSeconds() at the time of scheduling
+        std::string data;
+    };
+
+    std::unordered_map<uint32, std::unordered_map<std::string, PendingBotEventWrite>> _pendingEventWrites;
+    size_t _pendingEventWritesCount = 0;
+    uint32 _pendingEventLastFlushMs = 0;
+
+    // Fast lookup for CreatureData by entry (avoids full scans of GetAllCreatureData()).
+    // Store the spawn guid (low) instead of a raw pointer so the lookup stays valid even if
+    // creature data is reloaded (pointers can be invalidated by container rehash/rebuild).
+    std::unordered_map<uint32, ObjectGuid::LowType> _creatureDataByEntry;
+    bool _creatureEntryIndexBuilt = false;
     std::list<uint32> currentBots;
     uint32 bgBotsCount;
     uint32 playersLevel;

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -6,6 +6,13 @@
 #ifndef _PLAYERBOT_RANDOMPLAYERBOTMGR_H
 #define _PLAYERBOT_RANDOMPLAYERBOTMGR_H
 
+#include <list>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 #include "NewRpgInfo.h"
 #include "ObjectGuid.h"
 #include "PlayerbotMgr.h"
@@ -107,6 +114,12 @@ public:
     bool IsRandomBot(ObjectGuid::LowType bot);
     bool IsAddclassBot(Player* bot);
     bool IsAddclassBot(ObjectGuid::LowType bot);
+
+    // Fast lookup: real-player master -> controlled random-bots (so players without bots can skip packet forwarding).
+    bool HasMasterControlledRandomBots(ObjectGuid const& masterGuid) const;
+    void GetMasterControlledRandomBotGuidsSnapshot(ObjectGuid const& masterGuid, std::vector<ObjectGuid>& out) const;
+    void OnRandomBotMasterChanged(ObjectGuid const& botGuid, ObjectGuid const& oldMasterGuid, ObjectGuid const& newMasterGuid);
+    void OnRandomBotLoggedOut(ObjectGuid const& botGuid);
     void Randomize(Player* bot);
     void Clear(Player* bot);
     void RandomizeFirst(Player* bot);
@@ -154,6 +167,11 @@ public:
     void CheckLfgQueue();
     void CheckPlayers();
     void LogBattlegroundInfo();
+
+    // Prevent "wild" random-bots (no real-player master) from re-joining recently evacuated empty battleground instances.
+    // Used by BG status handler when a bot receives an invite to a specific BG instance.
+    bool IsWildBgJoinBlocked(uint32 instanceId);
+    void ClearWildBgJoinBlock(uint32 instanceId);
 
     std::map<TeamId, std::map<BattlegroundTypeId, std::vector<uint32>>> getBattleMastersCache()
     {
@@ -224,7 +242,6 @@ private:
     uint32 _slicedLoginTargetTotal = 0;
     bool _slicedDidAttemptLoginPhase = false;
 
-
     uint32 _slicedUpdateTarget = 0;
     uint32 _slicedLoginTarget = 0;
     uint32 _slicedLoginTargetInitial = 0;
@@ -292,9 +309,23 @@ private:
     uint32 bgBotsCount;
     uint32 playersLevel;
 
+    // --- Wild random-bot battleground maintenance ---
+    // We track empty BG instances (no real players) to evict "wild" random-bots after a short delay,
+    // and to temporarily block immediate re-joins to the same instance (stale BG queue snapshots, etc.).
+    uint32 _wildBgMaintenanceNextSec = 0;
+    std::unordered_map<uint32, uint32> _wildBgEmptySinceSec;         // instanceId -> first time we saw it empty
+    std::unordered_map<uint32, uint32> _wildBgJoinBlockedUntilSec;    // instanceId -> block expiration timestamp
+
+    void UpdateWildBotBattlegroundMaintenance();
+
     // Account lists
     std::vector<uint32> rndBotTypeAccounts;             // Accounts marked as RNDbot (type 1)
     std::vector<uint32> addClassTypeAccounts;           // Accounts marked as AddClass (type 2)
+
+    // Fast master->controlled random-bots index (maintained via PlayerbotAI::SetMaster()).
+    // Note: only real-player masters are tracked (bot masters are ignored).
+    std::unordered_map<ObjectGuid, std::unordered_set<ObjectGuid>> _controlledRandomBotsByMaster;
+    std::unordered_map<ObjectGuid, ObjectGuid> _controlledRandomBotMaster;
 
     //void ScaleBotActivity();      // Deprecated function
     static inline uint32 NowSeconds() { return static_cast<uint32>(GameTime::GetGameTime().count()); }

--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -185,7 +185,7 @@ void StatsWeightCalculator::GenerateWeights(Player* player)
 
     // PvP: resilience must dominate weights on battlegrounds/arenas.
     if (player->InBattleground() || player->InArena())
-        stats_weights_[STATS_TYPE_RESILIENCE] += 8.0f;
+        stats_weights_[STATS_TYPE_RESILIENCE] += 24.0f;
 }
 
 void StatsWeightCalculator::GenerateBasicWeights(Player* player)

--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -182,6 +182,10 @@ void StatsWeightCalculator::GenerateWeights(Player* player)
     GenerateBasicWeights(player);
     GenerateAdditionalWeights(player);
     ApplyWeightFinetune(player);
+
+    // PvP: resilience must dominate weights on battlegrounds/arenas.
+    if (player->InBattleground() || player->InArena())
+        stats_weights_[STATS_TYPE_RESILIENCE] += 8.0f;
 }
 
 void StatsWeightCalculator::GenerateBasicWeights(Player* player)

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -184,7 +184,15 @@ bool PlayerbotAIConfig::Initialize()
     minRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBots", 500);
     maxRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBots", 500);
     randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 20);
-    randomBotCountChangeMinInterval =
+    randomBotSlicing = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotSlicing", false);
+
+int32 sliceMs = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotSliceMs", 250);
+if (sliceMs < 50)
+    sliceMs = 50;
+if (sliceMs > 5000)
+    sliceMs = 5000;
+randomBotSliceMs = static_cast<uint32>(sliceMs);
+randomBotCountChangeMinInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMinInterval", 30 * MINUTE);
     randomBotCountChangeMaxInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMaxInterval", 2 * HOUR);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -127,6 +127,10 @@ public:
     float randomBotRpgChance;
     uint32 minRandomBots, maxRandomBots;
     uint32 randomBotUpdateInterval, randomBotCountChangeMinInterval, randomBotCountChangeMaxInterval;
+
+    // Smooth out heavy random-bot updates by splitting them into smaller slices.
+    bool randomBotSlicing;
+    uint32 randomBotSliceMs;
     uint32 minRandomBotInWorldTime, maxRandomBotInWorldTime;
     uint32 minRandomBotRandomizeTime, maxRandomBotRandomizeTime;
     uint32 minRandomBotChangeStrategyTime, maxRandomBotChangeStrategyTime;

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -423,12 +423,19 @@ public:
         if (!player)
             return;
 
+        if (!packet)
+            return;
+
         if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(player))
         {
             botAI->HandleBotOutgoingPacket(*packet);
         }
         if (PlayerbotMgr* playerbotMgr = GET_PLAYERBOT_MGR(player))
         {
+            // If this real player controls no bots (alts or controlled random-bots), skip expensive forwarding.
+            if (playerbotMgr->GetPlayerbotsCount() == 0 && !sRandomPlayerbotMgr->HasMasterControlledRandomBots(player->GetGUID()))
+                return;
+
             playerbotMgr->HandleMasterOutgoingPacket(*packet);
         }
     }

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -435,6 +435,7 @@ public:
 
     void OnPlayerbotUpdate(uint32 diff) override
     {
+        PlayerbotHolder::UpdateInitQueue(diff);
         sRandomPlayerbotMgr->UpdateSessions();  // Per-bot updates only
     }
 


### PR DESCRIPTION
This patch brings a lot of improvements to the arena and BG operation.
1) World bots entering the arena receive PVP equipment. When exiting the BG and the arena, the bots change their equipment back to PVE.
2) In the arena, the level of PVP bots depends on their rating. Bots at 1,500 and at 2,300 now have different levels of things.
3) When fighting on a random battlefield, bots no longer only go to 10 people, now they fill the slots in BG correctly (Alterac 40 people, Arati 15, etc.)
4) The player on BG can no longer summon his bots to himself (this broke the arena)
5) The bot arena teams now adjust to the player's rating of +-100. Now there will be no situations when a player with 2300 fights with bots with 1200.

The patch is being tested on 4 servers with a population of 100 real people and 2000 bots.

@hermensbas @noisiver 