### PR TITLE
Bear Alternative form for low level cat strat

### DIFF
--- a/src/Ai/Class/Druid/Strategy/CatDpsDruidStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/CatDpsDruidStrategy.cpp
@@ -61,7 +61,7 @@ private:
         return new ActionNode(
             "cat form",
             /*P*/ { NextAction("caster form") },
-            /*A*/ {},
+            /*A*/ { NextAction("bear form") },
             /*C*/ {}
         );
     }


### PR DESCRIPTION
This adds the bear form as an alternative form for druids with the cat strategies. This applies to low level (<20) druids that have the cat strategy applied. Reset botAI would not normally give them the strat, because they dont have cat form, but if set, this allows more dps. 