### PR TITLE
Fix WSG graveyard camping by flag carrier

### DIFF
--- a/src/Ai/Base/Actions/BattleGroundTactics.cpp
+++ b/src/Ai/Base/Actions/BattleGroundTactics.cpp
@@ -2227,8 +2227,8 @@ bool BGTactics::selectObjective(bool reset)
             }
             // Graveyard Camping if in lead
             else if (!hasFlag && role < 8 &&
-                (team == TEAM_ALLIANCE && allianceScore == 2 && hordeScore == 0) ||
-                (team == TEAM_HORDE && hordeScore == 2 && allianceScore == 0))
+                ((team == TEAM_ALLIANCE && allianceScore == 2 && hordeScore == 0) ||
+                (team == TEAM_HORDE && hordeScore == 2 && allianceScore == 0)))
             {
                 if (team == TEAM_ALLIANCE)
                     SetSafePos(WS_GY_CAMPING_HORDE, 10.0f);


### PR DESCRIPTION
Quick fix for a very annoying error identified by SmashingQuasar. In WSG, bots will camp the opposing graveyard if up 2-0. This is supposed to exclude the flag carrier, but a logical error has resulted in the flag carrier being excluded for Alliance camping only, meaning the Horde flag carrier will camp the GY with the rest of the team if up 2-0 and thus refuse to end the game.