### PR TITLE
Summon Logic Tweaks

### DIFF
--- a/src/Ai/Base/Actions/UseMeetingStoneAction.cpp
+++ b/src/Ai/Base/Actions/UseMeetingStoneAction.cpp
@@ -217,7 +217,6 @@ bool SummonAction::Teleport(Player* summoner, Player* player, bool preserveAuras
                     player->GetPet()->NearTeleportTo(x, y, z, player->GetOrientation());
                 if (player->GetGuardianPet())
                     player->GetGuardianPet()->NearTeleportTo(x, y, z, player->GetOrientation());
-                    
                 if (botAI->HasStrategy("stay", botAI->GetState()))
                 {
                     PositionMap& posMap = AI_VALUE(PositionMap&, "position");


### PR DESCRIPTION
Issues:
- When you have selfbot enabled and use summon command, you will summon yourself. This causes odd movement if you summon while moving, and can sometimes lead to falling through the floor.
- When using the summon command on bots with pets/guardians from a medium distance (like jumping down a ledge then commanding summon), the pets will pathfind run to catch up. This causes them to aggro everything on the way.

Solution: 
Fix summon logic to prevent selfbot summon and ensure pets are teleported with bots.

