### PR TITLE
Hotfix for OnBotLoginOperation() Crash

### DIFF
--- a/src/Script/WorldThr/PlayerbotOperations.h
+++ b/src/Script/WorldThr/PlayerbotOperations.h
@@ -503,8 +503,10 @@ public:
                 manager->OnBotLogin(bot);
             }
         }
-
-        sRandomPlayerbotMgr.OnBotLogin(bot);
+        else
+        {
+            sRandomPlayerbotMgr.OnBotLogin(bot);
+        }
 
         return true;
     }


### PR DESCRIPTION
Hotfix for an issue arising from https://github.com/mod-playerbots/mod-playerbots/pull/2082

OnBotLoginOperation() is calling OnBotLogin() twice for altbots. I don't know the full implication, but RandomPlayerbotMgr::OnBotLoginInternal() is being called on altbots, and the server will crash if you attempt to then log out the altbot.

This fix works for me right now. Discussed with @Celandriel , going to push this hotfix for now until the rest of the maintainers can take a look.