### PR TITLE
Fix Destro Warlock Glyphs

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -544,8 +544,8 @@ AiPlayerbot.AutoGearQualityLimit = 3
 # Max iLVL Phase 1(MC, Ony, ZG) = 78 | Phase 2(BWL) = 83 | Phase 2.5(AQ40) = 88 | Phase 3(Naxx40) = 92
 # TBC
 # Max iLVL Tier 4 = 120 | Tier 5 = 133 | Tier 6 = 164
-# Max iLVL Phase 1(Kara, Gruul, Mag) = 125 | Phase 1.5(ZA) = 138 | Phase 2(SC, TK) = 141 | Phase 3(Hyjal, BT) = 156 | Phase 4(Sunwell) = 164
-# Wotlk
+# Max iLVL Phase 1(Kara, Gruul, Mag) = 125 | Phase 2(SSC, TK, ZA) = 141 | Phase 3(Hyjal, BT) = 156 | Phase 4(Sunwell) = 164
+# WotLK
 # Max iLVL Tier 7(10/25) = 200/213 | Tier 8(10/25) = 225/232 | Tier 9(10/25) = 232/245 | Tier 10(10/25/HC) = 251/264/290
 # Max iLVL Phase 1(Naxx) = 224 | Phase 2(Ulduar) = 245 | Phase 3(ToC) = 258 | Phase 4(ICC) = 290
 # Default: 0 (no limit)
@@ -736,7 +736,7 @@ AiPlayerbot.RandomGearQualityLimit = 3
 # TBC
 # Max iLVL Tier 4 = 120 | Tier 5 = 133 | Tier 6 = 164
 # Max iLVL Phase 1(Kara, Gruul, Mag) = 125 | Phase 2(SSC, TK, ZA) = 141 | Phase 3(Hyjal, BT) = 156 | Phase 4(Sunwell) = 164
-# Wotlk
+# WotLK
 # Max iLVL Tier 7(10/25) = 200/213 | Tier 8(10/25) = 225/232 | Tier 9(10/25) = 232/245 | Tier 10(10/25/HC) = 251/264/290
 # Max iLVL Phase 1(Naxx) = 224 | Phase 2(Ulduar) = 245 | Phase 3(ToC) = 258 | Phase 4(ICC) = 290
 # Default: 0 (no limit)
@@ -1624,7 +1624,7 @@ AiPlayerbot.PremadeSpecLink.9.1.60 = -003203301135112530135201051
 AiPlayerbot.PremadeSpecLink.9.1.70 = -003203301135112530135201051-55
 AiPlayerbot.PremadeSpecLink.9.1.80 = -003203301135112530135221351-55000005
 AiPlayerbot.PremadeSpecName.9.2 = destro pve
-AiPlayerbot.PremadeSpecGlyph.9.2 = 45785,43390,50077,43394,43393,42454
+AiPlayerbot.PremadeSpecGlyph.9.2 = 45785,43390,42454,43394,43393,45785
 AiPlayerbot.PremadeSpecLink.9.2.60 = --05203215200231051305031151
 AiPlayerbot.PremadeSpecLink.9.2.80 = 23-0302-05203215220331051335231351
 AiPlayerbot.PremadeSpecName.9.3 = affli pvp


### PR DESCRIPTION
Updates are only to the config. This PR should be simple. Tl;dr is destro pve spec is using the wrong glyphs.

Longer explanation--right now, PreMadeSpecGlyph in the config provides for destro pve spec to use the following Major Glyphs at levels 15, 30, and 80, respectively: Life Tap, Quick Decay, Conflagrate. Quick Decay is useless for destro because destro does not cast Corruption except as a filler instant cast when on the move. Meanwhile, the spec is almost unplayable without Glyph of Conflagrate, so that should not be withheld until level 80. After Conflagrate, there are several viable glyphs, including Life Tap, Incinerate, Immolate, and Imp. I understand Glyph of Life Tap gets worse over time to the point that you don't want to use that glyph in ICC, but that's quite late, and it is useful for the vast majority of the game as a glyph that would actually be available at level 15. I also understand that Glyph of Immolate does not excel until high gear levels. Therefore, I decided to use Incinerate as the default level 80 glyph.

The new order for default glyphs for destro pve for levels 15, 30, and 80 is Life Tap, Conflagrate, and Incinerate, respectively. I also made a couple of other very minor fixes in the config. No impact on performance or AI, obviously.

Sidenote: Glyph of Conflagrate is not available at level 30--it requires level 40, so from 30 to 40, InitGlyphs() will plug in a random glyph for the second Major slot. This issue applies to many specs, and it's not avoidable unless InitGlyphs() is broken up into level brackets, which I think is not worthwhile. I think the better approach for glyphs is to ensure the right ones are applied at high levels, but with an attempt to make them usable at lower levels too where possible.