### PR TITLE
[CORE FIX] Bots are getting Mark of the Wild when they should not be learned

### DIFF
--- a/src/strategy/actions/AutoMaintenanceOnLevelupAction.cpp
+++ b/src/strategy/actions/AutoMaintenanceOnLevelupAction.cpp
@@ -99,11 +99,11 @@ void AutoMaintenanceOnLevelupAction::LearnQuestSpells(std::ostringstream* out)
 
         if (quest->GetRewSpellCast() > 0)
         {
-            LearnSpell(quest->GetRewSpellCast(), out);
+            LearnSpell(quest->GetRewSpellCast(), out, false);
         }
         else if (quest->GetRewSpell() > 0)
         {
-            LearnSpell(quest->GetRewSpell(), out);
+            LearnSpell(quest->GetRewSpell(), out, true);
         }
     }
 }
@@ -121,7 +121,7 @@ std::string const AutoMaintenanceOnLevelupAction::FormatSpell(SpellInfo const* s
     return out.str();
 }
 
-void AutoMaintenanceOnLevelupAction::LearnSpell(uint32 spellId, std::ostringstream* out)
+void AutoMaintenanceOnLevelupAction::LearnSpell(uint32 spellId, std::ostringstream* out, bool allowDirectLearn)
 {
     SpellInfo const* proto = sSpellMgr->GetSpellInfo(spellId);
     if (!proto)
@@ -144,7 +144,7 @@ void AutoMaintenanceOnLevelupAction::LearnSpell(uint32 spellId, std::ostringstre
         }
     }
 
-    if (!learned)
+    if (!learned && allowDirectLearn)
     {
         if (!bot->HasSpell(spellId))
         {

--- a/src/strategy/actions/AutoMaintenanceOnLevelupAction.h
+++ b/src/strategy/actions/AutoMaintenanceOnLevelupAction.h
@@ -28,7 +28,7 @@ protected:
     void LearnSpells(std::ostringstream* out);
     void LearnTrainerSpells(std::ostringstream* out);
     void LearnQuestSpells(std::ostringstream* out);
-    void LearnSpell(uint32 spellId, std::ostringstream* out);
+    void LearnSpell(uint32 spellId, std::ostringstream* out, bool allowDirectLearn);
     std::string const FormatSpell(SpellInfo const* sInfo);
 };
 


### PR DESCRIPTION
## Summary
- prevent direct learning from RewardSpellCast unless it actually teaches a spell.
- keep normal RewardSpell learning unchanged.

Solve issue #1759

Tested with 2000 bots 100% Actives.