### PR TITLE
Druid - lifebloom

### DIFF
--- a/src/Ai/Class/Druid/Action/DruidActions.cpp
+++ b/src/Ai/Class/Druid/Action/DruidActions.cpp
@@ -23,6 +23,16 @@ std::vector<NextAction> CastAbolishPoisonOnPartyAction::getAlternatives()
                              CastSpellAction::getPrerequisites());
 }
 
+bool CastLifebloomOnMainTankAction::isUseful()
+{
+    Unit* target = GetTarget();
+    if (!target || !target->IsAlive() || !CastSpellAction::isUseful())
+        return false;
+
+    Aura* lifebloom = botAI->GetAura("lifebloom", target, true, true);
+    return !lifebloom || lifebloom->GetStackAmount() < 3 || lifebloom->GetDuration() < 2000;
+}
+
 Value<Unit*>* CastEntanglingRootsCcAction::GetTargetValue()
 {
     return context->GetValue<Unit*>("cc target", "entangling roots");

--- a/src/Ai/Class/Druid/Action/DruidActions.h
+++ b/src/Ai/Class/Druid/Action/DruidActions.h
@@ -128,6 +128,14 @@ public:
     CastThornsOnMainTankAction(PlayerbotAI* botAI) : BuffOnMainTankAction(botAI, "thorns", false) {}
 };
 
+class CastLifebloomOnMainTankAction : public BuffOnMainTankAction
+{
+public:
+    CastLifebloomOnMainTankAction(PlayerbotAI* botAI) : BuffOnMainTankAction(botAI, "lifebloom", true) {}
+
+    bool isUseful() override;
+};
+
 class CastOmenOfClarityAction : public CastBuffSpellAction
 {
 public:

--- a/src/Ai/Class/Druid/DruidAiObjectContext.cpp
+++ b/src/Ai/Class/Druid/DruidAiObjectContext.cpp
@@ -79,6 +79,7 @@ public:
     DruidTriggerFactoryInternal()
     {
         creators["omen of clarity"] = &DruidTriggerFactoryInternal::omen_of_clarity;
+        creators["clearcasting"] = &DruidTriggerFactoryInternal::clearcasting;
         creators["thorns"] = &DruidTriggerFactoryInternal::thorns;
         creators["thorns on party"] = &DruidTriggerFactoryInternal::thorns_on_party;
         creators["thorns on main tank"] = &DruidTriggerFactoryInternal::thorns_on_main_tank;
@@ -117,6 +118,7 @@ public:
 
 private:
     static Trigger* natures_swiftness(PlayerbotAI* botAI) { return new NaturesSwiftnessTrigger(botAI); }
+    static Trigger* clearcasting(PlayerbotAI* botAI) { return new ClearcastingTrigger(botAI); }
     static Trigger* eclipse_solar(PlayerbotAI* botAI) { return new EclipseSolarTrigger(botAI); }
     static Trigger* eclipse_lunar(PlayerbotAI* botAI) { return new EclipseLunarTrigger(botAI); }
     static Trigger* thorns(PlayerbotAI* botAI) { return new ThornsTrigger(botAI); }
@@ -208,6 +210,7 @@ public:
         creators["thorns"] = &DruidAiObjectContextInternal::thorns;
         creators["thorns on party"] = &DruidAiObjectContextInternal::thorns_on_party;
         creators["thorns on main tank"] = &DruidAiObjectContextInternal::thorns_on_main_tank;
+        creators["lifebloom on main tank"] = &DruidAiObjectContextInternal::lifebloom_on_main_tank;
         creators["cure poison"] = &DruidAiObjectContextInternal::cure_poison;
         creators["cure poison on party"] = &DruidAiObjectContextInternal::cure_poison_on_party;
         creators["abolish poison"] = &DruidAiObjectContextInternal::abolish_poison;
@@ -302,6 +305,7 @@ private:
     static Action* thorns(PlayerbotAI* botAI) { return new CastThornsAction(botAI); }
     static Action* thorns_on_party(PlayerbotAI* botAI) { return new CastThornsOnPartyAction(botAI); }
     static Action* thorns_on_main_tank(PlayerbotAI* botAI) { return new CastThornsOnMainTankAction(botAI); }
+    static Action* lifebloom_on_main_tank(PlayerbotAI* botAI) { return new CastLifebloomOnMainTankAction(botAI); }
     static Action* cure_poison(PlayerbotAI* botAI) { return new CastCurePoisonAction(botAI); }
     static Action* cure_poison_on_party(PlayerbotAI* botAI) { return new CastCurePoisonOnPartyAction(botAI); }
     static Action* abolish_poison(PlayerbotAI* botAI) { return new CastAbolishPoisonAction(botAI); }

--- a/src/Ai/Class/Druid/Strategy/HealDruidStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/HealDruidStrategy.cpp
@@ -56,6 +56,9 @@ void HealDruidStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode("party member critical health",
                         { NextAction("nature's swiftness", ACTION_CRITICAL_HEAL + 4) }));
 
+    triggers.push_back(new TriggerNode("clearcasting",
+        { NextAction("lifebloom on main tank", ACTION_CRITICAL_HEAL - 1) }));
+
     triggers.push_back(new TriggerNode(
         "group heal setting",
         {

--- a/src/Ai/Class/Druid/Trigger/DruidTriggers.h
+++ b/src/Ai/Class/Druid/Trigger/DruidTriggers.h
@@ -61,6 +61,12 @@ public:
     OmenOfClarityTrigger(PlayerbotAI* botAI) : BuffTrigger(botAI, "omen of clarity") {}
 };
 
+class ClearcastingTrigger : public HasAuraTrigger
+{
+public:
+    ClearcastingTrigger(PlayerbotAI* botAI) : HasAuraTrigger(botAI, "clearcasting") {}
+};
+
 class RakeTrigger : public DebuffTrigger
 {
 public:


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Restoration Druid now use lifebloom when get Clearcasting proc.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Invite to group restoration druid and tank
2. Attack target (for example dummy)
3. When druid heals and get clearcasting should cast lifebloom on tank

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Restoration druid by default use lifebloom on tank when got clearcasting proc.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Copilot CLI to review.


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

<img width="728" height="268" alt="obraz" src="https://github.com/user-attachments/assets/25bf2b22-d8e5-4755-9f44-d24246cceae2" />
<img width="506" height="196" alt="obraz" src="https://github.com/user-attachments/assets/f4e4897c-496a-412f-bde7-a88f15d9099c" />


