### PR TITLE
Bug(self-bot): Self-bot should face target when using ranged or melee attack

### DIFF
--- a/src/Util/ServerFacade.cpp
+++ b/src/Util/ServerFacade.cpp
@@ -53,8 +53,7 @@ void ServerFacade::SetFacingTo(Player* bot, WorldObject* wo, bool force)
     bot->SetOrientation(angle);
 
     if (!bot->IsRooted())
-        bot->SendMovementFlagUpdate();
-    // }
+        bot->SendMovementFlagUpdate(true);
 }
 
 Unit* ServerFacade::GetChaseTarget(Unit* target)

--- a/src/Util/ServerFacade.cpp
+++ b/src/Util/ServerFacade.cpp
@@ -53,6 +53,8 @@ void ServerFacade::SetFacingTo(Player* bot, WorldObject* wo, bool force)
     bot->SetOrientation(angle);
 
     if (!bot->IsRooted())
+        // enforce (bool self) true otherwhise when using real-client with self-bot wont
+        // recieve update; e.g. will not face the target when using ranged attack
         bot->SendMovementFlagUpdate(true);
 }
 

--- a/src/Util/ServerFacade.cpp
+++ b/src/Util/ServerFacade.cpp
@@ -54,7 +54,7 @@ void ServerFacade::SetFacingTo(Player* bot, WorldObject* wo, bool force)
 
     if (!bot->IsRooted())
         // enforce (bool self) true otherwhise when using real-client with self-bot wont
-        // recieve update; e.g. will not face the target when using ranged attack
+        // recieve update; e.g. will not face the target when using (mostly ranged) attack
         bot->SendMovementFlagUpdate(true);
 }
 


### PR DESCRIPTION

## Pull Request Description

Currently when using self-bot and that self-bot is using ranged attacks its not facing the target, this happens because the client doesnt receive the instruction in Player::SendMessageToSet(WorldPacket const* data, bool self);

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Create new character with uses range attack as base attack (hunter, mage, druid etc) and observe. Apply patch and observe your self-bot character is now always facing towards the target.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


