### PR TITLE
Stat weights fix

### DIFF
--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -25,6 +25,10 @@ namespace
 constexpr uint32 SPELL_MOLTEN_ARMOR_RANK_1 = 30482;
 constexpr uint32 SPELL_MOLTEN_ARMOR_RANK_2 = 43045;
 constexpr uint32 SPELL_MOLTEN_ARMOR_RANK_3 = 43046;
+constexpr uint32 SPELL_FEL_ARMOR_RANK_1 = 28176;
+constexpr uint32 SPELL_FEL_ARMOR_RANK_2 = 28189;
+constexpr uint32 SPELL_FEL_ARMOR_RANK_3 = 47892;
+constexpr uint32 SPELL_FEL_ARMOR_RANK_4 = 47893;
 }
 
 StatsWeightCalculator::StatsWeightCalculator(Player* player) : player_(player)
@@ -469,6 +473,15 @@ void StatsWeightCalculator::GenerateAdditionalWeights(Player* player)
         {
             stats_weights_[STATS_TYPE_INTELLECT] += 0.2f;
             stats_weights_[STATS_TYPE_SPIRIT] -= 0.0f;
+        }
+    }
+    else if (cls == CLASS_WARLOCK)
+    {
+        if (!player->HasSpell(SPELL_FEL_ARMOR_RANK_1) && !player->HasSpell(SPELL_FEL_ARMOR_RANK_2) &&
+            !player->HasSpell(SPELL_FEL_ARMOR_RANK_3) && !player->HasSpell(SPELL_FEL_ARMOR_RANK_4))
+        {
+            stats_weights_[STATS_TYPE_INTELLECT] += 0.2f;
+            stats_weights_[STATS_TYPE_SPIRIT] -= 0.2f;
         }
     }
 }

--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -471,18 +471,17 @@ void StatsWeightCalculator::GenerateAdditionalWeights(Player* player)
             && !player->HasSpell(SPELL_MOLTEN_ARMOR_RANK_2)
             && !player->HasSpell(SPELL_MOLTEN_ARMOR_RANK_3))
         {
-            stats_weights_[STATS_TYPE_INTELLECT] += 0.2f;
-            stats_weights_[STATS_TYPE_SPIRIT] -= 0.0f;
+            if (tab != MAGE_TAB_FIRE)
+                stats_weights_[STATS_TYPE_SPIRIT] -= 0.6f;
+            else
+                stats_weights_[STATS_TYPE_SPIRIT] -= 0.7f;
         }
     }
     else if (cls == CLASS_WARLOCK)
     {
         if (!player->HasSpell(SPELL_FEL_ARMOR_RANK_1) && !player->HasSpell(SPELL_FEL_ARMOR_RANK_2) &&
             !player->HasSpell(SPELL_FEL_ARMOR_RANK_3) && !player->HasSpell(SPELL_FEL_ARMOR_RANK_4))
-        {
-            stats_weights_[STATS_TYPE_INTELLECT] += 0.2f;
-            stats_weights_[STATS_TYPE_SPIRIT] -= 0.2f;
-        }
+            stats_weights_[STATS_TYPE_SPIRIT] -= 0.4f;
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Added support for Warlock stat weights when he dont have Fel Armor.
Fixed Mage weights when he dont have Molten Armor

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Invite mage which dont have Molten Armor (level < 62) or warlock which dont have Fel Armor (level < 62)
2. Give him 2 items for same slot one with spirit one with intellect and unequip item on this slot and destroy
3. Bot should equip this with intellect (if other stats are same)

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

Mage and Warlock before getting Molten Armor/Fel Armor dont prioritize Spirit before Intellect

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


