### PR TITLE
Bug - Selfbot can trigger crash in printstats

### DIFF
--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -3215,7 +3215,10 @@ void RandomPlayerbotMgr::PrintStats()
 
         PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
         if (!botAI)
+        {
+            LOG_ERROR("playerbots", "Player/Bot {} is registered in sRandomPlayerbotMgr playerBots and has no bot AI!", bot->GetName().c_str());
             continue;
+        }
 
         if (botAI->AllowActivity())
             ++active;


### PR DESCRIPTION
Adding a guard against bots that may be registered in `playerBots` variable as selfbot have appeared to crash here. 

Edit: The exact circumstances that caused the incorrect registration are under investigation as it seems to be 'atypical' behavior.