### PR TITLE
Feat: Reintroduce timed logouts

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -243,9 +243,21 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
         nextAICheckDelay = 0;
 
     // Early return if bot is in invalid state
-    if (!bot || !bot->GetSession() || !bot->IsInWorld() || bot->IsBeingTeleported() ||
-        bot->GetSession()->isLogingOut() || bot->IsDuringRemoveFromWorld())
+    if (!bot || !bot->GetSession() || !bot->IsInWorld() || bot->IsBeingTeleported() || bot->IsDuringRemoveFromWorld())
         return;
+
+    // During timed logout countdown, cancel if bot enters combat (this cancellation is handled client-side for real players).
+    if (bot->GetSession()->isLogingOut())
+    {
+        bool canLogoutInCombat = bot->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);
+        if (bot->IsInCombat() && !canLogoutInCombat)
+        {
+            WorldPackets::Character::LogoutCancel cancelData = WorldPacket(CMSG_LOGOUT_CANCEL);
+            bot->GetSession()->HandleLogoutCancelOpcode(cancelData);
+        }
+        else
+            return;
+    }
 
     // Handle cheat options (set bot health and power if cheats are enabled)
     if (bot->IsAlive() &&
@@ -688,30 +700,9 @@ void PlayerbotAI::HandleCommand(uint32 type, const std::string& text, Player& fr
         Reset(true);
     }
 
-    // TODO: missing implementation to port
-    /*else if (filtered == "logout")
-    {
-        if (!(bot->IsStunnedByLogout() || bot->GetSession()->isLogingOut()))
-        {
-            if (type == CHAT_MSG_WHISPER)
-                TellPlayer(&fromPlayer, BOT_TEXT("logout_start"));
-
-            if (master && master->GetPlayerbotMgr())
-                SetShouldLogOut(true);
-        }
-    }
-    else if (filtered == "logout cancel")
-    {
-        if (bot->IsStunnedByLogout() || bot->GetSession()->isLogingOut())
-        {
-            if (type == CHAT_MSG_WHISPER)
-                TellPlayer(&fromPlayer, BOT_TEXT("logout_cancel"));
-
-            WorldPacket p;
-            bot->GetSession()->HandleLogoutCancelOpcode(p);
-            SetShouldLogOut(false);
-        }
-    }
+    // Commented-out logout commands blocks removed from here and implemented in HandleCommand.
+    // Remaining is a commented-out action delay command block.
+    /*
     else if ((filtered.size() > 5) && (filtered.substr(0, 5) == "wait ") && (filtered.find("wait for attack") ==
     std::string::npos))
     {
@@ -1057,7 +1048,7 @@ void PlayerbotAI::HandleCommand(uint32 type, std::string const text, Player* fro
             TellMaster(message);
         }
     }
-    else if (filtered == "logout cancel")
+    else if (filtered == "cancel logout" || filtered == "logout cancel")
     {
         if (!bot->GetSession()->isLogingOut())
             return;
@@ -1073,9 +1064,7 @@ void PlayerbotAI::HandleCommand(uint32 type, std::string const text, Player* fro
         bot->GetSession()->HandleLogoutCancelOpcode(data);
     }
     else
-    {
         chatCommands.push_back(ChatCommandHolder(filtered, fromPlayer, type));
-    }
 }
 
 void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -293,6 +293,11 @@ void PlayerbotHolder::LogoutAllBots()
         if (!botAI || botAI->IsRealPlayer())
             continue;
 
+        // If bot is mid-countdown, cancel the timer so LogoutPlayerBot proceeds immediately.
+        WorldSession* session = bot->GetSession();
+        if (session && session->isLogingOut())
+            session->SetLogoutStartTime(0);
+
         LogoutPlayerBot(bot->GetGUID());
     }
 }
@@ -355,17 +360,26 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         WorldSession* botWorldSessionPtr = bot->GetSession();
         WorldSession* masterWorldSessionPtr = nullptr;
 
+        // If already in timed logout countdown, complete it once the 20-second timer expires.
         if (botWorldSessionPtr->isLogingOut())
+        {
+            if (botWorldSessionPtr->ShouldLogOut(time(nullptr)))
+            {
+                std::string message = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                    "goodbye", "Goodbye!", {});
+                botAI->TellMaster(message);
+                RemoveFromPlayerbotsMap(guid);
+                botWorldSessionPtr->LogoutPlayer(true);
+                delete botWorldSessionPtr;
+            }
             return;
+        }
 
         Player* master = botAI->GetMaster();
         if (master)
             masterWorldSessionPtr = master->GetSession();
 
-        // TODO: Review whether or not to implement timed logout.
-        // Unused block. Useful only for timed logout.
-/*
-        // check for instant logout
+        // Instant logout checking:
         bool logout = botWorldSessionPtr->ShouldLogOut(time(nullptr));
 
         if (masterWorldSessionPtr && masterWorldSessionPtr->ShouldLogOut(time(nullptr)))
@@ -374,17 +388,30 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         if (masterWorldSessionPtr && !masterWorldSessionPtr->GetPlayer())
             logout = true;
 
-        if (bot->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || bot->HasUnitState(UNIT_STATE_IN_FLIGHT) ||
-            botWorldSessionPtr->GetSecurity() >= (AccountTypes)sWorld->getIntConfig(CONFIG_INSTANT_LOGOUT))
+        // Master's socket is already gone (EXIT GAME -> EXIT NOW is the most typical cause).
+        // Force instant logout. Without this, the bot restarts its 20-second countdown and fires LogoutPlayer() 20 seconds
+        // after the master's Player object has been deleted, causing the bot's logout to crash on the now deleted master.
+        if (masterWorldSessionPtr && masterWorldSessionPtr->IsSocketClosed())
             logout = true;
 
+        if (bot->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
+            logout = true;
+
+        // If the bot's master has security clearance for `InstantLogout` in worldserver.conf, so does the bot.
         if (master &&
             (master->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || master->HasUnitState(UNIT_STATE_IN_FLIGHT) ||
              (masterWorldSessionPtr &&
               masterWorldSessionPtr->GetSecurity() >= (AccountTypes)sWorld->getIntConfig(CONFIG_INSTANT_LOGOUT))))
             logout = true;
-*/
-        // Instant logout (the only option right now)
+
+        if (!logout)
+        {
+            // Start the 20-second logout countdown. CancelLogout() can interrupt this.
+            WorldPackets::Character::LogoutRequest data = WorldPacket(CMSG_LOGOUT_REQUEST);
+            botWorldSessionPtr->HandleLogoutRequestOpcode(data);
+            return;
+        }
+
         {
             std::string message = PlayerbotTextMgr::instance().GetBotTextOrDefault(
                 "goodbye", "Goodbye!", {});
@@ -1472,6 +1499,15 @@ void PlayerbotMgr::UpdateAIInternal(uint32 elapsed, bool /*minimal*/)
 {
     SetNextCheckDelay(sPlayerbotAIConfig.reactDelay);
     CheckTellErrors(elapsed);
+
+    // Complete timed logouts for added bots once the 20-second countdown has elapsed.
+    std::vector<ObjectGuid> expiredLogouts;
+    for (auto const& [botGuid, bot] : playerBots)
+        if (bot && bot->GetSession() && bot->GetSession()->ShouldLogOut(time(nullptr)))
+            expiredLogouts.push_back(botGuid);
+
+    for (ObjectGuid const& guid : expiredLogouts)
+        LogoutPlayerBot(guid);
 }
 
 void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -380,29 +380,21 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
             masterWorldSessionPtr = master->GetSession();
 
         // Instant logout checking:
-        bool logout = botWorldSessionPtr->ShouldLogOut(time(nullptr));
-
-        if (masterWorldSessionPtr && masterWorldSessionPtr->ShouldLogOut(time(nullptr)))
-            logout = true;
-
-        if (masterWorldSessionPtr && !masterWorldSessionPtr->GetPlayer())
-            logout = true;
-
-        // Master's socket is already gone (EXIT GAME -> EXIT NOW is the most typical cause).
-        // Force instant logout. Without this, the bot restarts its 20-second countdown and fires LogoutPlayer() 20 seconds
-        // after the master's Player object has been deleted, causing the bot's logout to crash on the now deleted master.
-        if (masterWorldSessionPtr && masterWorldSessionPtr->IsSocketClosed())
-            logout = true;
-
-        if (bot->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
-            logout = true;
-
-        // If the bot's master has security clearance for `InstantLogout` in worldserver.conf, so does the bot.
-        if (master &&
-            (master->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || master->HasUnitState(UNIT_STATE_IN_FLIGHT) ||
-             (masterWorldSessionPtr &&
-              masterWorldSessionPtr->GetSecurity() >= (AccountTypes)sWorld->getIntConfig(CONFIG_INSTANT_LOGOUT))))
-            logout = true;
+        bool logout =
+            bot->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) ||
+            bot->HasUnitState(UNIT_STATE_IN_FLIGHT) ||
+            (masterWorldSessionPtr && !masterWorldSessionPtr->GetPlayer()) ||
+            // Master's socket is already gone (EXIT GAME -> EXIT NOW is the most typical cause).
+            // Force instant logout. Without this, the bot restarts its 20-second countdown and fires LogoutPlayer() 20 seconds
+            // after the master's Player object has been deleted, causing the bot's logout to crash on the now deleted master.
+            (masterWorldSessionPtr && masterWorldSessionPtr->IsSocketClosed()) ||
+            (masterWorldSessionPtr && masterWorldSessionPtr->ShouldLogOut(time(nullptr))) ||
+            // If the bot's master has security clearance for `InstantLogout` in worldserver.conf, so does the bot.
+            (master &&
+                (master->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) ||
+                 master->HasUnitState(UNIT_STATE_IN_FLIGHT) ||
+                 (masterWorldSessionPtr &&
+                  masterWorldSessionPtr->GetSecurity() >= (AccountTypes)sWorld->getIntConfig(CONFIG_INSTANT_LOGOUT))));
 
         if (!logout)
         {


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Timed logouts was enabled in the past, but was disabled due to a misdiagnosis on an issue that caused crashes. That issue was better understood and resolved in #2131. Now timed logouts are reintroduced for alt-bots and addclass-bots. As before, random-bots do not and should not accept logout commands.

Note that if the bot's master has instant logout privileges according to `InstantLogout` in worldserver.conf, so would the bot. If not, neither would the bot.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Feature at minimum logic needed to implement. No measurable processing cost.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Have your account gmlevel set to 2 in acore_auth>account_access just to test how it works with security parameters.
2. Set `InstantLogout = 3` in worldserver.conf.
3. Invite an addclass or alt-bot.
4. Bot should logout if whispered "logout" to or if you logout.
5. If not in a resting place, neither you nor the bot should be able to instant logout according to the security setting.
6. After the bot logout, log it back in and whisper "logout" again, but right after whisper "cancel logout" or "logout cancel". That should cancel the logout.
7. Have your account gmlevel set to 3 in acore_auth>account_access. (when you change your gmlevel, you need to log out of your account for the change to take effect)
8. You are now at admin gmlevel, and with  `InstantLogout = 3`, you and any bot under your command should be able to logout instantly.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)
Bots now trigger instant or timed logout under the same circumstances that would apply to their master.


- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)
Checks if bot is eligible for instant logout or not. If not, timed logout applies to them.


## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->
While testing this I was having some odd issues with the command `account set gmlevel`. Not sure what's going on there, but for purposes of testing this and changing your account security level, doing it directly in the DB at "acore_auth>account_access" is going to be most reliable.

