### PR TITLE
Chilton wand fix

### DIFF
--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -1799,10 +1799,6 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                 {
                     for (uint32 itemId : sRandomItemMgr.GetCachedEquipments(requiredLevel, inventoryType))
                     {
-                        if (itemId == 46978 ||  // shaman earth ring totem
-                            itemId == 12468)    // chilton wand
-                            continue;
-
                         uint32 skipProb = 25;
                         if (urand(1, 100) <= skipProb)
                             continue;

--- a/src/Mgr/Item/RandomItemMgr.cpp
+++ b/src/Mgr/Item/RandomItemMgr.cpp
@@ -2256,10 +2256,13 @@ void RandomItemMgr::BuildEquipCacheNew()
         {
             continue;
         }
-        if (itemId == 22784)
-        {  // Sunwell Orb
+
+        // Unobtainable or unusable items
+        if (itemId == 12468 || // Chilton Wand
+            itemId == 22784 || // Sunwell Orb
+            itemId == 46978) // Totem of the Earthen Ring
             continue;
-        }
+
         equipCacheNew[proto->RequiredLevel][proto->InventoryType].push_back(itemId);
     }
 }


### PR DESCRIPTION
# Pull Request

Added Chilton wand to excluded to equipment items for bots and unified 2 exclusion lists to single one.
Resolves: https://github.com/mod-playerbots/mod-playerbots/issues/2093

---

## How to Test the Changes

Couldnt reproduce Chilton wand bug then testing sound impossible. Someone can try getting this items on shaman.

## Complexity & Impact

Does this change add new decision branches?
- - [x] No
- - [ ] Yes

Does this change increase per-bot or per-tick processing?
- - [x] No
- - [ ] Yes

Could this logic scale poorly under load?
- - [x] No
- - [ ] Yes
---

## Defaults & Configuration

Does this change modify default bot behavior?
- - [x] No
- - [ ] Yes

If this introduces more advanced or AI-heavy logic:
- - [ ] Lightweight mode remains the default
- - [ ] More complex behavior is optional and thereby configurable
---

## AI Assistance

Was AI assistance (e.g. ChatGPT or similar tools) used while working on this change?
- - [x] No
- - [ ] Yes
---

## Final Checklist

- - [x] Stability is not compromised
- - [x] Performance impact is understood, tested, and acceptable
- - [x] Added logic complexity is justified and explained
- - [x] Documentation updated if needed

---