### PR TITLE
fix: ByteBufferException error (opcode: 149)

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1119,6 +1119,9 @@ void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)
                 if (guid1.IsEmpty() || p.size() > p.DEFAULT_SIZE)
                     return;
 
+                if (lang == LANG_ADDON)
+                        return;
+
                 if (p.GetOpcode() == SMSG_GM_MESSAGECHAT)
                 {
                     p >> textLen;
@@ -1167,8 +1170,6 @@ void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)
                         return;
 
                     if (HasRealPlayerMaster() && guid1 != GetMaster()->GetGUID())
-                        return;
-                    if (lang == LANG_ADDON)
                         return;
 
                     if (message.starts_with(sPlayerbotAIConfig.toxicLinksPrefix) &&


### PR DESCRIPTION
Fixes #2204 

## Pull Request Description
Fixes an opcode 149 ByteBufferException when Questie-335 (or other addons that send addon messages) is used in a party with Playerbots.

The issue was caused by addon-language packets reaching parsing logic they should not have reached. This change adjusts the early return for `LANG_ADDON` packets before further handling.

## Feature Evaluation
- Describe the **minimum logic** required to achieve the intended behavior.
  - Moved the early return for `LANG_ADDON` packets in the outgoing packet handler.

- Describe the **processing cost** when this logic executes across many bots.
  - Negligible. It's a simple conditional check with an early return.

## How to Test the Changes
1. Install and enable Questie-335.
2. Invite at least 1 Playerbot to a party.
3. Accept a quest, abandon a quest, or progress a quest objective such as kill credit or looting a quest item.
4. Verify the worldserver no longer logs opcode 149 ByteBufferException errors.

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - [x] No, not at all
    - [ ] Minimal impact (**explain below**)
    - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - [x] No
    - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - [x] No
    - [ ] Yes (**explain below**)

## Messages to Translate
Does this change add bot messages to translate?
- [x] No
- [ ] Yes (**list messages in the table**)

| Message key  | Default message |
| --------------- | ------------------ |
|			 |			      |
|			 |			      |

## AI Assistance
Was AI assistance used while working on this change?
- [x] No
- [ ] Yes (**explain below**)

## Final Checklist

- [x] Stability is not compromised.
- [x] Performance impact is understood, tested, and acceptable.
- [x] Added logic complexity is justified and explained.
- [ ] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
This is a small fix intended only to prevent addon language packets from reaching incompatible packet parsing logic.