### PR TITLE
Add default case to mount initialization for bots.

### DIFF
--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -3039,8 +3039,10 @@ void PlayerbotFactory::InitMounts()
                 fast = {23228, 23227, 23229};
             }
             else // Human mounts
-            slow = {6654, 6653, 580};
-            fast = {23250, 23252, 23251};
+            {
+                slow = {6654, 6653, 580};
+                fast = {23250, 23252, 23251};
+            }
     }
 
     switch (bot->GetTeamId())

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -3032,6 +3032,15 @@ void PlayerbotFactory::InitMounts()
             slow = {33660, 35020, 35022, 35018};
             fast = {35025, 35025, 35027};
             break;
+        default:
+            if (bot->GetTeamId() == TEAM_HORDE)
+            { // Orc mounts
+                slow = {470, 6648, 458, 472};
+                fast = {23228, 23227, 23229};
+            }
+            else // Human mounts
+            slow = {6654, 6653, 580};
+            fast = {23250, 23252, 23251};
     }
 
     switch (bot->GetTeamId())


### PR DESCRIPTION
## Pull Request Description
<!-- Describe what this change does and why it is needed -->
This PR adds a default case for the mount initialization function for player bots, allowing custom race additions to not crash when added to an AzerothCore server (such as [`mod-worgoblin`](https://github.com/heyitsbench/mod-worgoblin)).

## Feature Evaluation
This feature ideally does not get touched in standard `mod-playerbots` usage, as it only adds a case to a switch statement, and would not be getting taken with Blizzlike data (which the vast majority of users likely use).

## How to Test the Changes
1. Add custom races to your AzerothCore instance (most easily accomplished with the above linked module).
2. Start the server and configure it to create random player bots (that fall under the added custom races).
3. Observe no crash.

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [X] No, not at all

- Does this change modify default bot behavior?
    - - [X] No

- Does this change add new decision branches or increase maintenance complexity?
    - - [X] Yes (**explain below**)
This does add another path in a switch statement. It also creates another set of data for that case. This could have been avoided by consolidating the human/orc cases into the default case, but I elected not to do that in case players make their own changes. If preferred, I can definitely consolidate the cases to not have those redundant data points.

## Messages to Translate
- Does this change add bot messages to translate?
    - - [X] No

## AI Assistance
- Was AI assistance used while working on this change?
    - - [X] No

## Final Checklist
- - [X] Stability is not compromised.
- - [X] Performance impact is understood, tested, and acceptable.
- - [X] Added logic complexity is justified and explained.
- - [ ] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
Pretty please? 🥹