### PR TITLE
Thorns reapply fix

### DIFF
--- a/src/Ai/Class/Druid/Action/DruidActions.cpp
+++ b/src/Ai/Class/Druid/Action/DruidActions.cpp
@@ -11,6 +11,22 @@
 #include "AoeValues.h"
 #include "TargetValue.h"
 
+namespace
+{
+    bool PrepareThornsTarget(PlayerbotAI* botAI, Unit* target)
+    {
+        if (!target)
+            return false;
+
+        Aura* existingThorns = botAI->GetAura("thorns", target, true);
+        if (!existingThorns)
+            return true;
+
+        target->RemoveOwnedAura(existingThorns, AURA_REMOVE_BY_CANCEL);
+        return true;
+    }
+}
+
 std::vector<NextAction> CastAbolishPoisonAction::getAlternatives()
 {
     return NextAction::merge({ NextAction("cure poison") },
@@ -31,6 +47,21 @@ bool CastLifebloomOnMainTankAction::isUseful()
 
     Aura* lifebloom = botAI->GetAura("lifebloom", target, true, true);
     return !lifebloom || lifebloom->GetStackAmount() < 3 || lifebloom->GetDuration() < 2000;
+}
+
+bool CastThornsAction::Execute(Event event)
+{
+    return PrepareThornsTarget(botAI, GetTarget()) && CastBuffSpellAction::Execute(event);
+}
+
+bool CastThornsOnPartyAction::Execute(Event event)
+{
+    return PrepareThornsTarget(botAI, GetTarget()) && BuffOnPartyAction::Execute(event);
+}
+
+bool CastThornsOnMainTankAction::Execute(Event event)
+{
+    return PrepareThornsTarget(botAI, GetTarget()) && BuffOnMainTankAction::Execute(event);
 }
 
 Value<Unit*>* CastEntanglingRootsCcAction::GetTargetValue()

--- a/src/Ai/Class/Druid/Action/DruidActions.h
+++ b/src/Ai/Class/Druid/Action/DruidActions.h
@@ -114,18 +114,24 @@ class CastThornsAction : public CastBuffSpellAction
 {
 public:
     CastThornsAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "thorns") {}
+
+    bool Execute(Event event) override;
 };
 
 class CastThornsOnPartyAction : public BuffOnPartyAction
 {
 public:
     CastThornsOnPartyAction(PlayerbotAI* botAI) : BuffOnPartyAction(botAI, "thorns") {}
+
+    bool Execute(Event event) override;
 };
 
 class CastThornsOnMainTankAction : public BuffOnMainTankAction
 {
 public:
     CastThornsOnMainTankAction(PlayerbotAI* botAI) : BuffOnMainTankAction(botAI, "thorns", false) {}
+
+    bool Execute(Event event) override;
 };
 
 class CastLifebloomOnMainTankAction : public BuffOnMainTankAction


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Allowed druid cast Thorns on target which already have Thorns on him to extend duration.
Related with: #2290 

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Invite 2 bot (one of them must be druid which can cast thorns)
2. Select second bot and use commad `cast thorns`
3. Wait until buff timer decrease
4. Use again same command
5. Druid should cast spell

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

To understand reason.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


