### PR TITLE
Workaround for crash related with uninitalized script

### DIFF
--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -17,6 +17,7 @@
 
 #include "Playerbots.h"
 
+#include "BattlefieldScript.h"
 #include "Channel.h"
 #include "Config.h"
 #include "DatabaseEnv.h"
@@ -518,12 +519,20 @@ public:
     void OnBattlegroundEnd(Battleground* bg, TeamId /*winnerTeam*/) override { bgStrategies.erase(bg->GetInstanceID()); }
 };
 
+// Workaround for missing InitEnabledHooksIfNeeded for new BattlefieldScript in ScriptMgr
+class PlayerbotsBattlefieldScript : public BattlefieldScript
+{
+public:
+    PlayerbotsBattlefieldScript() : BattlefieldScript("PlayerbotsBattlefieldScript") { }
+};
+
 void AddPlayerbotsSecureLoginScripts();
 
 void AddSC_TempestKeepBotScripts();
 
 void AddPlayerbotsScripts()
 {
+    new PlayerbotsBattlefieldScript();
     new PlayerbotsDatabaseScript();
     new PlayerbotsPlayerScript();
     new PlayerbotsMiscScript();


### PR DESCRIPTION
# Pull Request

Workaround for crashes related with uninitialized new script introduced in https://github.com/azerothcore/azerothcore-wotlk/commit/e74adf550e778bbbf182e1f4ef95ba2acb67fa19

---

## Feature Evaluation

---

## How to Test the Changes

- run server with default bots amount without changes and should crashed
- run server with default bots amount with changes and should run normally

## Complexity & Impact

Does this change add new decision branches?
- - [x] No
- - [ ] Yes (**explain below**)

Does this change increase per-bot or per-tick processing?
- - [x] No
- - [ ] Yes (**describe and justify impact**)

Could this logic scale poorly under load?
- - [x] No
- - [ ] Yes (**explain why**)
---

## Defaults & Configuration

Does this change modify default bot behavior?
- - [x] No
- - [ ] Yes (**explain why**)

If this introduces more advanced or AI-heavy logic:
- - [x] Lightweight mode remains the default
- - [x] More complex behavior is optional and thereby configurable
---

## AI Assistance

Was AI assistance (e.g. ChatGPT or similar tools) used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Used Copilot Cli to find crash reason.

---

## Final Checklist

- - [x] Stability is not compromised
- - [x] Performance impact is understood, tested, and acceptable
- - [x] Added logic complexity is justified and explained
- - [x] Documentation updated if needed

---