### PR TITLE
Minor flightMasterCache fix.

### DIFF
--- a/src/Db/FlightMasterCache.cpp
+++ b/src/Db/FlightMasterCache.cpp
@@ -13,7 +13,7 @@ void FlightMasterCache::AddAllianceFlightMaster(uint32 entry, WorldPosition pos)
 Creature* FlightMasterCache::GetNearestFlightMaster(Player* bot)
 {
     std::map<uint32, WorldPosition>& flightMasterCache =
-        (bot->GetTeamId() == ALLIANCE) ? allianceFlightMasterCache : hordeFlightMasterCache;
+        (bot->GetTeamId() == TEAM_ALLIANCE) ? allianceFlightMasterCache : hordeFlightMasterCache;
 
     Creature* nearestFlightMaster = nullptr;
     float nearestDistance = std::numeric_limits<float>::max();


### PR DESCRIPTION
# Pull Request

Incorrect comparison fix. 

---

## How to Test the Changes

- Alliance Bots should now be able to find the correct flightmaster and use it

## Complexity & Impact

- Does this change add new decision branches?
    - [X] No
    - [ ] Yes (**explain below**)

- Does this change increase per-bot or per-tick processing?
    - [X] No
    - [ ] Yes (**describe and justify impact**)

- Could this logic scale poorly under load?
    - [X] No
    - [ ] Yes (**explain why**)

---

## Defaults & Configuration

- Does this change modify default bot behavior?
    - [X] No
    - [ ] Yes (**explain why**)

If this introduces more advanced or AI-heavy logic:

- [X] Lightweight mode remains the default
- [ ] More complex behavior is optional and thereby configurable

---

## AI Assistance

- Was AI assistance (e.g. ChatGPT or similar tools) used while working on this change?
    - [X] No
    - [ ] Yes (**explain below**)

---

## Final Checklist

- [X] Stability is not compromised
- [X] Performance impact is understood, tested, and acceptable
- [X] Added logic complexity is justified and explained
- [X] Documentation updated if needed

