### PR TITLE
PvP Gear, Autogear Tuning, and Stat Weight Corrections

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -806,6 +806,53 @@ AiPlayerbot.RandomGearQualityLimit = 3
 # Default: 0 (no limit)
 AiPlayerbot.RandomGearScoreLimit = 0
 
+# Prefer armor of the class's ideal type: apply 3x score multiplier to class-appropriate armor.
+# When enabled, Warriors strongly prefer plate, Shamans prefer mail, etc.
+# A truly superior item can still win (no hard filtering), but same-quality
+# armor of the preferred type will score 3x higher and be equipped instead.
+#
+# ARMOR TYPE PREFERENCES:
+#   Plate:  Warriors, Paladins, Death Knights
+#   Mail:   Hunters, Shamans
+#   Leather: Rogues, Druids
+#   Cloth:  Priests, Mages, Warlocks
+#
+# Default: 0 (disabled)
+AiPlayerbot.PreferClassArmorType = 0
+
+# Allow autogear to equip items from quest rewards
+# Quest rewards are available based on the quest's minimum level requirement
+# When enabled, bots can equip suitable armor and weapons from quest rewards during autogear
+# Default: 0 (disabled)
+AiPlayerbot.AutogearAllowsQuestRewards = 0
+
+# Bypass low-level slot restrictions during autogear.
+# Normally, certain equipment slots are locked until the bot reaches a minimum level:
+#   Trinkets: level 50+
+#   Head / Neck: level 30+
+#   Rings: level 20+
+#   All other non-weapon slots: level 5+
+# When enabled, bots equip all slots regardless of level.
+# Default: 0 (disabled)
+AiPlayerbot.EquipAllSlotsAtAnyLevel = 0
+
+# Apply weapon speed governance during autogear item scoring.
+# When enabled, gives a 3x score multiplier to weapons matching the spec's preferred speed profile:
+#   Arms Warrior:                                      Slow 2H (>=3400ms) in mainhand; poleaxes and axes preferred (Axe Specialization)
+#   Ret Paladin / Blood & Unholy DK:                   Slow 2H (>=3400ms) in mainhand
+#   Prot Warrior & Paladin:                            Slow 1H (>=2600ms) in mainhand
+#   Fury Warrior SMF:                                  Slow 1H (>=2600ms) in both hands
+#   Fury Warrior TG:                                   Slow 2H (>=3400ms) in both hands
+#   Frost DK:                                          Slow 1H (>=2600ms) in both hands; 2H excluded
+#   Enhancement Shaman (DW):                           Slow 1H (>=2600ms) in both hands; synchronized MH/OH speeds get an additional bonus
+#   Enhancement Shaman (pre-DW):                       Slow 2H (>=3400ms) in mainhand
+#   Combat Rogue:                                      Slow MH (>=2600ms) + Fast OH (<=1500ms)
+#   Assassination / Subtlety Rogue:                    Slow dagger MH (>=1700ms) + Fast dagger OH (<=1500ms)
+#   Hunter:                                            Slow ranged (>=2600ms); melee is a stat stick, speed ignored
+#   Feral Druid:                                       No preference (forms normalize attack speed)
+# Default: 0 (disabled)
+AiPlayerbot.WeaponSpeedGovernance = 0
+
 # If disabled, random bots can only upgrade equipment through looting and quests
 # Default: 1 (enabled)
 AiPlayerbot.IncrementalGearInit = 1
@@ -1836,12 +1883,24 @@ AiPlayerbot.WorldBuffMatrix = # WARRIOR ARMS 1:0,1,0,80,80:53760,57358; # WARRIO
 #
 #
 
+# arms pve
 AiPlayerbot.RandomClassSpecProb.1.0 = 20
 AiPlayerbot.RandomClassSpecIndex.1.0 = 0
+# fury pve
 AiPlayerbot.RandomClassSpecProb.1.1 = 40
 AiPlayerbot.RandomClassSpecIndex.1.1 = 1
+# prot pve
 AiPlayerbot.RandomClassSpecProb.1.2 = 40
 AiPlayerbot.RandomClassSpecIndex.1.2 = 2
+# arms pvp
+AiPlayerbot.RandomClassSpecProb.1.3 = 0
+AiPlayerbot.RandomClassSpecIndex.1.3 = 3
+# fury pvp
+AiPlayerbot.RandomClassSpecProb.1.4 = 0
+AiPlayerbot.RandomClassSpecIndex.1.4 = 4
+# prot pvp
+AiPlayerbot.RandomClassSpecProb.1.5 = 0
+AiPlayerbot.RandomClassSpecIndex.1.5 = 5
 
 #
 #
@@ -1853,12 +1912,24 @@ AiPlayerbot.RandomClassSpecIndex.1.2 = 2
 #
 #
 
+# holy pve
 AiPlayerbot.RandomClassSpecProb.2.0 = 30
 AiPlayerbot.RandomClassSpecIndex.2.0 = 0
+# prot pve
 AiPlayerbot.RandomClassSpecProb.2.1 = 40
 AiPlayerbot.RandomClassSpecIndex.2.1 = 1
+# ret pve
 AiPlayerbot.RandomClassSpecProb.2.2 = 30
 AiPlayerbot.RandomClassSpecIndex.2.2 = 2
+# holy pvp
+AiPlayerbot.RandomClassSpecProb.2.3 = 0
+AiPlayerbot.RandomClassSpecIndex.2.3 = 3
+# prot pvp
+AiPlayerbot.RandomClassSpecProb.2.4 = 0
+AiPlayerbot.RandomClassSpecIndex.2.4 = 4
+# ret pvp
+AiPlayerbot.RandomClassSpecProb.2.5 = 0
+AiPlayerbot.RandomClassSpecIndex.2.5 = 5
 
 #
 #
@@ -1870,12 +1941,24 @@ AiPlayerbot.RandomClassSpecIndex.2.2 = 2
 #
 #
 
+# bm pve
 AiPlayerbot.RandomClassSpecProb.3.0 = 33
 AiPlayerbot.RandomClassSpecIndex.3.0 = 0
+# mm pve
 AiPlayerbot.RandomClassSpecProb.3.1 = 33
 AiPlayerbot.RandomClassSpecIndex.3.1 = 1
+# surv pve
 AiPlayerbot.RandomClassSpecProb.3.2 = 33
 AiPlayerbot.RandomClassSpecIndex.3.2 = 2
+# bm pvp
+AiPlayerbot.RandomClassSpecProb.3.3 = 0
+AiPlayerbot.RandomClassSpecIndex.3.3 = 3
+# mm pvp
+AiPlayerbot.RandomClassSpecProb.3.4 = 0
+AiPlayerbot.RandomClassSpecIndex.3.4 = 4
+# surv pvp
+AiPlayerbot.RandomClassSpecProb.3.5 = 0
+AiPlayerbot.RandomClassSpecIndex.3.5 = 5
 
 #
 #
@@ -1887,12 +1970,24 @@ AiPlayerbot.RandomClassSpecIndex.3.2 = 2
 #
 #
 
+# as pve
 AiPlayerbot.RandomClassSpecProb.4.0 = 45
 AiPlayerbot.RandomClassSpecIndex.4.0 = 0
+# combat pve
 AiPlayerbot.RandomClassSpecProb.4.1 = 45
 AiPlayerbot.RandomClassSpecIndex.4.1 = 1
+# subtlety pve
 AiPlayerbot.RandomClassSpecProb.4.2 = 10
 AiPlayerbot.RandomClassSpecIndex.4.2 = 2
+# as pvp
+AiPlayerbot.RandomClassSpecProb.4.3 = 0
+AiPlayerbot.RandomClassSpecIndex.4.3 = 3
+# combat pvp
+AiPlayerbot.RandomClassSpecProb.4.4 = 0
+AiPlayerbot.RandomClassSpecIndex.4.4 = 4
+# subtlety pvp
+AiPlayerbot.RandomClassSpecProb.4.5 = 0
+AiPlayerbot.RandomClassSpecIndex.4.5 = 5
 
 #
 #
@@ -1904,12 +1999,24 @@ AiPlayerbot.RandomClassSpecIndex.4.2 = 2
 #
 #
 
+# disc pve
 AiPlayerbot.RandomClassSpecProb.5.0 = 40
 AiPlayerbot.RandomClassSpecIndex.5.0 = 0
+# holy pve
 AiPlayerbot.RandomClassSpecProb.5.1 = 35
 AiPlayerbot.RandomClassSpecIndex.5.1 = 1
+# shadow pve
 AiPlayerbot.RandomClassSpecProb.5.2 = 25
 AiPlayerbot.RandomClassSpecIndex.5.2 = 2
+# disc pvp
+AiPlayerbot.RandomClassSpecProb.5.3 = 0
+AiPlayerbot.RandomClassSpecIndex.5.3 = 3
+# holy pvp
+AiPlayerbot.RandomClassSpecProb.5.4 = 0
+AiPlayerbot.RandomClassSpecIndex.5.4 = 4
+# shadow pvp
+AiPlayerbot.RandomClassSpecProb.5.5 = 0
+AiPlayerbot.RandomClassSpecIndex.5.5 = 5
 
 #
 #
@@ -1921,12 +2028,27 @@ AiPlayerbot.RandomClassSpecIndex.5.2 = 2
 #
 #
 
+# blood pve
 AiPlayerbot.RandomClassSpecProb.6.0 = 30
 AiPlayerbot.RandomClassSpecIndex.6.0 = 0
+# frost pve
 AiPlayerbot.RandomClassSpecProb.6.1 = 40
 AiPlayerbot.RandomClassSpecIndex.6.1 = 1
+# unholy pve
 AiPlayerbot.RandomClassSpecProb.6.2 = 30
 AiPlayerbot.RandomClassSpecIndex.6.2 = 2
+# double aura blood pve
+AiPlayerbot.RandomClassSpecProb.6.3 = 0
+AiPlayerbot.RandomClassSpecIndex.6.3 = 3
+# blood pvp
+AiPlayerbot.RandomClassSpecProb.6.4 = 0
+AiPlayerbot.RandomClassSpecIndex.6.4 = 4
+# frost pvp
+AiPlayerbot.RandomClassSpecProb.6.5 = 0
+AiPlayerbot.RandomClassSpecIndex.6.5 = 5
+# unholy pvp
+AiPlayerbot.RandomClassSpecProb.6.6 = 0
+AiPlayerbot.RandomClassSpecIndex.6.6 = 6
 
 #
 #
@@ -1938,12 +2060,24 @@ AiPlayerbot.RandomClassSpecIndex.6.2 = 2
 #
 #
 
+# ele pve
 AiPlayerbot.RandomClassSpecProb.7.0 = 33
 AiPlayerbot.RandomClassSpecIndex.7.0 = 0
+# enh pve
 AiPlayerbot.RandomClassSpecProb.7.1 = 33
 AiPlayerbot.RandomClassSpecIndex.7.1 = 1
+# resto pve
 AiPlayerbot.RandomClassSpecProb.7.2 = 33
 AiPlayerbot.RandomClassSpecIndex.7.2 = 2
+# ele pvp
+AiPlayerbot.RandomClassSpecProb.7.3 = 0
+AiPlayerbot.RandomClassSpecIndex.7.3 = 3
+# enh pvp
+AiPlayerbot.RandomClassSpecProb.7.4 = 0
+AiPlayerbot.RandomClassSpecIndex.7.4 = 4
+# resto pvp
+AiPlayerbot.RandomClassSpecProb.7.5 = 0
+AiPlayerbot.RandomClassSpecIndex.7.5 = 5
 
 #
 #
@@ -1955,12 +2089,27 @@ AiPlayerbot.RandomClassSpecIndex.7.2 = 2
 #
 #
 
+# arcane pve
 AiPlayerbot.RandomClassSpecProb.8.0 = 30
 AiPlayerbot.RandomClassSpecIndex.8.0 = 0
+# fire pve
 AiPlayerbot.RandomClassSpecProb.8.1 = 30
 AiPlayerbot.RandomClassSpecIndex.8.1 = 1
+# frost pve
 AiPlayerbot.RandomClassSpecProb.8.2 = 40
 AiPlayerbot.RandomClassSpecIndex.8.2 = 2
+# frostfire pve
+AiPlayerbot.RandomClassSpecProb.8.3 = 0
+AiPlayerbot.RandomClassSpecIndex.8.3 = 3
+# arcane pvp
+AiPlayerbot.RandomClassSpecProb.8.4 = 0
+AiPlayerbot.RandomClassSpecIndex.8.4 = 4
+# fire pvp
+AiPlayerbot.RandomClassSpecProb.8.5 = 0
+AiPlayerbot.RandomClassSpecIndex.8.5 = 5
+# frost pvp
+AiPlayerbot.RandomClassSpecProb.8.6 = 0
+AiPlayerbot.RandomClassSpecIndex.8.6 = 6
 
 #
 #
@@ -1972,12 +2121,24 @@ AiPlayerbot.RandomClassSpecIndex.8.2 = 2
 #
 #
 
+# affli pve
 AiPlayerbot.RandomClassSpecProb.9.0 = 33
 AiPlayerbot.RandomClassSpecIndex.9.0 = 0
+# demo pve
 AiPlayerbot.RandomClassSpecProb.9.1 = 34
 AiPlayerbot.RandomClassSpecIndex.9.1 = 1
+# destro pve
 AiPlayerbot.RandomClassSpecProb.9.2 = 33
 AiPlayerbot.RandomClassSpecIndex.9.2 = 2
+# affli pvp
+AiPlayerbot.RandomClassSpecProb.9.3 = 0
+AiPlayerbot.RandomClassSpecIndex.9.3 = 3
+# demo pvp
+AiPlayerbot.RandomClassSpecProb.9.4 = 0
+AiPlayerbot.RandomClassSpecIndex.9.4 = 4
+# destro pvp
+AiPlayerbot.RandomClassSpecProb.9.5 = 0
+AiPlayerbot.RandomClassSpecIndex.9.5 = 5
 
 #
 #
@@ -1989,14 +2150,27 @@ AiPlayerbot.RandomClassSpecIndex.9.2 = 2
 #
 #
 
+# balance pve
 AiPlayerbot.RandomClassSpecProb.11.0 = 20
 AiPlayerbot.RandomClassSpecIndex.11.0 = 0
+# bear pve
 AiPlayerbot.RandomClassSpecProb.11.1 = 25
 AiPlayerbot.RandomClassSpecIndex.11.1 = 1
+# resto pve
 AiPlayerbot.RandomClassSpecProb.11.2 = 35
 AiPlayerbot.RandomClassSpecIndex.11.2 = 2
+# cat pve
 AiPlayerbot.RandomClassSpecProb.11.3 = 20
 AiPlayerbot.RandomClassSpecIndex.11.3 = 3
+# balance pvp
+AiPlayerbot.RandomClassSpecProb.11.4 = 0
+AiPlayerbot.RandomClassSpecIndex.11.4 = 4
+# cat pvp
+AiPlayerbot.RandomClassSpecProb.11.5 = 0
+AiPlayerbot.RandomClassSpecIndex.11.5 = 5
+# resto pvp
+AiPlayerbot.RandomClassSpecProb.11.6 = 0
+AiPlayerbot.RandomClassSpecIndex.11.6 = 6
 
 #
 #

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -820,38 +820,12 @@ AiPlayerbot.RandomGearScoreLimit = 0
 # Default: 0 (disabled)
 AiPlayerbot.PreferClassArmorType = 0
 
-# Allow autogear to equip items from quest rewards
-# Quest rewards are available based on the quest's minimum level requirement
-# When enabled, bots can equip suitable armor and weapons from quest rewards during autogear
-# Default: 0 (disabled)
-AiPlayerbot.AutogearAllowsQuestRewards = 0
 
-# Bypass low-level slot restrictions during autogear.
-# Normally, certain equipment slots are locked until the bot reaches a minimum level:
-#   Trinkets: level 50+
-#   Head / Neck: level 30+
-#   Rings: level 20+
-#   All other non-weapon slots: level 5+
-# When enabled, bots equip all slots regardless of level.
+# When enabled, bots prefer spec-appropriate weapons based on speed and weapon type during autogear.
+# Examples: Arms Warriors favor slow 2H axes/polearms (Axe Specialization), Combat Rogues
+# favor a slow MH with a fast OH, and Enhancement Shamans favor synchronized slow 1H weapons.
 # Default: 0 (disabled)
-AiPlayerbot.EquipAllSlotsAtAnyLevel = 0
-
-# Apply weapon speed governance during autogear item scoring.
-# When enabled, gives a 3x score multiplier to weapons matching the spec's preferred speed profile:
-#   Arms Warrior:                                      Slow 2H (>=3400ms) in mainhand; poleaxes and axes preferred (Axe Specialization)
-#   Ret Paladin / Blood & Unholy DK:                   Slow 2H (>=3400ms) in mainhand
-#   Prot Warrior & Paladin:                            Slow 1H (>=2600ms) in mainhand
-#   Fury Warrior SMF:                                  Slow 1H (>=2600ms) in both hands
-#   Fury Warrior TG:                                   Slow 2H (>=3400ms) in both hands
-#   Frost DK:                                          Slow 1H (>=2600ms) in both hands; 2H excluded
-#   Enhancement Shaman (DW):                           Slow 1H (>=2600ms) in both hands; synchronized MH/OH speeds get an additional bonus
-#   Enhancement Shaman (pre-DW):                       Slow 2H (>=3400ms) in mainhand
-#   Combat Rogue:                                      Slow MH (>=2600ms) + Fast OH (<=1500ms)
-#   Assassination / Subtlety Rogue:                    Slow dagger MH (>=1700ms) + Fast dagger OH (<=1500ms)
-#   Hunter:                                            Slow ranged (>=2600ms); melee is a stat stick, speed ignored
-#   Feral Druid:                                       No preference (forms normalize attack speed)
-# Default: 0 (disabled)
-AiPlayerbot.WeaponSpeedGovernance = 0
+AiPlayerbot.PreferredSpecWeapons = 0
 
 # If disabled, random bots can only upgrade equipment through looting and quests
 # Default: 1 (enabled)

--- a/src/Ai/Base/Value/ItemUsageValue.cpp
+++ b/src/Ai/Base/Value/ItemUsageValue.cpp
@@ -234,6 +234,11 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto, 
     calculator.SetItemSetBonus(false);
     calculator.SetOverflowPenalty(false);
 
+    // Apply PvP weights if the bot is specced for PvP
+    bool isPvp = sRandomPlayerbotMgr.IsSpecPvp(bot->GetGUID().GetCounter(), bot->getClass());
+    if (isPvp)
+        calculator.SetPvpSpec(true);
+
     float itemScore = calculator.CalculateItem(itemProto->ItemId, randomPropertyId);
 
     if (itemScore)

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -60,7 +60,6 @@ std::vector<uint32> PlayerbotFactory::enchantSpellIdCache;
 std::vector<uint32> PlayerbotFactory::enchantGemIdCache;
 std::unordered_map<uint32, std::vector<uint32>> PlayerbotFactory::trainerIdCache;
 std::vector<uint32> PlayerbotFactory::ccBreakTrinketCache;
-std::map<uint32, uint32> PlayerbotFactory::questRewardItemCache;
 
 bool PlayerbotFactory::IsPrimaryTradeSkill(uint16 skillId)
 {
@@ -464,8 +463,6 @@ void PlayerbotFactory::Init()
     LOG_INFO("playerbots", "Loading {} enchantment gems", enchantGemIdCache.size());
 
     BuildCcBreakTrinketCache();
-    if (sPlayerbotAIConfig.autogearAllowsQuestRewards)
-        BuildQuestRewardCache();
 }
 
 void PlayerbotFactory::BuildCcBreakTrinketCache()
@@ -502,58 +499,6 @@ void PlayerbotFactory::BuildCcBreakTrinketCache()
     LOG_INFO("playerbots", "CC-break trinket cache: {} items.", ccBreakTrinketCache.size());
 }
 
-void PlayerbotFactory::BuildQuestRewardCache()
-{
-    questRewardItemCache.clear();
-
-    ObjectMgr::QuestMap const& questTemplates = sObjectMgr->GetQuestTemplates();
-    for (auto& [questId, quest] : questTemplates)
-    {
-        uint32 questLevel = quest->GetMinLevel();
-
-        // Check direct reward items (up to 4)
-        for (uint8 i = 0; i < QUEST_REWARDS_COUNT; i++)
-        {
-            uint32 itemId = quest->RewardItemId[i];
-            if (itemId > 0)
-            {
-                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                if (!proto)
-                    continue;
-
-                // Only cache armor and weapons (equippable items)
-                if (proto->Class != ITEM_CLASS_ARMOR && proto->Class != ITEM_CLASS_WEAPON)
-                    continue;
-
-                // Store the quest's min level as the item's effective level
-                // Only store if not already in cache (keeps first/lowest level quest)
-                if (questRewardItemCache.find(itemId) == questRewardItemCache.end())
-                    questRewardItemCache[itemId] = questLevel;
-            }
-        }
-
-        // Check choice reward items (up to 6)
-        for (uint8 i = 0; i < QUEST_REWARD_CHOICES_COUNT; i++)
-        {
-            uint32 itemId = quest->RewardChoiceItemId[i];
-            if (itemId > 0)
-            {
-                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                if (!proto)
-                    continue;
-
-                // Only cache armor and weapons (equippable items)
-                if (proto->Class != ITEM_CLASS_ARMOR && proto->Class != ITEM_CLASS_WEAPON)
-                    continue;
-
-                if (questRewardItemCache.find(itemId) == questRewardItemCache.end())
-                    questRewardItemCache[itemId] = questLevel;
-            }
-        }
-    }
-
-    LOG_INFO("playerbots", "Quest reward item cache: {} equippable items.", questRewardItemCache.size());
-}
 
 /*static*/ uint8 PlayerbotFactory::GetPreferredArmorType(uint8 cls)
 {
@@ -1936,26 +1881,9 @@ bool PlayerbotFactory::CanEquipItem(ItemTemplate const* proto)
     // disable since bad performance
     bool hasItem = bot->HasItemCount(proto->ItemId, 1, false);
     // bot->GetItemCount()
-    if (!requiredLevel)
-    {
-        // Check if it's a known quest reward in our cache
-        auto it = questRewardItemCache.find(proto->ItemId);
-        if (it != questRewardItemCache.end())
-        {
-            // It's a quest reward - use the quest's min level as the effective required level
-            requiredLevel = it->second;
-        }
-        else if (hasItem)
-        {
-            // Unknown no-level item and bot already has it, skip it
-            return false;
-        }
-        else
-        {
-            // Unknown no-level item and bot doesn't have it, skip it
-            return false;
-        }
-    }
+    // !requiredLevel -> it's a quest reward item
+    if (!requiredLevel && hasItem)
+        return false;
 
     uint32 level = bot->GetLevel();
 
@@ -2194,22 +2122,19 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         if (slot == EQUIPMENT_SLOT_TABARD || slot == EQUIPMENT_SLOT_BODY)
             continue;
 
-        if (!sPlayerbotAIConfig.equipAllSlotsAtAnyLevel)
-        {
-            if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
-                continue;
+        if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
+            continue;
 
-            if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
-                continue;
+        if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
+            continue;
 
-            if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
-                continue;
+        if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
+            continue;
 
-            if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
-                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
-                (slot != EQUIPMENT_SLOT_RANGED))
-                continue;
-        }
+        if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
+            (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
+            (slot != EQUIPMENT_SLOT_RANGED))
+            continue;
 
         // Exclude resilience weighting for trinkets
         bool isTrinketSlot = (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2);
@@ -2397,22 +2322,19 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             if (slot == EQUIPMENT_SLOT_TABARD || slot == EQUIPMENT_SLOT_BODY)
                 continue;
 
-            if (!sPlayerbotAIConfig.equipAllSlotsAtAnyLevel)
-            {
-                if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
-                    continue;
+            if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
+                continue;
 
-                if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
-                    continue;
+            if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
+                continue;
 
-                if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
-                    continue;
+            if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
+                continue;
 
-                if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
-                    (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
-                    (slot != EQUIPMENT_SLOT_RANGED))
-                    continue;
-            }
+            if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
+                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
+                (slot != EQUIPMENT_SLOT_RANGED))
+                continue;
 
             // CC-break trinket was force-equipped in the main pass; leave it alone.
             if (slot == EQUIPMENT_SLOT_TRINKET1 && pvpTrinket1 != 0)

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -499,7 +499,7 @@ void PlayerbotFactory::BuildCcBreakTrinketCache()
     LOG_INFO("playerbots", "CC-break trinket cache: {} items.", ccBreakTrinketCache.size());
 }
 
-/*static*/ uint8 PlayerbotFactory::GetPreferredArmorType(uint8 cls)
+uint8 PlayerbotFactory::GetPreferredArmorType(uint8 cls)
 {
     switch (cls)
     {

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -59,6 +59,8 @@ std::list<uint32> PlayerbotFactory::specialQuestIds;
 std::vector<uint32> PlayerbotFactory::enchantSpellIdCache;
 std::vector<uint32> PlayerbotFactory::enchantGemIdCache;
 std::unordered_map<uint32, std::vector<uint32>> PlayerbotFactory::trainerIdCache;
+std::vector<uint32> PlayerbotFactory::ccBreakTrinketCache;
+std::map<uint32, uint32> PlayerbotFactory::questRewardItemCache;
 
 bool PlayerbotFactory::IsPrimaryTradeSkill(uint16 skillId)
 {
@@ -460,6 +462,124 @@ void PlayerbotFactory::Init()
         enchantGemIdCache.push_back(gemId);
     }
     LOG_INFO("playerbots", "Loading {} enchantment gems", enchantGemIdCache.size());
+
+    BuildCcBreakTrinketCache();
+    if (sPlayerbotAIConfig.autogearAllowsQuestRewards)
+        BuildQuestRewardCache();
+}
+
+void PlayerbotFactory::BuildCcBreakTrinketCache()
+{
+    ccBreakTrinketCache.clear();
+    // Spell 42292: removes all movement-impairing and loss-of-control effects — the PvP trinket spell.
+    QueryResult result = WorldDatabase.Query(
+        "SELECT entry, ItemLevel FROM item_template "
+        "WHERE Quality >= 2 AND InventoryType = 12 "
+        "AND (FlagsExtra & 8192) = 0 "
+        "AND (spellid_1 = 42292 OR spellid_2 = 42292 OR spellid_3 = 42292 "
+        "  OR spellid_4 = 42292 OR spellid_5 = 42292)");
+
+    if (!result)
+    {
+        LOG_INFO("playerbots", "CC-break trinket cache: no items found.");
+        return;
+    }
+
+    struct CcItem { uint32 itemId; uint16 itemLevel; };
+    std::vector<CcItem> tmp;
+    do
+    {
+        Field* f = result->Fetch();
+        tmp.push_back({f[0].Get<uint32>(), f[1].Get<uint16>()});
+    } while (result->NextRow());
+
+    std::sort(tmp.begin(), tmp.end(), [](const CcItem& a, const CcItem& b) {
+        return a.itemLevel > b.itemLevel;
+    });
+    for (auto& c : tmp)
+        ccBreakTrinketCache.push_back(c.itemId);
+
+    LOG_INFO("playerbots", "CC-break trinket cache: {} items.", ccBreakTrinketCache.size());
+}
+
+void PlayerbotFactory::BuildQuestRewardCache()
+{
+    questRewardItemCache.clear();
+
+    ObjectMgr::QuestMap const& questTemplates = sObjectMgr->GetQuestTemplates();
+    for (auto& [questId, quest] : questTemplates)
+    {
+        uint32 questLevel = quest->GetMinLevel();
+
+        // Check direct reward items (up to 4)
+        for (uint8 i = 0; i < QUEST_REWARDS_COUNT; i++)
+        {
+            uint32 itemId = quest->RewardItemId[i];
+            if (itemId > 0)
+            {
+                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
+                if (!proto)
+                    continue;
+
+                // Only cache armor and weapons (equippable items)
+                if (proto->Class != ITEM_CLASS_ARMOR && proto->Class != ITEM_CLASS_WEAPON)
+                    continue;
+
+                // Store the quest's min level as the item's effective level
+                // Only store if not already in cache (keeps first/lowest level quest)
+                if (questRewardItemCache.find(itemId) == questRewardItemCache.end())
+                    questRewardItemCache[itemId] = questLevel;
+            }
+        }
+
+        // Check choice reward items (up to 6)
+        for (uint8 i = 0; i < QUEST_REWARD_CHOICES_COUNT; i++)
+        {
+            uint32 itemId = quest->RewardChoiceItemId[i];
+            if (itemId > 0)
+            {
+                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
+                if (!proto)
+                    continue;
+
+                // Only cache armor and weapons (equippable items)
+                if (proto->Class != ITEM_CLASS_ARMOR && proto->Class != ITEM_CLASS_WEAPON)
+                    continue;
+
+                if (questRewardItemCache.find(itemId) == questRewardItemCache.end())
+                    questRewardItemCache[itemId] = questLevel;
+            }
+        }
+    }
+
+    LOG_INFO("playerbots", "Quest reward item cache: {} equippable items.", questRewardItemCache.size());
+}
+
+/*static*/ uint8 PlayerbotFactory::GetPreferredArmorType(uint8 cls)
+{
+    switch (cls)
+    {
+        case CLASS_WARRIOR:
+        case CLASS_PALADIN:
+        case CLASS_DEATH_KNIGHT:
+            return ITEM_SUBCLASS_ARMOR_PLATE;
+
+        case CLASS_HUNTER:
+        case CLASS_SHAMAN:
+            return ITEM_SUBCLASS_ARMOR_MAIL;
+
+        case CLASS_ROGUE:
+        case CLASS_DRUID:
+            return ITEM_SUBCLASS_ARMOR_LEATHER;
+
+        case CLASS_PRIEST:
+        case CLASS_MAGE:
+        case CLASS_WARLOCK:
+            return ITEM_SUBCLASS_ARMOR_CLOTH;
+
+        default:
+            return 0;
+    }
 }
 
 void PlayerbotFactory::Prepare()
@@ -561,9 +681,9 @@ void PlayerbotFactory::Randomize(bool incremental)
     if (!incremental || !sPlayerbotAIConfig.equipmentPersistence ||
         bot->GetLevel() < sPlayerbotAIConfig.equipmentPersistenceLevel)
     {
-        InitTalentsTree();
+        uint32 specIndex = InitTalentsTree();
+        sRandomPlayerbotMgr.SetValue(bot->GetGUID().GetCounter(), "specNo", specIndex + 1);
     }
-    sRandomPlayerbotMgr.SetValue(bot->GetGUID().GetCounter(), "specNo", 0);
     if (botAI)
     {
         PlayerbotRepository::instance().Reset(botAI);
@@ -1359,7 +1479,7 @@ void PlayerbotFactory::ResetQuests()
     }
 }
 
-void PlayerbotFactory::InitTalentsTree(bool increment /*false*/, bool use_template /*true*/, bool reset /*false*/)
+uint32 PlayerbotFactory::InitTalentsTree(bool increment /*false*/, bool use_template /*true*/, bool reset /*false*/)
 {
     uint32 specTab;
     uint8 cls = bot->getClass();
@@ -1427,7 +1547,14 @@ void PlayerbotFactory::InitTalentsTree(bool increment /*false*/, bool use_templa
     if (bot->GetFreeTalentPoints())
         InitTalents((specTab + 2) % 3);
 
+    if (bot->getClass() == CLASS_SHAMAN && bot->HasSpell(30798))
+    {
+        bot->SetSkill(SKILL_DUAL_WIELD, 0, 1, 1);
+        bot->SetCanDualWield(true);
+    }
+
     bot->SendTalentsInfoData(false);
+    return sPlayerbotAIConfig.randomClassSpecIndex[cls][specTab];
 }
 
 void PlayerbotFactory::InitTalentsBySpecNo(Player* bot, int specNo, bool reset)
@@ -1505,7 +1632,15 @@ void PlayerbotFactory::InitTalentsBySpecNo(Player* bot, int specNo, bool reset)
             break;
         }
     }
+
+    if (bot->getClass() == CLASS_SHAMAN && bot->HasSpell(30798))
+    {
+        bot->SetSkill(SKILL_DUAL_WIELD, 0, 1, 1);
+        bot->SetCanDualWield(true);
+    }
+
     bot->SendTalentsInfoData(false);
+    sRandomPlayerbotMgr.SetValue(bot->GetGUID().GetCounter(), "specNo", (uint32)specNo + 1);
 }
 
 void PlayerbotFactory::InitTalentsByParsedSpecLink(Player* bot, std::vector<std::vector<uint32>> parsedSpecLink,
@@ -1801,9 +1936,26 @@ bool PlayerbotFactory::CanEquipItem(ItemTemplate const* proto)
     // disable since bad performance
     bool hasItem = bot->HasItemCount(proto->ItemId, 1, false);
     // bot->GetItemCount()
-    // !requiredLevel -> it's a quest reward item
-    if (!requiredLevel && hasItem)
-        return false;
+    if (!requiredLevel)
+    {
+        // Check if it's a known quest reward in our cache
+        auto it = questRewardItemCache.find(proto->ItemId);
+        if (it != questRewardItemCache.end())
+        {
+            // It's a quest reward - use the quest's min level as the effective required level
+            requiredLevel = it->second;
+        }
+        else if (hasItem)
+        {
+            // Unknown no-level item and bot already has it, skip it
+            return false;
+        }
+        else
+        {
+            // Unknown no-level item and bot doesn't have it, skip it
+            return false;
+        }
+    }
 
     uint32 level = bot->GetLevel();
 
@@ -2008,25 +2160,60 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
     uint32 blevel = bot->GetLevel();
     int32 delta = std::min(blevel, 10u);
 
+    bool isPvp = sRandomPlayerbotMgr.IsSpecPvp(bot->GetGUID().GetCounter(), bot->getClass());
+
     StatsWeightCalculator calculator(bot);
+    if (isPvp)
+        calculator.SetPvpSpec(true);
+
+    // Pre-select CC-break trinket for PvP specs: best available by item level
+    // that the bot meets the level requirement for.
+    // Humans (Every Man for Himself) and Undead (Will of the Forsaken) have a
+    // racial that shares the PvP trinket cooldown, so they don't need one.
+    bool racialHasCcBreak = (bot->getRace() == RACE_HUMAN || bot->getRace() == RACE_UNDEAD_PLAYER);
+    uint32 pvpTrinket1 = 0;
+    if (isPvp && level >= 50 && !racialHasCcBreak)
+    {
+        for (uint32 itemId : ccBreakTrinketCache)
+        {
+            ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
+            if (!proto) continue;
+            // Respect gear quality limit: trinket must not exceed itemQuality setting
+            if (static_cast<int32>(proto->Quality) > itemQuality) continue;
+            if (proto->RequiredLevel > level) continue;
+            if (!CanEquipItem(proto)) continue;
+            uint16 dest;
+            if (!CanEquipUnseenItem(EQUIPMENT_SLOT_TRINKET1, dest, itemId)) continue;
+            pvpTrinket1 = itemId;
+            break;
+        }
+    }
+
     for (int32 slot : initSlotsOrder)
     {
         if (slot == EQUIPMENT_SLOT_TABARD || slot == EQUIPMENT_SLOT_BODY)
             continue;
 
-        if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
-            continue;
+        if (!sPlayerbotAIConfig.equipAllSlotsAtAnyLevel)
+        {
+            if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
+                continue;
 
-        if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
-            continue;
+            if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
+                continue;
 
-        if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
-            continue;
+            if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
+                continue;
 
-        if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
-            (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
-            (slot != EQUIPMENT_SLOT_RANGED))
-            continue;
+            if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
+                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
+                (slot != EQUIPMENT_SLOT_RANGED))
+                continue;
+        }
+
+        // Exclude resilience weighting for trinkets
+        bool isTrinketSlot = (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2);
+        calculator.SetExcludeResilience(isTrinketSlot);
 
         Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
 
@@ -2036,6 +2223,28 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         }
 
         oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+
+        // PvP specs: force TRINKET1 to the best available CC-break trinket.
+        if (slot == EQUIPMENT_SLOT_TRINKET1 && pvpTrinket1 != 0)
+        {
+            if (oldItem)
+            {
+                uint8 bagIndex = oldItem->GetBagSlot();
+                uint8 oldSlot  = oldItem->GetSlot();
+                uint8 dstBag   = NULL_BAG;
+                WorldPacket packet(CMSG_AUTOSTORE_BAG_ITEM, 3);
+                packet << bagIndex << oldSlot << dstBag;
+                WorldPackets::Item::AutoStoreBagItem nicePacket(std::move(packet));
+                nicePacket.Read();
+                bot->GetSession()->HandleAutoStoreBagItemOpcode(nicePacket);
+                oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+                if (oldItem) continue;
+            }
+            uint16 dest;
+            if (CanEquipUnseenItem(slot, dest, pvpTrinket1))
+                bot->EquipNewItem(dest, pvpTrinket1, true);
+            continue;
+        }
 
         int32 desiredQuality = itemQuality;
         if (urand(0, 100) < 100 * sPlayerbotAIConfig.randomGearLoweringChance && desiredQuality > ITEM_QUALITY_NORMAL)
@@ -2054,6 +2263,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                         if (urand(1, 100) <= skipProb)
                             continue;
 
+                        ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
                         // disable next expansion gear
                         if (sPlayerbotAIConfig.limitGearExpansion && bot->GetLevel() <= 60 && itemId >= 23728)
                             continue;
@@ -2064,7 +2274,6 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                                               // wearable TBC items above 35570 but nothing of significance
                             continue;
 
-                        ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
                         if (!proto)
                             continue;
 
@@ -2115,7 +2324,15 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
             ItemTemplate const* proto = sObjectMgr->GetItemTemplate(newItemId);
 
-            float cur_score = calculator.CalculateItem(newItemId);
+            float cur_score = calculator.CalculateItem(newItemId, 0, slot);
+
+            if (cur_score > 0.0f && proto && proto->Class == ITEM_CLASS_ARMOR && sPlayerbotAIConfig.preferClassArmorType)
+            {
+                uint8 preferredArmorType = GetPreferredArmorType(bot->getClass());
+                if (preferredArmorType != 0 && proto->SubClass == preferredArmorType)
+                    cur_score *= 3.0f;  // 3x multiplier for preferred armor type
+            }
+
             if (cur_score > bestScoreForSlot)
             {
                 // delay heavy check to here
@@ -2141,7 +2358,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
         if (incremental && oldItem)
         {
-            float old_score = calculator.CalculateItem(oldItem->GetEntry(), oldItem->GetItemRandomPropertyId());
+            float old_score = calculator.CalculateItem(oldItem->GetEntry(), oldItem->GetItemRandomPropertyId(), slot);
             if (bestScoreForSlot < 1.2f * old_score)
                 continue;
         }
@@ -2180,21 +2397,31 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             if (slot == EQUIPMENT_SLOT_TABARD || slot == EQUIPMENT_SLOT_BODY)
                 continue;
 
-            if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
+            if (!sPlayerbotAIConfig.equipAllSlotsAtAnyLevel)
+            {
+                if (level < 50 && (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2))
+                    continue;
+
+                if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
+                    continue;
+
+                if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
+                    continue;
+
+                if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
+                    (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
+                    (slot != EQUIPMENT_SLOT_RANGED))
+                    continue;
+            }
+
+            // CC-break trinket was force-equipped in the main pass; leave it alone.
+            if (slot == EQUIPMENT_SLOT_TRINKET1 && pvpTrinket1 != 0)
                 continue;
 
-            if (level < 30 && (slot == EQUIPMENT_SLOT_NECK || slot == EQUIPMENT_SLOT_HEAD))
-                continue;
+            bool isTrinketSlot = (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2);
+            calculator.SetExcludeResilience(isTrinketSlot);
 
-            if (level < 20 && (slot == EQUIPMENT_SLOT_FINGER1 || slot == EQUIPMENT_SLOT_FINGER2))
-                continue;
-
-            if (level < 5 && (slot != EQUIPMENT_SLOT_MAINHAND) && (slot != EQUIPMENT_SLOT_OFFHAND) &&
-                (slot != EQUIPMENT_SLOT_FEET) && (slot != EQUIPMENT_SLOT_LEGS) && (slot != EQUIPMENT_SLOT_CHEST) &&
-                (slot != EQUIPMENT_SLOT_RANGED))
-                continue;
-
-            if (bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot) != nullptr)
+            if (Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
                 bot->DestroyItem(INVENTORY_SLOT_BAG_0, slot, true);
 
             std::vector<uint32>& ids = items[slot];
@@ -2209,7 +2436,15 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(newItemId);
 
-                float cur_score = calculator.CalculateItem(newItemId);
+                float cur_score = calculator.CalculateItem(newItemId, 0, slot);
+
+                if (cur_score > 0.0f && proto && proto->Class == ITEM_CLASS_ARMOR && sPlayerbotAIConfig.preferClassArmorType)
+                {
+                    uint8 preferredArmorType = GetPreferredArmorType(bot->getClass());
+                    if (preferredArmorType != 0 && proto->SubClass == preferredArmorType)
+                        cur_score *= 3.0f;  // 3x multiplier for preferred armor type
+                }
+
                 if (cur_score > bestScoreForSlot)
                 {
                     // delay heavy check to here

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -499,7 +499,6 @@ void PlayerbotFactory::BuildCcBreakTrinketCache()
     LOG_INFO("playerbots", "CC-break trinket cache: {} items.", ccBreakTrinketCache.size());
 }
 
-
 /*static*/ uint8 PlayerbotFactory::GetPreferredArmorType(uint8 cls)
 {
     switch (cls)

--- a/src/Bot/Factory/PlayerbotFactory.h
+++ b/src/Bot/Factory/PlayerbotFactory.h
@@ -223,8 +223,6 @@ private:
     static std::vector<uint32> enchantSpellIdCache;
     static std::vector<uint32> enchantGemIdCache;
     static std::vector<uint32> ccBreakTrinketCache;
-    static std::map<uint32, uint32> questRewardItemCache;
-    static void BuildQuestRewardCache();
 
 protected:
     EnchantContainer m_EnchantContainer;

--- a/src/Bot/Factory/PlayerbotFactory.h
+++ b/src/Bot/Factory/PlayerbotFactory.h
@@ -63,7 +63,7 @@ public:
 
     static uint32 tradeSkills[];
     static float CalculateEnchantScore(uint32 enchant_id, Player* bot);
-    void InitTalentsTree(bool incremental = false, bool use_template = true, bool reset = false);
+    uint32 InitTalentsTree(bool incremental = false, bool use_template = true, bool reset = false);
     static void InitTalentsBySpecNo(Player* bot, int specNo, bool reset);
     static void InitTalentsByParsedSpecLink(Player* bot, std::vector<std::vector<uint32>> parsedSpecLink, bool reset);
     void InitAvailableSpells();
@@ -189,6 +189,8 @@ private:
     std::vector<uint32> GetCurrentGemsCount();
     bool CanEquipArmor(ItemTemplate const* proto);
     bool CanEquipWeapon(ItemTemplate const* proto);
+    static void BuildCcBreakTrinketCache();
+    static uint8 GetPreferredArmorType(uint8 cls);
     void EnchantItem(Item* item);
     void AddItemStats(uint32 mod, uint8& sp, uint8& ap, uint8& tank);
     bool CheckItemStats(uint8 sp, uint8 ap, uint8 tank);
@@ -220,6 +222,9 @@ private:
     static std::unordered_map<uint32, std::vector<uint32>> trainerIdCache;
     static std::vector<uint32> enchantSpellIdCache;
     static std::vector<uint32> enchantGemIdCache;
+    static std::vector<uint32> ccBreakTrinketCache;
+    static std::map<uint32, uint32> questRewardItemCache;
+    static void BuildQuestRewardCache();
 
 protected:
     EnchantContainer m_EnchantContainer;

--- a/src/Bot/Factory/PlayerbotFactory.h
+++ b/src/Bot/Factory/PlayerbotFactory.h
@@ -190,7 +190,7 @@ private:
     bool CanEquipArmor(ItemTemplate const* proto);
     bool CanEquipWeapon(ItemTemplate const* proto);
     static void BuildCcBreakTrinketCache();
-    static uint8 GetPreferredArmorType(uint8 cls);
+    uint8 GetPreferredArmorType(uint8 cls);
     void EnchantItem(Item* item);
     void AddItemStats(uint32 mod, uint8& sp, uint8& ap, uint8& tank);
     bool CheckItemStats(uint8 sp, uint8 ap, uint8 tank);

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2266,6 +2266,16 @@ CachedEvent* RandomPlayerbotMgr::FindEvent(uint32 bot, std::string const& event)
     return &e;
 }
 
+bool RandomPlayerbotMgr::IsSpecPvp(uint32 bot, uint8 cls)
+{
+    uint32 stored = GetValue(bot, "specNo");
+    if (!stored)
+        return false;
+    uint32 specIndex = stored - 1;
+    std::string const& name = sPlayerbotAIConfig.premadeSpecName[cls][specIndex];
+    return !name.empty() && name.find("pvp") != std::string::npos;
+}
+
 uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, std::string const& event)
 {
     if (CachedEvent* e = FindEvent(bot, event))

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -140,6 +140,7 @@ public:
     std::string GetData(uint32 bot, std::string const& type);
     void SetValue(uint32 bot, std::string const& type, uint32 value, std::string const& data = "");
     void SetValue(Player* bot, std::string const& type, uint32 value, std::string const& data = "");
+    bool IsSpecPvp(uint32 bot, uint8 cls);
     void Remove(Player* bot);
     ObjectGuid GetBattleMasterGUID(Player* bot, BattlegroundTypeId bgTypeId);
     CreatureData const* GetCreatureDataByEntry(uint32 entry);

--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -68,7 +68,7 @@ void StatsWeightCalculator::Reset()
     }
 }
 
-float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyIds)
+float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyIds, int32 slot)
 {
     ItemTemplate const* proto = &sObjectMgr->GetItemTemplateStore()->at(itemId);
 
@@ -107,10 +107,12 @@ float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyId
             weight_ *= PlayerbotFactory::CalcMixedGearScore(lvl, ITEM_QUALITY_EPIC);
         else
             weight_ *= PlayerbotFactory::CalcMixedGearScore(proto->ItemLevel, proto->Quality);
-
-        return weight_;
     }
-    // If quality/level blending is disabled, also return the calculated weight.
+
+    // Apply weapon speed governance if slot is provided and this is a weapon
+    if (sPlayerbotAIConfig.weaponSpeedGovernance && slot >= 0 && proto->Class == ITEM_CLASS_WEAPON)
+        weight_ *= ApplyWeaponSpeedGovernance(proto, slot);
+
     return weight_;
 }
 
@@ -208,6 +210,7 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HIT] += 1.7f;
         stats_weights_[STATS_TYPE_CRIT] += 1.4f;
         stats_weights_[STATS_TYPE_HASTE] += 1.6f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_RANGED_DPS] += 7.5f;
     }
     else if (cls == CLASS_HUNTER && tab == HUNTER_TAB_MARKSMANSHIP)
@@ -218,6 +221,7 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HIT] += 2.1f;
         stats_weights_[STATS_TYPE_CRIT] += 2.0f;
         stats_weights_[STATS_TYPE_HASTE] += 1.8f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_RANGED_DPS] += 10.0f;
     }
     else if (cls == CLASS_ROGUE && tab == ROGUE_TAB_COMBAT)
@@ -229,6 +233,7 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HIT] += 2.1f;
         stats_weights_[STATS_TYPE_CRIT] += 1.4f;
         stats_weights_[STATS_TYPE_HASTE] += 1.7f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 2.0f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 7.0f;
     }
@@ -253,64 +258,69 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HIT] += 2.1f;
         stats_weights_[STATS_TYPE_CRIT] += 1.1f;
         stats_weights_[STATS_TYPE_HASTE] += 1.8f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 2.1f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 5.0f;
     }
     else if (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_FURY)
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 1.8f;
-        stats_weights_[STATS_TYPE_STRENGTH] += 2.6f;
-        stats_weights_[STATS_TYPE_ATTACK_POWER] += 1.0f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.8f;
+        stats_weights_[STATS_TYPE_STRENGTH] += 2.5f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.8f;
         stats_weights_[STATS_TYPE_ARMOR_PENETRATION] += 2.1f;
         stats_weights_[STATS_TYPE_HIT] += 2.3f;
         stats_weights_[STATS_TYPE_CRIT] += 2.2f;
-        stats_weights_[STATS_TYPE_HASTE] += 1.8f;
+        stats_weights_[STATS_TYPE_HASTE] += 0.8f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 2.0f;
+        stats_weights_[STATS_TYPE_DEFENSE] -= 1.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 2.5f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 7.0f;
     }
     else if (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_ARMS)
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 1.6f;
-        stats_weights_[STATS_TYPE_STRENGTH] += 2.3f;
-        stats_weights_[STATS_TYPE_ATTACK_POWER] += 1.0f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.8f;
+        stats_weights_[STATS_TYPE_STRENGTH] += 2.5f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.8f;
         stats_weights_[STATS_TYPE_ARMOR_PENETRATION] += 1.7f;
         stats_weights_[STATS_TYPE_HIT] += 2.0f;
         stats_weights_[STATS_TYPE_CRIT] += 1.9f;
         stats_weights_[STATS_TYPE_HASTE] += 0.8f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 2.0f;
+        stats_weights_[STATS_TYPE_DEFENSE] -= 1.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 1.4f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 7.0f;
     }
     else if (cls == CLASS_DEATH_KNIGHT && tab == DEATH_KNIGHT_TAB_FROST)
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 1.7f;
-        stats_weights_[STATS_TYPE_STRENGTH] += 2.8f;
-        stats_weights_[STATS_TYPE_ATTACK_POWER] += 1.0f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.5f;
+        stats_weights_[STATS_TYPE_STRENGTH] += 2.5f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.5f;
         stats_weights_[STATS_TYPE_ARMOR_PENETRATION] += 2.7f;
         stats_weights_[STATS_TYPE_HIT] += 2.3f;
         stats_weights_[STATS_TYPE_CRIT] += 2.2f;
         stats_weights_[STATS_TYPE_HASTE] += 2.1f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 2.5f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 7.0f;
     }
     else if (cls == CLASS_DEATH_KNIGHT && tab == DEATH_KNIGHT_TAB_UNHOLY)
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 0.9f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.5f;
         stats_weights_[STATS_TYPE_STRENGTH] += 2.5f;
-        stats_weights_[STATS_TYPE_ATTACK_POWER] += 1.0f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.5f;
         stats_weights_[STATS_TYPE_ARMOR_PENETRATION] += 1.3f;
         stats_weights_[STATS_TYPE_HIT] += 2.2f;
         stats_weights_[STATS_TYPE_CRIT] += 1.7f;
         stats_weights_[STATS_TYPE_HASTE] += 1.8f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 1.5f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 5.0f;
     }
     else if (cls == CLASS_PALADIN && tab == PALADIN_TAB_RETRIBUTION)
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 1.6f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.5f;
         stats_weights_[STATS_TYPE_STRENGTH] += 2.5f;
-        stats_weights_[STATS_TYPE_INTELLECT] += 0.1f;
-        stats_weights_[STATS_TYPE_ATTACK_POWER] += 1.0f;
-        stats_weights_[STATS_TYPE_SPELL_POWER] += 0.3f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.5f;
         stats_weights_[STATS_TYPE_ARMOR_PENETRATION] += 1.5f;
         stats_weights_[STATS_TYPE_HIT] += 1.9f;
         stats_weights_[STATS_TYPE_CRIT] += 1.7f;
@@ -324,7 +334,7 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_STRENGTH] += 1.1f;
         stats_weights_[STATS_TYPE_INTELLECT] += 0.3f;
         stats_weights_[STATS_TYPE_ATTACK_POWER] += 1.0f;
-        stats_weights_[STATS_TYPE_SPELL_POWER] += 0.95f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] += 0.5f;
         stats_weights_[STATS_TYPE_ARMOR_PENETRATION] += 0.9f;
         stats_weights_[STATS_TYPE_HIT] += 2.1f;
         stats_weights_[STATS_TYPE_CRIT] += 1.5f;
@@ -343,6 +353,7 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HIT] += 1.1f;
         stats_weights_[STATS_TYPE_CRIT] += 0.8f;
         stats_weights_[STATS_TYPE_HASTE] += 1.0f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_RANGED_DPS] += 1.0f;
     }
     else if (cls == CLASS_MAGE && tab == MAGE_TAB_FIRE)
@@ -353,15 +364,17 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_HIT] += 1.2f;
         stats_weights_[STATS_TYPE_CRIT] += 1.1f;
         stats_weights_[STATS_TYPE_HASTE] += 0.8f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_RANGED_DPS] += 1.0f;
     }
     else if (cls == CLASS_SHAMAN && tab == SHAMAN_TAB_ELEMENTAL)
     {
-        stats_weights_[STATS_TYPE_INTELLECT] += 0.25f;
-        stats_weights_[STATS_TYPE_SPELL_POWER] += 1.0f;
+        stats_weights_[STATS_TYPE_INTELLECT] += 0.5f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] += 1.2f;
         stats_weights_[STATS_TYPE_HIT] += 1.1f;
         stats_weights_[STATS_TYPE_CRIT] += 0.8f;
         stats_weights_[STATS_TYPE_HASTE] += 1.0f;
+        stats_weights_[STATS_TYPE_MANA_REGENERATION] += 0.5f;
     }
     else if ((cls == CLASS_PALADIN && tab == PALADIN_TAB_HOLY) ||
              (cls == CLASS_SHAMAN && tab == SHAMAN_TAB_RESTORATION))
@@ -382,14 +395,15 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_MANA_REGENERATION] += 0.9f;
         stats_weights_[STATS_TYPE_CRIT] += 0.6f;
         stats_weights_[STATS_TYPE_HASTE] += 0.8f;
+        stats_weights_[STATS_TYPE_ATTACK_POWER] -= 1.0f;
         stats_weights_[STATS_TYPE_RANGED_DPS] += 1.0f;
     }
     else if ((cls == CLASS_WARRIOR && tab == WARRIOR_TAB_PROTECTION) ||
              (cls == CLASS_PALADIN && tab == PALADIN_TAB_PROTECTION))
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 2.0f;
-        stats_weights_[STATS_TYPE_STRENGTH] += 1.0f;
-        stats_weights_[STATS_TYPE_STAMINA] += 3.5f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.2f;
+        stats_weights_[STATS_TYPE_STRENGTH] += 1.3f;
+        stats_weights_[STATS_TYPE_STAMINA] += 3.0f;
         stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.2f;
         stats_weights_[STATS_TYPE_DEFENSE] += 2.5f;
         stats_weights_[STATS_TYPE_PARRY] += 2.0f;
@@ -399,26 +413,26 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_BLOCK_VALUE] += 0.5f;
         stats_weights_[STATS_TYPE_ARMOR] += 0.15f;
         stats_weights_[STATS_TYPE_HIT] += 2.0f;
-        stats_weights_[STATS_TYPE_CRIT] += 0.2f;
-        stats_weights_[STATS_TYPE_HASTE] += 0.5f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 2.0f;
         stats_weights_[STATS_TYPE_EXPERTISE] += 3.0f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 2.0f;
     }
     else if (cls == CLASS_DEATH_KNIGHT && tab == DEATH_KNIGHT_TAB_BLOOD)
     {
-        stats_weights_[STATS_TYPE_AGILITY] += 2.0f;
-        stats_weights_[STATS_TYPE_STRENGTH] += 1.0f;
-        stats_weights_[STATS_TYPE_STAMINA] += 3.5f;
+        stats_weights_[STATS_TYPE_AGILITY] += 0.2f;
+        stats_weights_[STATS_TYPE_STRENGTH] += 1.3f;
+        stats_weights_[STATS_TYPE_STAMINA] += 3.0f;
         stats_weights_[STATS_TYPE_ATTACK_POWER] += 0.2f;
-        stats_weights_[STATS_TYPE_DEFENSE] += 3.5f;
+        stats_weights_[STATS_TYPE_DEFENSE] += 2.5f;
         stats_weights_[STATS_TYPE_PARRY] += 2.0f;
         stats_weights_[STATS_TYPE_DODGE] += 2.0f;
+        stats_weights_[STATS_TYPE_BLOCK_RATING] -= 2.0f;
+        stats_weights_[STATS_TYPE_BLOCK_VALUE] -= 2.0f;
         // stats_weights_[STATS_TYPE_RESILIENCE] += 2.0f;
         stats_weights_[STATS_TYPE_ARMOR] += 0.15f;
         stats_weights_[STATS_TYPE_HIT] += 2.0f;
-        stats_weights_[STATS_TYPE_CRIT] += 0.5f;
-        stats_weights_[STATS_TYPE_HASTE] += 0.5f;
-        stats_weights_[STATS_TYPE_EXPERTISE] += 3.5f;
+        stats_weights_[STATS_TYPE_SPELL_POWER] -= 1.0f;
+        stats_weights_[STATS_TYPE_EXPERTISE] += 3.0f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 2.0f;
     }
     else
@@ -438,6 +452,11 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_EXPERTISE] += 3.7f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 3.0f;
     }
+
+    if (pvpSpec_ && !exclude_resilience_)
+        stats_weights_[STATS_TYPE_RESILIENCE] += 7.0f;
+    else if (!pvpSpec_)
+        stats_weights_[STATS_TYPE_RESILIENCE] -= 3.0f;
 }
 
 void StatsWeightCalculator::GenerateAdditionalWeights(Player* player)
@@ -561,7 +580,8 @@ void StatsWeightCalculator::CalculateItemTypePenalty(ItemTemplate const* proto)
                  (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_FURY && !player_->CanTitanGrip() &&
                   player_->CanDualWield()) ||
                  (cls == CLASS_WARRIOR && tab == WARRIOR_TAB_PROTECTION) ||
-                 (cls == CLASS_PALADIN && tab == PALADIN_TAB_PROTECTION)))
+                 (cls == CLASS_PALADIN && tab == PALADIN_TAB_PROTECTION) ||
+                 (cls == CLASS_PALADIN && tab == PALADIN_TAB_HOLY)))
             {
                 weight_ *= 0.1;
             }
@@ -580,10 +600,15 @@ void StatsWeightCalculator::CalculateItemTypePenalty(ItemTemplate const* proto)
                 weight_ *= 0.1;
             }
             // caster's main hand (cannot duel weapon but can equip two-hands stuff)
-            if (cls == CLASS_MAGE || cls == CLASS_PRIEST || cls == CLASS_WARLOCK || cls == CLASS_DRUID ||
-                (cls == CLASS_SHAMAN && !player_->CanDualWield()))
+            if ((cls == CLASS_MAGE || cls == CLASS_PRIEST || cls == CLASS_WARLOCK || cls == CLASS_DRUID ||
+                (cls == CLASS_SHAMAN && !player_->CanDualWield())) &&
+                !(cls == CLASS_PALADIN && tab == PALADIN_TAB_HOLY))
             {
                 weight_ *= 0.65;
+            }
+            if (cls == CLASS_PALADIN && tab == PALADIN_TAB_HOLY)
+            {
+                weight_ *= 0.8;
             }
         }
         // fury with titan's grip
@@ -754,4 +779,168 @@ void StatsWeightCalculator::ApplyWeightFinetune(Player* player)
                 stats_weights_[STATS_TYPE_ARMOR_PENETRATION] *= 1.2f;
         }
     }
+}
+
+float StatsWeightCalculator::ApplyWeaponSpeedGovernance(ItemTemplate const* proto, int32 slot)
+{
+    // Weapon speed governance: multiply score by (1 + weight) when this weapon's Delay
+    // matches the spec-ideal speed. weight = 2.0f, giving a 3x boost for matching weapons.
+    float weight = 2.0f;
+
+    if (weight == 0.0f)
+        return 1.0f;
+
+    // Applies to mainhand, offhand, and ranged slots only.
+    if (slot != EQUIPMENT_SLOT_MAINHAND &&
+        slot != EQUIPMENT_SLOT_OFFHAND  &&
+        slot != EQUIPMENT_SLOT_RANGED)
+        return 1.0f;
+
+    uint32 delay = proto->Delay;  // milliseconds
+    float boost = 1.0f + weight;  // applied on a match
+
+    // Hunter: melee weapons are stat sticks — speed irrelevant.
+    // Ranged weapons scale Aimed/Chimera/Explosive Shot from top-end damage,
+    // so a slow ranged weapon (>=2600 ms) is strongly preferred.
+    if (cls == CLASS_HUNTER)
+    {
+        if (slot == EQUIPMENT_SLOT_RANGED && delay >= 2600)
+            return boost;
+        return 1.0f;
+    }
+
+    // Feral Druid: forms normalise attack speed; raw weapon Delay is irrelevant.
+    if (cls == CLASS_DRUID && tab == DRUID_TAB_FERAL)
+        return 1.0f;
+
+    switch (cls)
+    {
+        case CLASS_WARRIOR:
+            if (tab == WARRIOR_TAB_ARMS)
+            {
+                // Arms: slow 2H axes or polearms in mainhand only (Axe Specialization: +5% crit).
+                bool isAxeOrPolearm = (proto->SubClass == ITEM_SUBCLASS_WEAPON_AXE2 ||
+                                       proto->SubClass == ITEM_SUBCLASS_WEAPON_POLEARM);
+                if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 3400 && isAxeOrPolearm)
+                    return boost;
+            }
+            else if (tab == WARRIOR_TAB_FURY)
+            {
+                if (!player_->CanDualWield())
+                {
+                    // Pre-DW: treat like Arms — slow 2H in mainhand only.
+                    if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 3400)
+                        return boost;
+                }
+                else if (player_->CanTitanGrip())
+                {
+                    // TG: slow 2H (>=3400) in both hands.
+                    if (delay >= 3400)
+                        return boost;
+                }
+                else
+                {
+                    // SMF: slow 1H (>=2600) in both hands.
+                    // 2H must be excluded — delay >= 2600 would otherwise pass
+                    // for a 2H heirloom (~3600ms) just as it did for Enhancement.
+                    if (proto->InventoryType == INVTYPE_2HWEAPON)
+                        break;
+                    if (delay >= 2600)
+                        return boost;
+                }
+            }
+            else if (tab == WARRIOR_TAB_PROTECTION)
+            {
+                // Prot: slow 1H (>=2600) in mainhand. Shield in offhand, no speed bonus.
+                if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 2600)
+                    return boost;
+            }
+            break;
+
+        case CLASS_PALADIN:
+            if (tab == PALADIN_TAB_RETRIBUTION)
+            {
+                // Ret: slow 2H in mainhand only.
+                if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 3400)
+                    return boost;
+            }
+            else if (tab == PALADIN_TAB_PROTECTION)
+            {
+                // Prot: slow 1H (>=2600) in mainhand. Shield in offhand.
+                if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 2600)
+                    return boost;
+            }
+            break;
+
+        case CLASS_DEATH_KNIGHT:
+            if (tab == DEATH_KNIGHT_TAB_BLOOD || tab == DEATH_KNIGHT_TAB_UNHOLY)
+            {
+                // Blood / Unholy: slow 2H in mainhand only.
+                if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 3400)
+                    return boost;
+            }
+            else if (tab == DEATH_KNIGHT_TAB_FROST)
+            {
+                // Frost DK has Dual Wield innately — always dual-wields 1H.
+                if (proto->InventoryType == INVTYPE_2HWEAPON)
+                    break;
+                if (delay >= 2600)
+                    return boost;
+            }
+            break;
+
+        case CLASS_SHAMAN:
+            if (tab == SHAMAN_TAB_ENHANCEMENT)
+            {
+                if (!player_->CanDualWield())
+                {
+                    // Pre-Dual Wield: Enhancement plays like a 2H spec.
+                    if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 3400)
+                        return boost;
+                }
+                else
+                {
+                    // Post-Dual Wield: slow 1H (>=2600) in both hands.
+                    if (proto->InventoryType == INVTYPE_2HWEAPON)
+                        break;
+
+                    if (delay >= 2600)
+                    {
+                        float mult = boost;
+                        if (slot == EQUIPMENT_SLOT_OFFHAND)
+                        {
+                            Item* mh = player_->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                            if (mh && mh->GetTemplate() && mh->GetTemplate()->Delay == delay)
+                                mult *= boost;  // synchronized: ×(1+weight)² total = ×9 for 2.0f weight
+                        }
+                        return mult;
+                    }
+                }
+            }
+            break;
+
+        case CLASS_ROGUE:
+            if (tab == ROGUE_TAB_COMBAT)
+            {
+                // Combat: slow MH (>=2600), fast OH (<=1500).
+                if (slot == EQUIPMENT_SLOT_MAINHAND && delay >= 2600)
+                    return boost;
+                if (slot == EQUIPMENT_SLOT_OFFHAND && delay <= 1500)
+                    return boost;
+            }
+            else  // Assassination or Subtlety: slow dagger MH, fast dagger OH.
+            {
+                bool isDagger = (proto->SubClass == ITEM_SUBCLASS_WEAPON_DAGGER);
+                if (slot == EQUIPMENT_SLOT_MAINHAND && isDagger && delay >= 1700)
+                    return boost;
+                if (slot == EQUIPMENT_SLOT_OFFHAND && isDagger && delay <= 1500)
+                    return boost;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    return 1.0f;
 }

--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -110,8 +110,8 @@ float StatsWeightCalculator::CalculateItem(uint32 itemId, int32 randomPropertyId
     }
 
     // Apply weapon speed governance if slot is provided and this is a weapon
-    if (sPlayerbotAIConfig.weaponSpeedGovernance && slot >= 0 && proto->Class == ITEM_CLASS_WEAPON)
-        weight_ *= ApplyWeaponSpeedGovernance(proto, slot);
+    if (sPlayerbotAIConfig.preferredSpecWeapons && slot >= 0 && proto->Class == ITEM_CLASS_WEAPON)
+        weight_ *= ApplyPreferredSpecWeapons(proto, slot);
 
     return weight_;
 }
@@ -452,11 +452,6 @@ void StatsWeightCalculator::GenerateBasicWeights(Player* player)
         stats_weights_[STATS_TYPE_EXPERTISE] += 3.7f;
         stats_weights_[STATS_TYPE_MELEE_DPS] += 3.0f;
     }
-
-    if (pvpSpec_ && !exclude_resilience_)
-        stats_weights_[STATS_TYPE_RESILIENCE] += 7.0f;
-    else if (!pvpSpec_)
-        stats_weights_[STATS_TYPE_RESILIENCE] -= 3.0f;
 }
 
 void StatsWeightCalculator::GenerateAdditionalWeights(Player* player)
@@ -490,6 +485,11 @@ void StatsWeightCalculator::GenerateAdditionalWeights(Player* player)
             stats_weights_[STATS_TYPE_SPIRIT] -= 0.0f;
         }
     }
+
+    if (pvpSpec_ && !exclude_resilience_)
+        stats_weights_[STATS_TYPE_RESILIENCE] += 7.0f;
+    else if (!pvpSpec_)
+        stats_weights_[STATS_TYPE_RESILIENCE] -= 3.0f;
 }
 
 void StatsWeightCalculator::CalculateItemSetMod(Player* player, ItemTemplate const* proto)
@@ -781,7 +781,7 @@ void StatsWeightCalculator::ApplyWeightFinetune(Player* player)
     }
 }
 
-float StatsWeightCalculator::ApplyWeaponSpeedGovernance(ItemTemplate const* proto, int32 slot)
+float StatsWeightCalculator::ApplyPreferredSpecWeapons(ItemTemplate const* proto, int32 slot)
 {
     // Weapon speed governance: multiply score by (1 + weight) when this weapon's Delay
     // matches the spec-ideal speed. weight = 2.0f, giving a 3x boost for matching weapons.
@@ -834,13 +834,13 @@ float StatsWeightCalculator::ApplyWeaponSpeedGovernance(ItemTemplate const* prot
                 }
                 else if (player_->CanTitanGrip())
                 {
-                    // TG: slow 2H (>=3400) in both hands.
+                    // Titan's Grip: slow 2H (>=3400) in both hands.
                     if (delay >= 3400)
                         return boost;
                 }
                 else
                 {
-                    // SMF: slow 1H (>=2600) in both hands.
+                    // 1H DW: slow 1H (>=2600) in both hands.
                     // 2H must be excluded — delay >= 2600 would otherwise pass
                     // for a 2H heirloom (~3600ms) just as it did for Enhancement.
                     if (proto->InventoryType == INVTYPE_2HWEAPON)

--- a/src/Mgr/Item/StatsWeightCalculator.cpp
+++ b/src/Mgr/Item/StatsWeightCalculator.cpp
@@ -783,12 +783,8 @@ void StatsWeightCalculator::ApplyWeightFinetune(Player* player)
 
 float StatsWeightCalculator::ApplyPreferredSpecWeapons(ItemTemplate const* proto, int32 slot)
 {
-    // Weapon speed governance: multiply score by (1 + weight) when this weapon's Delay
-    // matches the spec-ideal speed. weight = 2.0f, giving a 3x boost for matching weapons.
+    // Multiply score by 3x when this weapon's delay matches the spec-ideal speed.
     float weight = 2.0f;
-
-    if (weight == 0.0f)
-        return 1.0f;
 
     // Applies to mainhand, offhand, and ranged slots only.
     if (slot != EQUIPMENT_SLOT_MAINHAND &&

--- a/src/Mgr/Item/StatsWeightCalculator.h
+++ b/src/Mgr/Item/StatsWeightCalculator.h
@@ -47,7 +47,7 @@ public:
     void CalculateSocketBonus(Player* player, ItemTemplate const* proto);
 
     void CalculateItemTypePenalty(ItemTemplate const* proto);
-    float ApplyWeaponSpeedGovernance(ItemTemplate const* proto, int32 slot);
+    float ApplyPreferredSpecWeapons(ItemTemplate const* proto, int32 slot);
 
     bool NotBestArmorType(uint32 item_subclass_armor);
 

--- a/src/Mgr/Item/StatsWeightCalculator.h
+++ b/src/Mgr/Item/StatsWeightCalculator.h
@@ -28,12 +28,14 @@ class StatsWeightCalculator
 public:
     StatsWeightCalculator(Player* player);
     void Reset();
-    float CalculateItem(uint32 itemId, int32 randomPropertyId = 0);
+    float CalculateItem(uint32 itemId, int32 randomPropertyId = 0, int32 slot = -1);
     float CalculateEnchant(uint32 enchantId);
 
     void SetOverflowPenalty(bool apply) { enable_overflow_penalty_ = apply; }
     void SetItemSetBonus(bool apply) { enable_item_set_bonus_ = apply; }
     void SetQualityBlend(bool apply) { enable_quality_blend_ = apply; }
+    void SetPvpSpec(bool isPvp) { pvpSpec_ = isPvp; }
+    void SetExcludeResilience(bool exclude) { exclude_resilience_ = exclude; }
 
     private:
     void GenerateWeights(Player* player);
@@ -45,6 +47,7 @@ public:
     void CalculateSocketBonus(Player* player, ItemTemplate const* proto);
 
     void CalculateItemTypePenalty(ItemTemplate const* proto);
+    float ApplyWeaponSpeedGovernance(ItemTemplate const* proto, int32 slot);
 
     bool NotBestArmorType(uint32 item_subclass_armor);
 
@@ -65,6 +68,8 @@ private:
 
     float weight_;
     float stats_weights_[STATS_TYPE_MAX];
+    bool pvpSpec_ = false;
+    bool exclude_resilience_ = false;
 };
 
 #endif

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -125,6 +125,10 @@ bool PlayerbotAIConfig::Initialize()
     incrementalGearInit = sConfigMgr->GetOption<bool>("AiPlayerbot.IncrementalGearInit", true);
     randomGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearQualityLimit", 3);
     randomGearScoreLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearScoreLimit", 0);
+    preferClassArmorType       = sConfigMgr->GetOption<bool>("AiPlayerbot.PreferClassArmorType", true);
+    autogearAllowsQuestRewards = sConfigMgr->GetOption<bool>("AiPlayerbot.AutogearAllowsQuestRewards", false);
+    equipAllSlotsAtAnyLevel    = sConfigMgr->GetOption<bool>("AiPlayerbot.EquipAllSlotsAtAnyLevel", false);
+    weaponSpeedGovernance      = sConfigMgr->GetOption<bool>("AiPlayerbot.WeaponSpeedGovernance", false);
 
     randomBotMinLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMinLevelChance", 0.1f);
     randomBotMaxLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMaxLevelChance", 0.1f);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -125,10 +125,8 @@ bool PlayerbotAIConfig::Initialize()
     incrementalGearInit = sConfigMgr->GetOption<bool>("AiPlayerbot.IncrementalGearInit", true);
     randomGearQualityLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearQualityLimit", 3);
     randomGearScoreLimit = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomGearScoreLimit", 0);
-    preferClassArmorType       = sConfigMgr->GetOption<bool>("AiPlayerbot.PreferClassArmorType", true);
-    autogearAllowsQuestRewards = sConfigMgr->GetOption<bool>("AiPlayerbot.AutogearAllowsQuestRewards", false);
-    equipAllSlotsAtAnyLevel    = sConfigMgr->GetOption<bool>("AiPlayerbot.EquipAllSlotsAtAnyLevel", false);
-    weaponSpeedGovernance      = sConfigMgr->GetOption<bool>("AiPlayerbot.WeaponSpeedGovernance", false);
+    preferClassArmorType  = sConfigMgr->GetOption<bool>("AiPlayerbot.PreferClassArmorType", false);
+    preferredSpecWeapons  = sConfigMgr->GetOption<bool>("AiPlayerbot.PreferredSpecWeapons", false);
 
     randomBotMinLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMinLevelChance", 0.1f);
     randomBotMaxLevelChance = sConfigMgr->GetOption<float>("AiPlayerbot.RandomBotMaxLevelChance", 0.1f);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -128,6 +128,10 @@ public:
     bool incrementalGearInit;
     int32 randomGearQualityLimit;
     int32 randomGearScoreLimit;
+    bool preferClassArmorType;
+    bool autogearAllowsQuestRewards;
+    bool equipAllSlotsAtAnyLevel;
+    bool weaponSpeedGovernance;
     float randomBotMinLevelChance, randomBotMaxLevelChance;
     float randomBotRpgChance;
     uint32 minRandomBots, maxRandomBots;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -129,9 +129,7 @@ public:
     int32 randomGearQualityLimit;
     int32 randomGearScoreLimit;
     bool preferClassArmorType;
-    bool autogearAllowsQuestRewards;
-    bool equipAllSlotsAtAnyLevel;
-    bool weaponSpeedGovernance;
+    bool preferredSpecWeapons;
     float randomBotMinLevelChance, randomBotMaxLevelChance;
     float randomBotRpgChance;
     uint32 minRandomBots, maxRandomBots;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Hello playerbots community! I have been working diligently whilst on vacation to help get pvp gear up and running for pvp specs. Throughout this process, I have looked at our current autogear system, tested it through and through, and made some changes to make gearing more appropriate per spec. _I am going to have my description of the changes in italics_, **and the AI description overview will be bolded.** Let's begin!

**This PR makes some improvements to the bot autogear system across item scoring, spec tracking(pvp specs and gear), and stat weights. Changes are split between those that are always active and those controlled by new config options.**

**Mandatory Changes:**

**PvP Spec Detection (IsSpecPvp)
A new method RandomPlayerbotMgr::IsSpecPvp(botGuid, cls) checks the bot's stored specNo against the spec name string defined in config. If the name contains "pvp", the bot is treated as a PvP spec throughout the entire gear pipeline. This is the single source of truth used by both InitEquipment() and ItemUsageValue. In the future this detection can be expanded to drive bot behavior decisions — such as prioritizing dueling players in the world, joining Wintergrasp, or preferring BG and Arena queues over PvE content.**

_This is scalable, so if someone were to create their own pvp spec in the config, it would still be tracked if the name contains "pvp". I like the idea of pvp specced random bots having an identifier for pvp events._

**PvP Weights Applied During Loot Evaluation
ItemUsageValue::QueryItemUsageForEquip() now calls IsSpecPvp() before scoring a looted item. If the bot is on a PvP spec, it passes SetPvpSpec(true) to the StatsWeightCalculator, ensuring looted items are evaluated with PvP stat priorities (including resilience weighting) rather than PvE weights. Previously, a PvP-specced bot would score loot identically to a PvE bot.**

_So, during autogear and upgrade equips, pvp specced bots will now heavily prioritize resilience. On the flip side, pve bots really don't want resilience gear, so a negative weight modifier (penalty for resilience items) has been applied to pve autogearing and upgrade equips. This is important, because you can switch a bot from a pve spec to a pvp spec, and it will automatically consider resilience items in it's inventory as upgrades, and equip them. Same for when you switch a bot from a pvp spec back to a pve spec - the resilience penalty will encourage the bot to switch back to the best available pve gear._

**Resilience Weighting
After all per-spec weights are generated in GenerateBasicWeights(), a global resilience modifier is applied unconditionally:**

**PvP specs: +7.0 resilience weight — strongly prioritizes resilience gear
Non-PvP specs: −3.0 resilience weight — actively discourages resilience gear
Resilience is additionally excluded entirely from trinket slot scoring via SetExcludeResilience(true), preventing the PvP resilience bonus from inflating the scores of non-CC trinkets.**

_I tried several different numbers here - as high as 10 and as low as 3 for resilience. I ended up with 7 so nearly all specs will slot resilience in every slot EXCEPT for trinkets. I stopped weighing resilience on trinkets because they ended up being garbage trinkets for the most part - other endgame pve trinkets were way more impactful. In my testing, the only class/specs that wont use 100% resilience gears are the tanks, since defense rating/parry/block/dodge weights are so high._

**CC-Break Trinket Cache
At server startup, PlayerbotFactory::BuildCcBreakTrinketCache() queries the world database for all trinkets (InventoryType=12, Quality≥2) whose spell IDs include spell 42292 — the CC-break / PvP trinket effect shared by items like Medallion of the Alliance/Horde. Results are sorted by item level descending and cached in a static vector, ready for fast lookup during gearing.**

_This creates a cache of cc trinkets on startup, for this:_

**CC-Break Trinket Force-Equip
During InitEquipment(), PvP-specced bots at level 50 or higher (level minimum for autogear to apply trinkets) run a pre-selection pass over ccBreakTrinketCache to find the best CC-break trinket they meet the level requirement and quality limit for. Human and Undead bots are excluded from this — they have racial abilities (Every Man for Himself, Will of the Forsaken) that share the PvP trinket cooldown, making a dedicated trinket redundant.**

**If a suitable trinket is found, it is stored as pvpTrinket1 and force-equipped into TRINKET1 before the main gear loop runs. If an item already occupies the slot, it is moved to bags first. The second-chance pass also skips TRINKET1 when pvpTrinket1 is set, so the CC trinket is never overwritten.**

_This is the catch-all forced pvp trinket for trinket slot 1. In my testing, I really found out how few cc trinkets there are - most of them are epic, and blue ones start showing up super late in the game. An heirloom patch would really help the lower levels, being able to equip a pvp trinket at level 10 or something. Keep in mind, that if your bot isn't getting a pvp trinket with autogear, make sure they aren't human or undead, and check your config for what quality items are allowed with autogear. NOTE - PVP TRINKET STRATEGIES ARE NOT CURRENTLY CODED, SAME WITH CC RACIALS. They will not break out of stun/cc currently. This is for future updates if/when I make a trinketstrategy._

**Enhancement Shaman Dual Wield Fix
Classes like Rogues, Frost DKs, and Fury Warriors have their dual wield capability established through class initialization code in the core. Enhancement Shamans acquire Dual Wield only through a specific talent (spell 30798, learned around level 40), and the bot factory had no code to detect and apply this. The result was that Enhancement Shaman bots would sometimes have their offhand weapon unequipped — despite having the talent. After talents are applied in both InitTalentsTree() and InitTalentsBySpecNo(), the code now checks for spell 30798 and explicitly grants SKILL_DUAL_WIELD and SetCanDualWield(true) when present.**

_When testing the weapon speed preferences, I noticed that randombot enhancement shamans were unequipping their offhand randomly. They would just walk around with a single 1-hand weapon. This is because they were not considered in the system as dual wielding, so when initequipment or autoequipupgrades was ran, it would unequip the offhand through a function, despite having the dual wield talent. Looking at the code, the other classes already have this flag (warriors, rogues, dks, hunters) because they didn't acquire it through talents._

**CalculateItem() Slot Awareness
StatsWeightCalculator::CalculateItem() now accepts an optional slot parameter (default -1). When provided and the item is a weapon, ApplyWeaponSpeedGovernance() can be called. Both item scoring calls inside InitEquipment() — the candidate scoring loop and the incremental old-item comparison — now pass the current equipment slot.**

_This change allows the calculate item function to know what slot it's working with, and that's how it modifies it's decision making for some of the optional features below._

**Holy Paladin Weapon Scoring Fix
Prior to this change, Holy Paladin could end up equipping 2H weapons because haste and crit sticks (2H weapons) were outscoring appropriate 1H caster weapons — the item type penalty was not catching them correctly. Holy Paladin is now explicitly added to the dual-wield penalty group (preventing 2H weapons from being viable), excluded from the generic caster 1H penalty (since they use 1H + shield rather than a staff), and given a 0.8x soft preference for 1H weapons.**

_In autogear testing, sometimes 2h weps with high crit/haste would win over caster gear - this is especially noticeable at lower levels, with shallower item pools (greens only). You'd hit autogear and the holy paladin would equip a 2h axe with crit :( So this makes it so holy paladins only use 1h weapons. They can use either a shield or an offhand, depending on stat weights._

**PvP Spec Slots Added for All Classes
The existing RandomClassSpecProb / RandomClassSpecIndex config entries control what percentage of random bots in the world are assigned each spec. Previously only PvE specs (indices 0–2, or 0–3 for Druids) were defined, giving server operators no way to introduce PvP-specced random bots into the world population. This PR adds PvP spec slots for every class (indices 3–6 depending on class), all defaulting to 0 probability. Server operators can raise these values to spawn PvP-specced random bots — e.g., setting RandomClassSpecProb.1.3 = 20 would make 20% of Warrior bots run Arms PvP.
Two additional PvE specs have also been added:
Death Knight index 3: Double-aura Blood (a hybrid Blood/Frost PvE tank variant)
Mage index 3: Frostfire (a PvE hybrid spec)
All existing spec entries have been annotated with comments identifying each one (e.g., # arms pve, # holy pve) for readability.**

_This change was actually added at the start - I realized that there was no way for pvp-specced randombots to spawn naturally, so I added optional probabilities to the config. They are currently set at 0% by default, but giving the user the option I feel is necessary. Also, it would have been impossible for me to test the init on randombots with pvp gear otherwise. Also, I noticed that the frostfire mage and the dual-aura dk didn't have an option, so I added them in as well, as well as names above each option for quality of life._

**Stat Weight Corrections
The following per-spec stat weights were adjusted to better reflect actual WotLK priorities. Entries marked NEW did not previously exist; unmarked rows show old → new values.**

<img width="795" height="268" alt="arms warrior" src="https://github.com/user-attachments/assets/cb0deb00-a985-432d-81a1-133fc953088b" />

_Arms warriors would prefer leather/ap gear about half of the time - the combined weights of both would often beat strength gear, especially at lower levels, or where the item pool was shallow. Also, they continued to spawn with spell power gear and defense gear occasionally, especially on gear with resilience (resilience, spell power, crit, haste, stam items)._

<img width="796" height="301" alt="fury warrior" src="https://github.com/user-attachments/assets/715ff3a3-3d20-4e0e-a953-7ed6fd9386db" />

_Fury warriors had the same issues as arms warrior, but really can't afford to lose a strength item - beserker stance increases strength by 20%. Also had to reduce haste here because haste really isn't nearly as important as strength, crit, arp. Haste items would win often over strength/crit/arp gear._

<img width="796" height="300" alt="prot tanks" src="https://github.com/user-attachments/assets/624de09a-2506-4aee-95aa-c49cbc5b85d3" />

_So, prot paladins and prot warriors currently are weighed identically fyi. Look at that whopping 2.0 agility - twice as important as strength? I noticed that my prot paladins/warriors were equipping agility/haste/crit items instead of defense gear on their neck, rings, trinkets, and back. This adjustment pretty much ensures that defense gear takes those slots if it's available. Removed the crit/haste weightings, because realistically if a tank wants more damage, it will just get strength. Lastly added the spell power penalty because prot paladins would spawn in fully holy gear if they were pvp specced (resilience is weighted so high, resilience/spellpower/stam/haste gear would often win). This aims to prevent that._

<img width="802" height="421" alt="dps dks" src="https://github.com/user-attachments/assets/371d1344-2382-4460-b3a7-f38b33025b73" />

_Same issue with plate dps as the warriors had. Spell power gear would occasionally spawn on crit/hit items in pve, and a ton of spell power resilience gear would spawn. There is no scenario where a DK wants spell power, this isn't patch 3.0.1..._

<img width="796" height="447" alt="blood dk" src="https://github.com/user-attachments/assets/c84a2bbf-7daa-4805-acf3-cd3bf815eda4" />

_Similar issues to prot paladin/warrior. I was really tired of seeing block rating/value gear as a result of getting gear with defense/stam. This results in a lot more defense rating/expertise/hit/dodge/parry gear, and basically makes shield stats nearly non-existent (unless the upgrade is good enough, it could still win)_

<img width="794" height="226" alt="ret paladin" src="https://github.com/user-attachments/assets/b09f40ed-b25f-4945-940c-2ce92f81c7c4" />

_Prior to this PR, the positive spellpower and int weights were enough for ret paladins to spawn with spellpower/int/haste/crit gear. This is unlikely now. And agility/ap was reduced to favor more strength gear._

<img width="795" height="306" alt="Enhancement Shaman" src="https://github.com/user-attachments/assets/1e5231fd-36ea-4b7e-a546-cf0075d17bd4" />

_While spell power is a decent stat on enhancment shamans, it was appearing on too much gear, especially on items that were haste/crit/spell power. And for elemental shamans, they were getting agi/haste/crit gear, so this aims to get rid of those items entirely without reducing haste/crit._

<img width="800" height="119" alt="shaman pally" src="https://github.com/user-attachments/assets/6ea3300a-effd-4a03-8f6f-4ae13c5383a5" />

_Holy paladins and resto shamans are scored the same, but this prevents attack power/haste/crit gear, since haste and crit are weighted high._

<img width="1025" height="385" alt="mage" src="https://github.com/user-attachments/assets/03191dfd-dc09-477d-8424-8fd56f3e0d71" />

_Prevents mages from equipping/autogearing items with attack power, some attack power/crit/haste/hit items were winning with shallow item pools._

<img width="1022" height="502" alt="hunter rogue" src="https://github.com/user-attachments/assets/06fa67c9-7709-4ee8-a0e2-34de18594018" />

_Prevents hunters and rogues from getting spell power leather gear with hit/crit. Crit is very heavy for hunters so this was decently common._

**Optional Changes (Config-Controlled)**

**AiPlayerbot.PreferClassArmorType (default: 0)
Applies a 3x score multiplier to armor matching the bot's class-appropriate type (plate/mail/leather/cloth). A significantly better off-type item can still win — this is a soft preference, not a hard filter.**

_Are you tired of your fury warrior being a leather daddy? Are you tired of your holy paladin running around in cloth lingerie? This will fix that. For mail classes (hunters/shamans) and plate classes, this only kicks in after level 40. But it really helps adhere to the highest armor class available. This would be the perfect solution to the quarterly question "Why is my paladin wearing leather?". This definitely should remain optional, as quite a few BIS lists would disagree with it. Leather at certain stages is great for hunters/shamans/warriors/dks._

**AiPlayerbot.AutogearAllowsQuestRewards (default: 0)
Builds a cache of equippable armor and weapon quest rewards at startup. Bots can then equip these items during autogear, using the quest's minimum level as the effective required level gate.**

_So, I noticed that autogear didn't allow items without a level requirement (quest rewards), because it didn't know how to handle that when giving out gear. It would previously just flat out reject all quest rewards, as they wouldn't be a part of the item pool. This option enables quest rewards to be considered in the item pool, and the level correlates to the lowest level you could get the quest. I have tested this for about 3 hours across all specs and using blue/green gear, it seems like a really nice bonus. Keep in mind that I do 0 quests on my way to 80, so players like me could still benefit from those items. I think this should remain optional._

**AiPlayerbot.EquipAllSlotsAtAnyLevel (default: 0)
Bypasses the low-level slot restrictions in InitEquipment():
Trinkets normally locked until level 50
Head/Neck until level 30
Rings until level 20
All other non-weapon slots until level 5**

_Autogear currently has level floors for slots - they will not ever give items below the above thresholds. This config option bypasses that. I have not tested this as much as I should have, so as people test this, they could let us know of items that should be blacklisted._

**AiPlayerbot.WeaponSpeedGovernance (default: 0)
When enabled, ApplyWeaponSpeedGovernance() applies a 3x score multiplier to weapons matching the spec's ideal attack speed profile. Applies to mainhand, offhand, and ranged slots only. Per-spec preferences:
Arms Warrior: Slow 2H (>=3400ms) in mainhand; poleaxes and axes preferred (Axe Specialization)
Ret Paladin / Blood & Unholy DK:  Slow 2H (>=3400ms) in mainhand
Prot Warrior & Paladin: Slow 1H (>=2600ms) in mainhand
Fury Warrior dual wield:  Slow 1H (>=2600ms) in both hands
Fury Warrior titan's grip: Slow 2H (>=3400ms) in both hands
Frost DK: Slow 1H (>=2600ms) in both hands; 2H excluded
Enhancement Shaman (dual wield):  Slow 1H (>=2600ms) in both hands; synchronized MH/OH speeds for flurry procs
Enhancement Shaman (pre-dual wield): Slow 2H (>=3400ms) in mainhand
Combat Rogue: Slow MH (>=2600ms) + Fast OH (<=1500ms)
Assassination / Subtlety Rogue: Slow dagger MH (>=1700ms) + Fast dagger OH (<=1500ms)
Hunter: Slow ranged (>=2600ms); melee is a stat stick, speed ignored
Feral Druid: No preference (forms normalize attack speed)**

_Besides pvp gearing for pvp specs, I feel like this is one of the nicest additions. It was really frustrating to see an enhancement shaman put windfury on a 1.5 dagger. Without this, weights for melee dps are calculated on dps alone, not weapon speed. You'll see 2h specs use fast 2h weapons (3.0), rogues use 2 fast weapons or slow weapons, frost dks occasionally using 2h weapons while having dual wield talents. I tested this for about 6 hours across all mentioned specs at levels 20, 30, 40, 50, 60, 65, 70, 75, and 80, with 3 quality types (greens, blues, purples). I would actually consider making this mandatory, simply because of the impact I saw in the dps charts. Super happy and proud of this._

<img width="1021" height="470" alt="files changes" src="https://github.com/user-attachments/assets/f55d955c-8760-4adf-b4d9-84797da2dc65" />


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.

_Two caches are built upon startup - the pvp trinket cache and the quest reward cache. From there, this directly modifies the stat weight calculations involving initequipement (autogear) and autoequipupgrades, as both go off of stat weight calculations. I tried to implement these changes with as little custom functions and coding as possible, and relied as much as I could on the pre-existing framework._ 

- Describe the **processing cost** when this logic executes across many bots.

_Fortunately most of the gates are boolean so it shouldn't impact performance much at all. I ran these changes on my local server with stock 500 bots, noticed no pmon difference from the main branch. Did a 24h stress test on my server yesterday, stats looked consistent with the stress test I did prior to making any changes on 3-31-26._

_It helps that it uses pre-existing functions such as initequipment and autoequipupgrades, and it really just modifies them with slightly more logic. That being said, autogear didn't lag my server at all, nor did the bots equipping upgrades._

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

_So, with the basic stock playerbots config (do not forget to copy the new config!), the only thing that should change is the pvp gear appearing on pvp specs, and the classes preferring more appropriate stats across the board. You can load into the game, level a bot to 20, autogear, and notice the difference. Same at level 40, 60, 75, or whatever. You could add in the optional config settings to further streamline the gear you want. I currently run with all 4 enabled, 2 of which increase the item pool, and 2 of which help guide them to more appropriate gear (armor/weps)._

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

_The code is only used on startup (cache generation) and when autogear/autoequipupgrades is called. Not all the time, and not per tick. I noticed no performance impact after these changes._

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

_It modifies the decision making as far as equipment goes, but as far as priority/strategies, this does not affect that._

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

_Not to my knowledge, but I'll rely on testers and the community to let me know if it does._

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

_AI was used in the research of the initequipment system, stat weights, and cache building. As far as generating the code, using AI was 2 steps forward, 1 step back. I used Claude Code with Sonnet 4.6 (high) and had gemini/copilot review the work. **AI did generate a large portion of the code being used.** I have personally reviewed every line, and a lot was removed out of being obsolete/new system that copied an old one/too many comments. I don't think anything else can be trimmed, though. I also used AI in the PR description, and made my own comments in italics below each entry. I hate explaining/writing._

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

_I would like atleast 5-10 people to review this over the next 1-6 months. The big problem I used to have with my PRs was I was acting like they were a sprint, when it's really a marathon - good changes take time, and I was too quick to bust out new content. The old PRs I made introduced just as many new bugs as they did features. I learned my lesson, and have tested this extensively (code was pretty much complete on 4-10-26, been testing alone for the last 11 days) and it's ready for the test realm for others to try out. I think it's going to be a good step forward when it comes to gear decision making for bots as a whole. PvPers have come and gone too much from this project due to the lack of options, and this helps captivate that audience. Please reach out to me on discord at Zhur#4391, I am happy to hear results/suggestions there as well as here._


