### PR TITLE
Fix teleport to invalid map (xxx) or invalid coordinates (x xxxxxx, y yyyyyy, z  zzzzzzz, o oooooo) given when teleporting player

### DIFF
--- a/src/TravelMgr.cpp
+++ b/src/TravelMgr.cpp
@@ -231,6 +231,8 @@ bool WorldPosition::NormalizePositionForTeleport(Player* bot)
 
     Map* map = getMap();
     if (!map)
+        map = sMapMgr->FindBaseMap(getMapId());
+    if (!map)
         return false;
 
     float x = getX();
@@ -242,6 +244,7 @@ bool WorldPosition::NormalizePositionForTeleport(Player* bot)
         setX(x);
         setY(y);
         setZ(z);
+
         return true;
     }
 
@@ -250,15 +253,15 @@ bool WorldPosition::NormalizePositionForTeleport(Player* bot)
     float safeZ = std::max(groundZ, waterZ);
     if (safeZ <= INVALID_HEIGHT || safeZ == VMAP_INVALID_HEIGHT_VALUE)
     {
-        LOG_DEBUG("playerbots",
-                  "[Teleport] Invalid destination after height check ({},{},{},{}) groundZ:{} waterZ:{}",
-                  x, y, z, getMapId(), groundZ, waterZ);
+    LOG_ERROR("playerbots", "[MISSED Teleport by Travel Manager] Normalized destination ({},{},{},{})",
+             x, y, safeZ, getMapId());
         return false;
     }
 
     setX(x);
     setY(y);
     setZ(safeZ);
+
     return true;
 }
 

--- a/src/TravelMgr.h
+++ b/src/TravelMgr.h
@@ -142,6 +142,7 @@ public:
     bool isInWater();
     bool isUnderWater();
     bool IsValid();
+    bool NormalizePositionForTeleport(Player* bot);
 
     WorldPosition relPoint(WorldPosition* center);
     WorldPosition offset(WorldPosition* center);

--- a/src/strategy/actions/ReleaseSpiritAction.cpp
+++ b/src/strategy/actions/ReleaseSpiritAction.cpp
@@ -14,6 +14,7 @@
 #include "ServerFacade.h"
 #include "Corpse.h"
 #include "Log.h"
+#include "TravelMgr.h"
 
 // ReleaseSpiritAction implementation
 bool ReleaseSpiritAction::Execute(Event event)
@@ -148,7 +149,12 @@ bool AutoReleaseSpiritAction::HandleBattlegroundSpiritHealer()
 
         // Teleport to nearest friendly Spirit Healer when not currently in range of one.
         bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
-        bot->TeleportTo(bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(), spiritHealer->GetPositionZ(), 0.f);
+        WorldPosition safePos(bot->GetMapId(), spiritHealer->GetPositionX(), spiritHealer->GetPositionY(),
+                              spiritHealer->GetPositionZ(), 0.f);
+        if (safePos.NormalizePositionForTeleport(bot))
+        {
+            bot->TeleportTo(safePos.getMapId(), safePos.getX(), safePos.getY(), safePos.getZ(), 0.f);
+        }
         RESET_AI_VALUE(bool, "combat::self target");
         RESET_AI_VALUE(WorldPosition, "current position");
     }
@@ -244,7 +250,11 @@ int64 RepopAction::CalculateDeadTime() const
 void RepopAction::PerformGraveyardTeleport(const GraveyardStruct* graveyard) const
 {
     bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
-    bot->TeleportTo(graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f);
+    WorldPosition safePos(graveyard->Map, graveyard->x, graveyard->y, graveyard->z, 0.f);
+    if (safePos.NormalizePositionForTeleport(bot))
+    {
+        bot->TeleportTo(safePos.getMapId(), safePos.getX(), safePos.getY(), safePos.getZ(), 0.f);
+    }
     RESET_AI_VALUE(bool, "combat::self target");
     RESET_AI_VALUE(WorldPosition, "current position");
 }

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -174,7 +174,6 @@ bool FindCorpseAction::Execute(Event event)
             WorldPosition safePos = moveToPos;
             if (safePos.NormalizePositionForTeleport(bot))
             {
-                         bot->GetName(), safePos.getX(), safePos.getY(), safePos.getZ(), safePos.getMapId());
                 bot->TeleportTo(safePos.getMapId(), safePos.getX(), safePos.getY(), safePos.getZ(), 0);
             }
             else

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -13,6 +13,7 @@
 #include "Playerbots.h"
 #include "RandomPlayerbotMgr.h"
 #include "ServerFacade.h"
+#include "TravelMgr.h"
 #include "Corpse.h"
 
 bool ReviveFromCorpseAction::Execute(Event event)
@@ -170,7 +171,17 @@ bool FindCorpseAction::Execute(Event event)
         {
             bot->GetMotionMaster()->Clear();
             bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
-            bot->TeleportTo(moveToPos.getMapId(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 0);
+            WorldPosition safePos = moveToPos;
+            if (safePos.NormalizePositionForTeleport(bot))
+            {
+                         bot->GetName(), safePos.getX(), safePos.getY(), safePos.getZ(), safePos.getMapId());
+                bot->TeleportTo(safePos.getMapId(), safePos.getX(), safePos.getY(), safePos.getZ(), 0);
+            }
+            else
+            {
+                LOG_DEBUG("playerbots", "Skip corpse teleport for {} due to invalid destination ({},{},{},{})",
+                          bot->GetName(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), moveToPos.getMapId());
+            }
         }
 
         moved = true;

--- a/src/strategy/actions/ReviveFromCorpseAction.cpp
+++ b/src/strategy/actions/ReviveFromCorpseAction.cpp
@@ -173,14 +173,7 @@ bool FindCorpseAction::Execute(Event event)
             bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
             WorldPosition safePos = moveToPos;
             if (safePos.NormalizePositionForTeleport(bot))
-            {
                 bot->TeleportTo(safePos.getMapId(), safePos.getX(), safePos.getY(), safePos.getZ(), 0);
-            }
-            else
-            {
-                LOG_DEBUG("playerbots", "Skip corpse teleport for {} due to invalid destination ({},{},{},{})",
-                          bot->GetName(), moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), moveToPos.getMapId());
-            }
         }
 
         moved = true;
@@ -318,6 +311,9 @@ bool SpiritHealerAction::Execute(Event event)
     GraveyardStruct const* ClosestGrave =
         GetGrave(dCount > 10 || deadTime > 15 * MINUTE || AI_VALUE(uint8, "durability") < 10);
 
+    if (!ClosestGrave)
+        return false;
+
     if (bot->GetDistance2d(ClosestGrave->x, ClosestGrave->y) < sPlayerbotAIConfig->sightDistance)
     {
         GuidVector npcs = AI_VALUE(GuidVector, "nearest npcs");
@@ -343,11 +339,6 @@ bool SpiritHealerAction::Execute(Event event)
         }
     }
 
-    if (!ClosestGrave)
-    {
-        return false;
-    }
-
     bool moved = false;
 
     if (bot->IsWithinLOS(ClosestGrave->x, ClosestGrave->y, ClosestGrave->z))
@@ -358,17 +349,16 @@ bool SpiritHealerAction::Execute(Event event)
     if (moved)
         return true;
 
-    // if (!botAI->HasActivePlayerMaster())
-    // {
     context->GetValue<uint32>("death count")->Set(dCount + 1);
     bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
-    return bot->TeleportTo(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
-    // }
-
-    // LOG_INFO("playerbots", "Bot {} {}:{} <{}> can't find a spirit healer", bot->GetGUID().ToString().c_str(),
-    //          bot->GetTeamId() == TEAM_ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName().c_str());
-
-    // botAI->TellError("Cannot find any spirit healer nearby");
+    WorldPosition safePos(ClosestGrave->Map, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, 0.f);
+    if (safePos.NormalizePositionForTeleport(bot))
+    {
+        return bot->TeleportTo(safePos.getMapId(), safePos.getX(), safePos.getY(), safePos.getZ(), 0.f);
+    }
+    LOG_DEBUG("playerbots",
+              "Skip spirit healer teleport for {} due to invalid destination ({},{},{},{})",
+              bot->GetName(), safePos.getX(), safePos.getY(), safePos.getZ(), safePos.getMapId());
     return false;
 }
 

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -59,16 +59,24 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
         // Unfortunately we've been stuck here for over 5 mins, fallback to teleporting directly to the destination
         botAI->rpgInfo.stuckTs = getMSTime();
         botAI->rpgInfo.stuckAttempts = 0;
+        WorldPosition safeDest = dest;
+        if (!safeDest.NormalizePositionForTeleport(bot))
+        {
+            LOG_DEBUG("playerbots",
+                      "[New RPG Teleport] Skip teleport for {} due to invalid destination ({},{},{},{})",
+                      bot->GetName(), dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(), dest.getMapId());
+            return false;
+        }
+
         const AreaTableEntry* entry = sAreaTableStore.LookupEntry(bot->GetZoneId());
         std::string zone_name = PlayerbotAI::GetLocalizedAreaName(entry);
-        LOG_DEBUG(
-            "playerbots",
-            "[New RPG] Teleport {} from ({},{},{},{}) to ({},{},{},{}) as it stuck when moving far - Zone: {} ({})",
-            bot->GetName(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot->GetMapId(),
-            dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(), dest.getMapId(), bot->GetZoneId(),
-            zone_name);
+        LOG_DEBUG("playerbots",
+                  "[New RPG] Teleport {} from ({},{},{},{}) to ({},{},{},{}) as it stuck when moving far - Zone: {} ({})",
+                  bot->GetName(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot->GetMapId(),
+                  safeDest.GetPositionX(), safeDest.GetPositionY(), safeDest.GetPositionZ(), safeDest.getMapId(),
+                  bot->GetZoneId(), zone_name);
         bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
-        return bot->TeleportTo(dest);
+        return bot->TeleportTo(safeDest);
     }
 
     float dis = bot->GetExactDist(dest);

--- a/src/strategy/rpg/NewRpgBaseAction.cpp
+++ b/src/strategy/rpg/NewRpgBaseAction.cpp
@@ -63,7 +63,7 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
         if (!safeDest.NormalizePositionForTeleport(bot))
         {
             LOG_DEBUG("playerbots",
-                      "[New RPG Teleport] Skip teleport for {} due to invalid destination ({},{},{},{})",
+                      "[New RPG] Skip teleport for {} due to invalid destination ({},{},{},{})",
                       bot->GetName(), dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(), dest.getMapId());
             return false;
         }


### PR DESCRIPTION
**This patch fix the bad bot teleports that was spamming invalid coords.**
I add a small helper in WorldPosition to normalize the teleport destination only once, using core helpers.
First we try CanReachPositionAndGetValidCoords (path/nav data), and if it fail we fallback to a safe Z from GetHeight / GetWaterLevel.
So we keep it core‑friendly and no duplicated logic.

Then I use this helper only in the two places where we do “hard” teleports (New RPG stuck teleport and corpse teleport).
If the destination is still invalid we just skip and log a debug line, so no more invalid TeleportTo.

The change is very local and should not touch PlayerbotAI or global movement.